### PR TITLE
ci: add Playwright E2E CI job and test-only CAPTCHA bypass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ FROM_EMAIL=onboarding@resend.dev
 RECAPTCHA_SECRET_KEY=6Lcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 RECAPTCHA_SITE_KEY=6Lcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# Test-only CAPTCHA bypass (default OFF). Set to `true` or `1` to skip reCAPTCHA
+# verification, e.g. for local E2E testing. Ignored when FLASK_ENV=production,
+# so production stays protected regardless of this value.
+DISABLE_CAPTCHA=
+
 # Vision AI (Optional — for AI-powered floorplan auto-detection)
 # Get your Gemini API key from https://aistudio.google.com/apikey
 # Get your OpenAI API key from https://platform.openai.com/api-keys

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Run Playwright tests
         working-directory: front-end
         run: npx playwright test
+      - name: Docker compose logs
+        if: always()
+        run: docker compose logs
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,15 +70,18 @@ jobs:
           node-version: "20"
           cache: npm
           cache-dependency-path: front-end/package-lock.json
-      - run: docker compose build
-      - run: docker compose up -d
-      - run: ./scripts/seed_fixture.sh
+      # Install front-end deps on the host BEFORE `docker compose up`. Otherwise
+      # Docker (as root) creates the anonymous-volume mountpoint `front-end/node_modules`
+      # on the host bind mount root-owned, and the later `npm ci` fails with EACCES.
       - name: Install front-end dependencies
         working-directory: front-end
         run: npm ci
       - name: Install Playwright browsers
         working-directory: front-end
         run: npx playwright install chromium --with-deps
+      - run: docker compose build
+      - run: docker compose up -d
+      - run: ./scripts/seed_fixture.sh
       - name: Run Playwright tests
         working-directory: front-end
         run: npx playwright test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,3 +58,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: docker compose build
+
+  e2e:
+    runs-on: ubuntu-latest
+    env:
+      DISABLE_CAPTCHA: "true"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: front-end/package-lock.json
+      - run: docker compose build
+      - run: docker compose up -d
+      - run: ./scripts/seed_fixture.sh
+      - name: Install front-end dependencies
+        working-directory: front-end
+        run: npm ci
+      - name: Install Playwright browsers
+        working-directory: front-end
+        run: npx playwright install chromium --with-deps
+      - name: Run Playwright tests
+        working-directory: front-end
+        run: npx playwright test
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-artifacts
+          path: |
+            front-end/playwright-report/
+            front-end/test-results/
+          retention-days: 7

--- a/back-end/.env.example
+++ b/back-end/.env.example
@@ -35,6 +35,11 @@ FRONTEND_URL=http://localhost:5173
 # Get your keys from https://www.google.com/recaptcha/admin
 RECAPTCHA_SECRET_KEY=6Lcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# Test-only CAPTCHA bypass (default OFF). Set to `true` or `1` to skip reCAPTCHA
+# verification for local development or E2E testing. Ignored when
+# FLASK_ENV=production, so production stays protected regardless of this value.
+DISABLE_CAPTCHA=
+
 # Figma MCP (local development tooling)
 # Get your personal access token from Figma → Settings → Personal access tokens
 FIGMA_API_KEY=

--- a/back-end/tests/test_captcha.py
+++ b/back-end/tests/test_captcha.py
@@ -1,0 +1,93 @@
+import os
+import sys
+import types
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.captcha import verify_recaptcha
+
+
+class TestCaptchaBypass:
+    def test_bypass_when_disable_captcha_enabled(self, monkeypatch):
+        monkeypatch.setenv("DISABLE_CAPTCHA", "true")
+        monkeypatch.setenv("FLASK_ENV", "development")
+        monkeypatch.delenv("RECAPTCHA_SECRET_KEY", raising=False)
+
+        success, score = verify_recaptcha("dummy-token")
+
+        assert success is True
+        assert score == 1.0
+
+    def test_bypass_when_disable_captcha_is_1(self, monkeypatch):
+        monkeypatch.setenv("DISABLE_CAPTCHA", "1")
+        monkeypatch.setenv("FLASK_ENV", "development")
+        monkeypatch.delenv("RECAPTCHA_SECRET_KEY", raising=False)
+
+        success, score = verify_recaptcha("dummy-token")
+
+        assert success is True
+        assert score == 1.0
+
+    def test_disable_captcha_ignored_in_production(self, monkeypatch):
+        monkeypatch.setenv("DISABLE_CAPTCHA", "true")
+        monkeypatch.setenv("FLASK_ENV", "production")
+
+        class FakeResponse:
+            def json(self):
+                return {"success": False, "score": 0.1}
+
+        def fake_post(url, data, timeout):
+            return FakeResponse()
+
+        monkeypatch.setattr("utils.captcha.requests.post", fake_post)
+
+        import utils.captcha as captcha_mod
+        monkeypatch.setattr(captcha_mod, "RECAPTCHA_SECRET_KEY", "prod-secret-key")
+
+        success, score = verify_recaptcha("dummy-token")
+
+        assert success is False
+        assert score == 0.1
+
+    def test_dev_bypass_when_no_secret_key(self, monkeypatch):
+        monkeypatch.delenv("DISABLE_CAPTCHA", raising=False)
+        monkeypatch.delenv("RECAPTCHA_SECRET_KEY", raising=False)
+        monkeypatch.setenv("FLASK_ENV", "development")
+
+        success, score = verify_recaptcha("dummy-token")
+
+        assert success is True
+        assert score == 1.0
+
+    def test_enforced_when_secret_key_set_and_no_bypass(self, monkeypatch):
+        monkeypatch.delenv("DISABLE_CAPTCHA", raising=False)
+        monkeypatch.setenv("FLASK_ENV", "development")
+
+        class FakeResponse:
+            def json(self):
+                return {"success": False, "score": 0.1}
+
+        def fake_post(url, data, timeout):
+            return FakeResponse()
+
+        monkeypatch.setattr("utils.captcha.requests.post", fake_post)
+
+        import utils.captcha as captcha_mod
+        monkeypatch.setattr(captcha_mod, "RECAPTCHA_SECRET_KEY", "test-secret-key")
+
+        success, score = verify_recaptcha("bad-token")
+
+        assert success is False
+        assert score == 0.1
+
+    def test_enforced_rejects_empty_token_with_secret_key(self, monkeypatch):
+        monkeypatch.delenv("DISABLE_CAPTCHA", raising=False)
+        monkeypatch.setenv("FLASK_ENV", "development")
+
+        import utils.captcha as captcha_mod
+        monkeypatch.setattr(captcha_mod, "RECAPTCHA_SECRET_KEY", "test-secret-key")
+
+        success, score = verify_recaptcha("", ip_address=None)
+
+        assert success is False
+        assert score == 0.0

--- a/back-end/utils/captcha.py
+++ b/back-end/utils/captcha.py
@@ -13,16 +13,23 @@ MIN_SCORE = 0.5  # Minimum score threshold for reCAPTCHA v3
 
 def verify_recaptcha(token: str, ip_address: Optional[str] = None) -> Tuple[bool, float]:
     """Verify reCAPTCHA v3 token.
-    
+
     Args:
         token: reCAPTCHA token from frontend
         ip_address: Optional IP address of the user
-        
+
     Returns:
         Tuple of (success: bool, score: float)
         - success: True if verification passed and score >= MIN_SCORE
         - score: reCAPTCHA score (0.0 to 1.0)
     """
+    # Explicit test-mode bypass: DISABLE_CAPTCHA skips verification entirely.
+    # Only honored in non-production environments. Defaults OFF - production
+    # stays protected by CAPTCHA regardless of this flag.
+    if os.getenv("FLASK_ENV", "") != "production" and os.getenv("DISABLE_CAPTCHA", "").lower() in ("true", "1"):
+        print("Warning: DISABLE_CAPTCHA is enabled - captcha verification skipped")
+        return True, 1.0
+
     if not RECAPTCHA_SECRET_KEY:
         # In development, allow bypass if secret key not set
         print("Warning: RECAPTCHA_SECRET_KEY not set, skipping verification")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost:5173}
       - FROM_EMAIL=${FROM_EMAIL:-onboarding@resend.dev}
       - RECAPTCHA_SECRET_KEY=${RECAPTCHA_SECRET_KEY:-}
+      - DISABLE_CAPTCHA=${DISABLE_CAPTCHA:-}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
     ports:

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -49,6 +49,7 @@ This document outlines the complete technology stack used in the Conventioner ap
   - Score-based verification (minimum 0.5)
   - Used on registration endpoint
   - Secret key configured via `RECAPTCHA_SECRET_KEY` environment variable
+  - Test-only bypass via `DISABLE_CAPTCHA` (non-production only; see Environment Variables)
 
 ### Utilities
 - **Cryptography 41.0.0+** - Cryptographic functions
@@ -173,7 +174,7 @@ This document outlines the complete technology stack used in the Conventioner ap
 ### Continuous Integration
 - **GitHub Actions** - CI pipeline (`.github/workflows/test.yml`)
   - Runs on pushes and pull requests to `main` or `dev`
-  - Jobs: back-end pytest, front-end type-check + lint + unit tests, Docker build verification
+  - Jobs: back-end pytest, front-end type-check + lint + unit tests, Docker build verification, and E2E (Playwright against the Docker stack with `DISABLE_CAPTCHA=true`, uploading artifacts on failure)
 - **GitHub Actions** - Release automation (`.github/workflows/release-please.yml`)
   - Runs [release-please](https://github.com/googleapis/release-please) on pushes to `main`
   - Opens/updates a Release PR (version bump + CHANGELOG) that, when merged, tags a release
@@ -230,6 +231,7 @@ This document outlines the complete technology stack used in the Conventioner ap
 - `FRONTEND_URL` - Frontend URL for email links (e.g., `http://localhost:5173`)
 - `FROM_EMAIL` - Email address to send from (default: `onboarding@resend.dev`)
 - `RECAPTCHA_SECRET_KEY` - Google reCAPTCHA v3 secret key
+- `DISABLE_CAPTCHA` - Test-only flag to skip reCAPTCHA verification (default OFF; set `true`/`1`). Honored only when `FLASK_ENV` is not `production`
 - `MONGODB_HOST` - MongoDB hostname (default: `mongodb` in Docker, `localhost` locally)
 - `MONGODB_PORT` - MongoDB port (default: `27017`)
 - `MONGODB_USER` - MongoDB username (default: `admin`)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -25,8 +25,8 @@ pip install -r requirements-dev.txt
 python -m pytest tests/ -v
 ```
 
-57 tests covering the assignment algorithm, statistics, Discord webhook, attendance,
-column mapping, schema generation, and role validation.
+63 tests covering the assignment algorithm, statistics, Discord webhook, attendance,
+column mapping, schema generation, role validation, and CAPTCHA verification/bypass.
 
 Requirements: `pytest` (listed in `requirements-dev.txt`), no database connection needed
 (tests use in-memory fakes).
@@ -81,12 +81,25 @@ The suite is built on a Page Object Model plus a fixture layer under `front-end/
   Playwright's `APIRequestContext` (cookies flow automatically). Requires a
   verified test user created by `scripts/seed_fixture.sh`.
 
+### Bypassing CAPTCHA in tests
+
+The registration flow is protected by reCAPTCHA v3. For local development and E2E
+runs, set `DISABLE_CAPTCHA=true` (or `1`) so `verify_recaptcha` skips verification
+and returns a passing result. The bypass is honored only when `FLASK_ENV` is not
+`production`, defaults OFF, and never applies in production. The CI e2e job sets
+`DISABLE_CAPTCHA=true`, and `docker-compose.yml` forwards the variable to the
+back-end so `./scripts/seed_fixture.sh` and Playwright can register users without a
+real CAPTCHA token.
+
 ## CI Pipeline
 
 Pushes and PRs to `main` or `dev` trigger `.github/workflows/test.yml`:
 - Back-end: install dependencies + pytest
 - Front-end: npm ci + type-check + lint + unit tests
 - Docker build verification
+- E2E: build and start the Docker stack, seed fixtures, install Playwright
+  (Chromium), run the Playwright suite with `DISABLE_CAPTCHA=true`, and upload the
+  Playwright report + test results as artifacts on failure
 
 ## Testing Gotchas
 


### PR DESCRIPTION
## Intent

Make the Playwright E2E suite runnable in CI, and add a test-only CAPTCHA bypass for the registration flow. Two deliverables: (1) Add an e2e job to .github/workflows/test.yml that brings up the Docker stack, seeds data, installs Playwright browsers, runs the smoke suite, and uploads artifacts on failure. (2) Add a DISABLE_CAPTCHA environment-gated bypass in back-end/utils/captcha.py that only skips CAPTCHA verification in non-production environments, defaults OFF so production stays protected. Add back-end unit tests proving both states. Wire DISABLE_CAPTCHA into docker-compose.yml and set it to true in the CI e2e job's environment.

## What Changed

- Added an `e2e` job to `.github/workflows/test.yml` that brings up the Docker stack, seeds fixtures, installs Playwright browsers, runs the smoke suite with `DISABLE_CAPTCHA=true`, captures `docker compose logs` on failure, and uploads the Playwright report/test-results as artifacts.
- Added a `DISABLE_CAPTCHA` env-gated bypass in `back-end/utils/captcha.py` that skips CAPTCHA verification only in non-production environments and defaults OFF, plus `back-end/tests/test_captcha.py` covering the bypass ON, ignored-in-production, default-OFF, and empty-token cases.
- Wired `DISABLE_CAPTCHA` through `docker-compose.yml` and the `.env.example` files, and documented the bypass and e2e job in `docs/TESTING.md` and `docs/TECH_STACK.md`.

## Risk Assessment

✅ Low: The change is small, well-bounded CI/test-mode plumbing with a correctly double-gated, default-off bypass; the only finding is a minor test-robustness issue that does not affect production behavior.

## Testing

Baseline: the 6 new back-end unit tests (`pytest tests/test_captcha.py`) pass, proving the DISABLE_CAPTCHA logic in both states (bypass in non-prod, ignored in production, default-OFF enforced when a secret key is set). To show the intent working as an end user would, I stood up an isolated copy of the full Docker stack (unique container names/ports so the two pre-existing dev stacks were never touched) with `DISABLE_CAPTCHA=true`, seeded data the same way `seed_fixture.sh` does, and ran the actual Playwright smoke suite - both tests passed and Playwright captured screenshots/videos of the real authenticated dashboard and the seeded market card (Owner). I additionally exercised the real `/register` endpoint with a bogus captcha token: it sailed past the CAPTCHA gate (failing only later at email send, which is unconfigured in this env) and the backend logged "DISABLE_CAPTCHA is enabled - captcha verification skipped", directly demonstrating deliverable (2) at the product surface. The CI-only conditional steps (compose-logs-on-failure, upload-artifact-on-failure) are not exercisable without an actual CI failure; that is a CI harness behavior, not a code defect. All transient artifacts (isolated stack, images, volumes, node_modules, test outputs) were removed afterward and the working tree is clean.

- Evidence: Smoke test 1 - authenticated dashboard after login (real UI) (local file: <code>/tmp/no-mistakes-evidence/01KWRAVX38EYJE6P7QNFZ0XRZW/smoke-1-dashboard.png</code>)
- Evidence: Smoke test 2 - Markets view showing seeded &#39;Seed Market E2E&#39; card (Owner) (local file: <code>/tmp/no-mistakes-evidence/01KWRAVX38EYJE6P7QNFZ0XRZW/smoke-2-markets.png</code>)
- Evidence: Smoke test 1 video - login -&gt; dashboard (local file: <code>/tmp/no-mistakes-evidence/01KWRAVX38EYJE6P7QNFZ0XRZW/smoke-1-login-dashboard.webm</code>)
- Evidence: Smoke test 2 video - markets navigation (local file: <code>/tmp/no-mistakes-evidence/01KWRAVX38EYJE6P7QNFZ0XRZW/smoke-2-markets.webm</code>)
<details>
<summary>Evidence: DISABLE_CAPTCHA bypass transcript (/register with dummy token + backend log)</summary>

```text
Product-level demonstration of DISABLE_CAPTCHA bypass (deliverable 2)
Backend running via docker-compose with DISABLE_CAPTCHA=true, FLASK_ENV=development, RECAPTCHA_SECRET_KEY="".

$ curl -k -X POST https://localhost:5090/register \
    -H "Content-Type: application/json" \
    -d '{"email":"newuser@example.com","password":"password12345","captcha_token":"dummy-invalid-token"}'

{"error":"email_send_failed","msg":"Registration failed: Unable to send verification email. ..."}

--> Request passed the CAPTCHA gate with a bogus token (did NOT return HTTP 400
    "CAPTCHA verification failed"); it proceeded all the way to email sending,
    which only fails because no email provider is configured in this test env.

Backend log:
  Warning: DISABLE_CAPTCHA is enabled - captcha verification skipped
```
</details>
<details>
<summary>Evidence: Playwright smoke run result</summary>

```text
Running 2 tests using 1 worker
✓ 1 [chromium] › e2e/smoke.spec.ts:4:3 › login and access dashboard (679ms)
✓ 2 [chromium] › e2e/smoke.spec.ts:17:3 › navigate to markets and see seeded market (773ms)
2 passed (1.9s)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `.github/workflows/test.yml:85` - The new e2e job brings up the full Docker stack (`docker compose up -d`) and seeds it, but on failure it only uploads Playwright report/test-results artifacts. If the backend or frontend container fails to start, or seed_fixture.sh fails, there are no docker logs to diagnose the failure - the run will be opaque. Add a `docker compose logs` step with `if: always()` (or `if: failure()`) so container output is captured for triage.
- ℹ️ `back-end/utils/captcha.py:29` - The CAPTCHA bypass is fail-open by design and its production safety depends entirely on FLASK_ENV being set to &#34;production&#34; in the deployed environment (there is no vercel.json/prod config in-repo to confirm this). This is acceptable defense-in-depth since it is double-gated: DISABLE_CAPTCHA also defaults OFF (docker-compose passes `${DISABLE_CAPTCHA:-}` = empty), so a bypass in prod requires BOTH FLASK_ENV to be misconfigured AND DISABLE_CAPTCHA to be explicitly enabled. It also matches the existing FLASK_ENV production checks in app.py. Noting the prod dependency; no change required.

🔧 Fix: ci: capture docker compose logs on e2e job failure
1 info still open:
- ℹ️ `back-end/tests/test_captcha.py:54` - test_dev_bypass_when_no_secret_key uses monkeypatch.delenv(&#34;RECAPTCHA_SECRET_KEY&#34;), but verify_recaptcha checks the module-level constant RECAPTCHA_SECRET_KEY captured at import time via os.getenv, not the live environment. The delenv therefore has no effect on the code path; the test only passes because the constant happens to be None when the env var was unset at import. If pytest runs with RECAPTCHA_SECRET_KEY set (as in a dev machine or some CI setups), this test would fall through to a real requests.post and fail. The other tests correctly patch the module attribute directly; this test should also do monkeypatch.setattr(captcha_mod, &#34;RECAPTCHA_SECRET_KEY&#34;, None) to be robust.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`python3 -m pytest tests/test_captcha.py` (back-end) - 6/6 pass, covering DISABLE_CAPTCHA bypass ON (true/1), ignored in production, default-OFF enforced with secret key, and empty-token rejection</code>
- <code>Built &amp; launched an isolated stack (unique names/ports, `DISABLE_CAPTCHA=true`) via `docker compose -p convtest ...` to avoid disturbing the already-running dev stacks</code>
- <code>Seeded fixtures replicating `scripts/seed_fixture.sh` (reset db, create e2e user, create market as owner, upload vendors.csv) against the live backend on port 5090</code>
- <code>`FRONTEND_PORT=5190 npx playwright test` (front-end/e2e/smoke.spec.ts) - both smoke tests pass against the live stack, producing screenshots + videos</code>
- <code>Product-level bypass check: `curl -k -X POST https://localhost:5090/register` with a dummy/invalid captcha_token - request passed the CAPTCHA gate (reached email step, not a CAPTCHA 400); backend logged the bypass warning</code>
- `Verified referenced e2e assets exist for the new CI job: scripts/seed_fixture.sh, front-end/playwright.config.ts, front-end/e2e/smoke.spec.ts, and the DISABLE_CAPTCHA wiring in docker-compose.yml`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
