### PR TITLE
fix(market-setup): drop null column values and add full pipeline E2E coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ This file is the project's committed home for project-intrinsic agent knowledge:
   No product behavior changes - purely additive test infrastructure.
 - **Page Object Model**: Located under `front-end/e2e/pages/`.
   Each page object wraps Playwright `getByTestId()` selectors and exposes action methods.
-  New pages should follow the existing `LoginPage`, `MarketSetupPage`, `AssignmentResultsPage` patterns.
+  New pages should follow the existing `LoginPage`, `NewMarketPage`, `MarketSetupPage`, `AssignmentResultsPage` patterns.
 - **Fixtures**: `front-end/e2e/fixtures.ts` provides `TEST_USER`, `authenticatedPage`,
   and re-exports page objects for convenience.
 - **API-level seeding**: `front-end/e2e/helpers/seeds.ts` exports `seedMarketWithVendors()`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -55,7 +55,10 @@ npm run test:e2e
 ```
 
 E2E tests use Playwright driving Chromium against the running Docker stack.
-The smoke test covers login, dashboard, and markets navigation.
+The smoke test covers login, dashboard, and markets navigation, and the market
+pipeline test (`market-pipeline.spec.ts`) exercises the full product flow:
+creating a market with a CSV upload, walking the 3-page setup wizard, triggering
+assignment generation, and verifying the assignment results view.
 
 Configuration: `front-end/playwright.config.ts` (auto-detects the worktree
 frontend port via `detectFrontendPort()`).
@@ -70,9 +73,10 @@ The suite is built on a Page Object Model plus a fixture layer under `front-end/
 - **data-testid convention**: selectors follow `viewname-element`
   (e.g. `login-email-input`, `markets-create-button`). Views are instrumented
   with `data-testid` attributes so tests never depend on CSS classes or text.
-- **Page objects** (`front-end/e2e/pages/`): `LoginPage`, `MarketSetupPage`, and
-  `AssignmentResultsPage` each wrap `getByTestId()` selectors and expose action
-  methods. New page objects should follow these patterns.
+- **Page objects** (`front-end/e2e/pages/`): `LoginPage`, `NewMarketPage`,
+  `MarketSetupPage`, and `AssignmentResultsPage` each wrap `getByTestId()`
+  selectors and expose action methods. New page objects should follow these
+  patterns.
 - **Fixtures** (`front-end/e2e/fixtures.ts`): provides `TEST_USER`, the
   `authenticatedPage` fixture (logs in before the test), and re-exports page
   objects for convenience.

--- a/front-end/e2e/fixtures.ts
+++ b/front-end/e2e/fixtures.ts
@@ -24,3 +24,6 @@ export const test = base.extend<{ authenticatedPage: Page }>({
 
 export { expect } from '@playwright/test';
 export { LoginPage } from './pages/LoginPage';
+export { MarketSetupPage } from './pages/MarketSetupPage';
+export { AssignmentResultsPage } from './pages/AssignmentResultsPage';
+export { NewMarketPage } from './pages/NewMarketPage';

--- a/front-end/e2e/fixtures/test-vendors.csv
+++ b/front-end/e2e/fixtures/test-vendors.csv
@@ -1,0 +1,6 @@
+email,vendor_name,table_choice,buddy_email,day_1
+alice@example.com,Alice,Full table,,Gold
+bob@example.com,Bob,Full table,,Gold
+carol@example.com,Carol,Half Table,,Silver
+dave@example.com,Dave,Half Table,carol@example.com,Silver
+eve@example.com,Eve,Full table,,Gold

--- a/front-end/e2e/market-pipeline.spec.ts
+++ b/front-end/e2e/market-pipeline.spec.ts
@@ -47,7 +47,7 @@ test.describe('Market pipeline E2E', () => {
 
     // Add a market date: map the "day_1" column (index 4) to a date.
     // This also seeds tier names from the date column values ("Gold", "Silver").
-    await setupPage.addMarketDate('2026-07-15', 4);
+    await setupPage.addMarketDate('2026-07-15', 4, 0);
 
     // Advance to page 1
     await setupPage.clickNext();

--- a/front-end/e2e/market-pipeline.spec.ts
+++ b/front-end/e2e/market-pipeline.spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { test, expect, TEST_USER, MarketSetupPage, AssignmentResultsPage, NewMarketPage } from './fixtures';
+import { test, expect, MarketSetupPage, AssignmentResultsPage, NewMarketPage } from './fixtures';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CSV_PATH = path.resolve(__dirname, 'fixtures', 'test-vendors.csv');

--- a/front-end/e2e/market-pipeline.spec.ts
+++ b/front-end/e2e/market-pipeline.spec.ts
@@ -1,0 +1,117 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { test, expect, TEST_USER, MarketSetupPage, AssignmentResultsPage, NewMarketPage } from './fixtures';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CSV_PATH = path.resolve(__dirname, 'fixtures', 'test-vendors.csv');
+
+test.describe('Market pipeline E2E', () => {
+  /**
+   * Full end-to-end pipeline: create market with CSV upload, walk the 3-page
+   * setup wizard, trigger assignment generation, and verify the results view.
+   *
+   * This test exercises the real product flow without API shortcuts.
+   */
+  test('create market, configure, assign, and view results', async ({ authenticatedPage: page }) => {
+    const marketName = `Pipeline E2E ${Date.now()}`;
+
+    // ── Phase 1: Create a new market with CSV upload ──────────────────────
+    const newMarketPage = new NewMarketPage(page);
+
+    // Navigate to Markets and open the New Market overlay
+    await page.goto('/markets');
+    await page.getByTestId('markets-create-button').click();
+    await newMarketPage.waitForOverlay();
+
+    // Upload the CSV fixture
+    await newMarketPage.uploadCsv(CSV_PATH);
+
+    // After CSV parsing, the name input appears
+    await newMarketPage.waitForNameInput();
+    await newMarketPage.fillMarketName(marketName);
+
+    // Submit to create the market
+    await newMarketPage.clickSubmit();
+    await newMarketPage.waitForSetupRedirect();
+
+    // ── Phase 2: Walk the setup wizard ────────────────────────────────────
+    const setupPage = new MarketSetupPage(page);
+    await setupPage.waitForWizard();
+
+    // --- Page 0: Manage Columns + Market Dates ---
+    // Verify that columns from the CSV are visible (5 columns: email, vendor_name,
+    // table_choice, buddy_email, day_1)
+    await expect(page.locator('.double-column-body .setup-row').first()).toBeVisible({ timeout: 5000 });
+    const columnRows = page.locator('.double-column-body .setup-row');
+    await expect(columnRows).toHaveCount(5);
+
+    // Add a market date: map the "day_1" column (index 4) to a date.
+    // This also seeds tier names from the date column values ("Gold", "Silver").
+    await setupPage.addMarketDate('2026-07-15', 4);
+
+    // Advance to page 1
+    await setupPage.clickNext();
+
+    // --- Page 1: Tiers + Locations + Sections ---
+    // The ChoosePathOverlay appears because sections are empty.
+    // Select Manual Setup.
+    await setupPage.selectManualPath();
+
+    // Tiers auto-populate from the day_1 column values ("Gold", "Silver").
+    // Verify tier rows are present.
+    await expect(page.locator('.triple-column-body .priority-row').first()).toBeVisible({ timeout: 5000 });
+
+    // Add a location
+    await setupPage.addLocation('Main Hall', 0);
+
+    // Add a section: Gold tier, Main Hall location, 1 table
+    await setupPage.addSection('Gold Tables', 'Main Hall', 'Gold', 1, 0);
+
+    // Advance to page 2
+    await setupPage.clickNext();
+
+    // --- Page 2: Assignment Priority + Assignment Options ---
+    // Configure required assignment options.
+    // Column indices from CSV headers: email=0, vendor_name=1, table_choice=2,
+    // buddy_email=3, day_1=4
+    await setupPage.selectEmailColumn(0);
+    await setupPage.selectTableChoiceColumn(2);
+    await setupPage.selectTableShareEmailColumn(3);
+
+    // Numeric options: max 1 assignment per vendor, 100% half-table proportion
+    await setupPage.setMaxAssignmentsPerVendor(1);
+    await setupPage.setMaxHalfTableProportion(100);
+
+    // Verify the Assign button is enabled and click it
+    await setupPage.waitForAssignEnabled();
+    await setupPage.clickAssign();
+
+    // ── Phase 3: Verify assignment results ─────────────────────────────────
+    const resultsPage = new AssignmentResultsPage(page);
+
+    // Wait for the results page to load with statistics
+    await expect(resultsPage.summaryStats).toBeVisible({ timeout: 15000 });
+
+    // Verify summary stats render meaningful data
+    const summaryText = await resultsPage.summaryStats.textContent();
+    expect(summaryText).toContain('Assignments');
+    expect(summaryText).toContain('Assigned Tables');
+    expect(summaryText).toContain('Assigned Vendors');
+    expect(summaryText).toContain('Satisfaction Score');
+
+    // Verify action buttons are present
+    await expect(resultsPage.doneButton).toBeVisible();
+    await expect(resultsPage.downloadCsvButton).toBeVisible();
+    await expect(resultsPage.backButton).toBeVisible();
+
+    // Verify per-date, per-section, and per-tier breakdowns are rendered
+    await expect(page.locator('.body-grid-date .stat-list')).toBeVisible();
+    await expect(page.locator('.body-grid-section .stat-list')).toBeVisible();
+    await expect(page.locator('.body-grid-tier .stat-list')).toBeVisible();
+
+    // Verify quick-nav buttons are visible
+    await expect(resultsPage.viewVendorsButton).toBeVisible();
+    await expect(resultsPage.viewTablesButton).toBeVisible();
+    await expect(resultsPage.viewAttendanceButton).toBeVisible();
+  });
+});

--- a/front-end/e2e/pages/MarketSetupPage.ts
+++ b/front-end/e2e/pages/MarketSetupPage.ts
@@ -86,13 +86,12 @@ export class MarketSetupPage {
   // --- Page 0: Market Dates ---
 
   /** Add a new market date row and configure it. */
-  async addMarketDate(date: string, columnIndex: number): Promise<void> {
+  async addMarketDate(date: string, columnIndex: number, index: number = 0): Promise<void> {
     await this.datesAddButton.click();
-    // Wait for the new row to appear (date input at index 0 if it was the first)
-    const dateInput = this.page.getByTestId('setup-dates-date-input-0');
+    const dateInput = this.page.getByTestId(`setup-dates-date-input-${index}`);
     await dateInput.waitFor({ state: 'visible' });
     await dateInput.fill(date);
-    const colSelect = this.page.getByTestId('setup-dates-column-select-0');
+    const colSelect = this.page.getByTestId(`setup-dates-column-select-${index}`);
     await colSelect.selectOption(String(columnIndex));
   }
 

--- a/front-end/e2e/pages/MarketSetupPage.ts
+++ b/front-end/e2e/pages/MarketSetupPage.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 
 /**
  * Page object for the Market Setup wizard view.
@@ -115,12 +115,10 @@ export class MarketSetupPage {
 
   /** Verify that N column rows are visible. */
   async expectColumnCount(count: number): Promise<void> {
-    await this.page.locator('.setup-row').first().waitFor({ state: 'visible' });
-    const rows = this.page.locator('.setup-row');
-    // Only count rows within the ElementSetupColumns component (the first double-column-body)
-    // The setup-row class is used across multiple components; scope to the first container.
+    // The setup-row class is used across multiple components; scope to the columns container.
     const colRows = this.page.locator('.double-column-body .setup-row');
     await colRows.first().waitFor({ state: 'visible' });
+    await expect(colRows).toHaveCount(count);
   }
 
   // --- Page 1: Path choice ---
@@ -161,9 +159,19 @@ export class MarketSetupPage {
     await nameInput.waitFor({ state: 'visible' });
     await nameInput.fill(name);
     await this.page.getByTestId(`setup-section-location-select-${index}`).selectOption({ label: locationOptionLabel });
-    // Use index-based selection to preserve the TierObject reference with its id field.
-    // Index 0 is the disabled placeholder ("Select a tier"), so real options start at index 1.
-    await this.page.getByTestId(`setup-section-tier-select-${index}`).selectOption({ index: 1 });
+    // Resolve the tier option matching the requested label, then select by index.
+    // Index-based selection preserves the bound TierObject reference (with its id field);
+    // index 0 is the disabled placeholder ("Select a tier"), so real options start at 1.
+    const tierSelect = this.page.getByTestId(`setup-section-tier-select-${index}`);
+    const tierOptionIndex = await tierSelect.locator('option').evaluateAll(
+      (options, label) =>
+        options.findIndex((option) => (option.textContent ?? '').trim() === label),
+      tierOptionLabel,
+    );
+    if (tierOptionIndex < 1) {
+      throw new Error(`Tier option "${tierOptionLabel}" not found in section tier select`);
+    }
+    await tierSelect.selectOption({ index: tierOptionIndex });
     await this.page.getByTestId(`setup-section-count-input-${index}`).fill(String(count));
   }
 

--- a/front-end/e2e/pages/MarketSetupPage.ts
+++ b/front-end/e2e/pages/MarketSetupPage.ts
@@ -2,7 +2,8 @@ import type { Locator, Page } from '@playwright/test';
 
 /**
  * Page object for the Market Setup wizard view.
- * Covers wizard step navigation (Back/Next/Assign) and the Discord webhook input.
+ * Covers wizard step navigation (Back/Next/Assign), the Discord webhook input,
+ * and interactions with the setup wizard sub-components.
  */
 export class MarketSetupPage {
   readonly page: Page;
@@ -15,6 +16,25 @@ export class MarketSetupPage {
   // Discord webhook
   readonly discordWebhookInput: Locator;
 
+  // Page 0: Market Dates
+  readonly datesAddButton: Locator;
+
+  // Page 1: Path choice overlay
+  readonly choosePathManualCard: Locator;
+
+  // Page 1: Locations
+  readonly locationAddButton: Locator;
+
+  // Page 1: Sections
+  readonly sectionAddButton: Locator;
+
+  // Page 2: Assignment Options
+  readonly optionsEmailSelect: Locator;
+  readonly optionsTableChoiceSelect: Locator;
+  readonly optionsTableShareEmailSelect: Locator;
+  readonly optionsMaxAssignmentsInput: Locator;
+  readonly optionsMaxProportionInput: Locator;
+
   constructor(page: Page) {
     this.page = page;
 
@@ -23,6 +43,20 @@ export class MarketSetupPage {
     this.assignButton = page.getByTestId('market-setup-assign-button');
 
     this.discordWebhookInput = page.getByTestId('market-setup-discord-webhook-input');
+
+    this.datesAddButton = page.getByTestId('setup-dates-add-button');
+
+    this.choosePathManualCard = page.getByTestId('choose-path-manual');
+
+    this.locationAddButton = page.getByTestId('setup-location-add-button');
+
+    this.sectionAddButton = page.getByTestId('setup-section-add-button');
+
+    this.optionsEmailSelect = page.getByTestId('setup-options-email-select');
+    this.optionsTableChoiceSelect = page.getByTestId('setup-options-table-choice-select');
+    this.optionsTableShareEmailSelect = page.getByTestId('setup-options-table-share-email-select');
+    this.optionsMaxAssignmentsInput = page.getByTestId('setup-options-max-assignments-input');
+    this.optionsMaxProportionInput = page.getByTestId('setup-options-max-proportion-input');
   }
 
   async goto(): Promise<void> {
@@ -47,5 +81,153 @@ export class MarketSetupPage {
 
   async fillDiscordWebhook(url: string): Promise<void> {
     await this.discordWebhookInput.fill(url);
+  }
+
+  // --- Page 0: Market Dates ---
+
+  /** Add a new market date row and configure it. */
+  async addMarketDate(date: string, columnIndex: number): Promise<void> {
+    await this.datesAddButton.click();
+    // Wait for the new row to appear (date input at index 0 if it was the first)
+    const dateInput = this.page.getByTestId('setup-dates-date-input-0');
+    await dateInput.waitFor({ state: 'visible' });
+    await dateInput.fill(date);
+    const colSelect = this.page.getByTestId('setup-dates-column-select-0');
+    await colSelect.selectOption(String(columnIndex));
+  }
+
+  /** Get a date input by row index. */
+  getDateInput(index: number): Locator {
+    return this.page.getByTestId(`setup-dates-date-input-${index}`);
+  }
+
+  /** Get a date column select by row index. */
+  getDateColumnSelect(index: number): Locator {
+    return this.page.getByTestId(`setup-dates-column-select-${index}`);
+  }
+
+  // --- Page 0: Column checkboxes ---
+
+  /** Get a column's include checkbox by column index. */
+  getColumnCheckbox(index: number): Locator {
+    return this.page.locator('.setup-row').nth(index).locator('.include-checkbox');
+  }
+
+  /** Verify that N column rows are visible. */
+  async expectColumnCount(count: number): Promise<void> {
+    await this.page.locator('.setup-row').first().waitFor({ state: 'visible' });
+    const rows = this.page.locator('.setup-row');
+    // Only count rows within the ElementSetupColumns component (the first double-column-body)
+    // The setup-row class is used across multiple components; scope to the first container.
+    const colRows = this.page.locator('.double-column-body .setup-row');
+    await colRows.first().waitFor({ state: 'visible' });
+  }
+
+  // --- Page 1: Path choice ---
+
+  /** Select the Manual Setup path from the ChoosePathOverlay. */
+  async selectManualPath(): Promise<void> {
+    await this.choosePathManualCard.click();
+    await this.choosePathManualCard.waitFor({ state: 'hidden' }).catch(() => {});
+  }
+
+  // --- Page 1: Locations ---
+
+  /** Add a new location with the given name. */
+  async addLocation(name: string, index: number = 0): Promise<void> {
+    await this.locationAddButton.click();
+    const nameInput = this.page.getByTestId(`setup-location-name-input-${index}`);
+    await nameInput.waitFor({ state: 'visible' });
+    await nameInput.fill(name);
+  }
+
+  /** Get a location name input by row index. */
+  getLocationNameInput(index: number): Locator {
+    return this.page.getByTestId(`setup-location-name-input-${index}`);
+  }
+
+  // --- Page 1: Sections ---
+
+  /** Add a new section row and configure it. */
+  async addSection(
+    name: string,
+    locationOptionLabel: string,
+    tierOptionLabel: string,
+    count: number,
+    index: number = 0,
+  ): Promise<void> {
+    await this.sectionAddButton.click();
+    const nameInput = this.page.getByTestId(`setup-section-name-input-${index}`);
+    await nameInput.waitFor({ state: 'visible' });
+    await nameInput.fill(name);
+    await this.page.getByTestId(`setup-section-location-select-${index}`).selectOption({ label: locationOptionLabel });
+    // Use index-based selection to preserve the TierObject reference with its id field.
+    // Index 0 is the disabled placeholder ("Select a tier"), so real options start at index 1.
+    await this.page.getByTestId(`setup-section-tier-select-${index}`).selectOption({ index: 1 });
+    await this.page.getByTestId(`setup-section-count-input-${index}`).fill(String(count));
+  }
+
+  /** Get a section name input by row index. */
+  getSectionNameInput(index: number): Locator {
+    return this.page.getByTestId(`setup-section-name-input-${index}`);
+  }
+
+  /** Get a section location select by row index. */
+  getSectionLocationSelect(index: number): Locator {
+    return this.page.getByTestId(`setup-section-location-select-${index}`);
+  }
+
+  /** Get a section tier select by row index. */
+  getSectionTierSelect(index: number): Locator {
+    return this.page.getByTestId(`setup-section-tier-select-${index}`);
+  }
+
+  /** Get a section count input by row index. */
+  getSectionCountInput(index: number): Locator {
+    return this.page.getByTestId(`setup-section-count-input-${index}`);
+  }
+
+  // --- Page 2: Assignment Options ---
+
+  /** Select the email column by its column index. */
+  async selectEmailColumn(columnIndex: number): Promise<void> {
+    await this.optionsEmailSelect.selectOption(String(columnIndex));
+  }
+
+  /** Select the table choice column by its column index. */
+  async selectTableChoiceColumn(columnIndex: number): Promise<void> {
+    await this.optionsTableChoiceSelect.selectOption(String(columnIndex));
+  }
+
+  /** Select the table share email column by its column index. */
+  async selectTableShareEmailColumn(columnIndex: number): Promise<void> {
+    await this.optionsTableShareEmailSelect.selectOption(String(columnIndex));
+  }
+
+  /** Set the max assignments per vendor. */
+  async setMaxAssignmentsPerVendor(value: number): Promise<void> {
+    await this.optionsMaxAssignmentsInput.fill(String(value));
+  }
+
+  /** Set the max half table proportion per section. */
+  async setMaxHalfTableProportion(value: number): Promise<void> {
+    await this.optionsMaxProportionInput.fill(String(value));
+  }
+
+  // --- Wizard flow helpers ---
+
+  /** Wait for the setup wizard to be visible. */
+  async waitForWizard(): Promise<void> {
+    await this.nextButton.waitFor({ state: 'visible', timeout: 10000 });
+  }
+
+  /** Wait for the Assign button to become enabled (all required options configured). */
+  async waitForAssignEnabled(): Promise<void> {
+    await this.assignButton.waitFor({ state: 'visible', timeout: 5000 });
+    // The button should not be disabled
+    await this.page.waitForFunction(() => {
+      const btn = document.querySelector('[data-testid="market-setup-assign-button"]') as HTMLButtonElement;
+      return btn && !btn.disabled;
+    }, { timeout: 10000 });
   }
 }

--- a/front-end/e2e/pages/NewMarketPage.ts
+++ b/front-end/e2e/pages/NewMarketPage.ts
@@ -1,0 +1,60 @@
+import type { Locator, Page } from '@playwright/test';
+
+/**
+ * Page object for the New Market overlay.
+ * Covers CSV file upload, market name entry, and submission.
+ */
+export class NewMarketPage {
+  readonly page: Page;
+
+  readonly overlayBackground: Locator;
+  readonly chooseFileButton: Locator;
+  readonly nameInput: Locator;
+  readonly submitButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    this.overlayBackground = page.getByTestId('new-market-overlay-background');
+    this.chooseFileButton = page.getByTestId('file-drop-choose-button');
+    this.nameInput = page.getByTestId('new-market-name-input');
+    this.submitButton = page.getByTestId('new-market-submit-button');
+  }
+
+  /** Wait for the overlay to be visible. */
+  async waitForOverlay(): Promise<void> {
+    await this.chooseFileButton.waitFor({ state: 'visible', timeout: 5000 });
+  }
+
+  /**
+   * Upload a CSV file via the file chooser.
+   * Uses Playwright's fileChooser event to handle the VueUse file dialog.
+   */
+  async uploadCsv(filePath: string): Promise<void> {
+    const fileChooserPromise = this.page.waitForEvent('filechooser');
+    await this.chooseFileButton.click();
+    const fileChooser = await fileChooserPromise;
+    await fileChooser.setFiles(filePath);
+  }
+
+  /** Fill the market name input. */
+  async fillMarketName(name: string): Promise<void> {
+    await this.nameInput.waitFor({ state: 'visible', timeout: 10000 });
+    await this.nameInput.fill(name);
+  }
+
+  /** Click the submit button to create the market. */
+  async clickSubmit(): Promise<void> {
+    await this.submitButton.click();
+  }
+
+  /** Wait for the name input to appear (indicating CSV was parsed). */
+  async waitForNameInput(): Promise<void> {
+    await this.nameInput.waitFor({ state: 'visible', timeout: 10000 });
+  }
+
+  /** Wait for navigation to the market setup wizard after submission. */
+  async waitForSetupRedirect(): Promise<void> {
+    await this.page.waitForURL('**/market-setup', { timeout: 15000 });
+  }
+}

--- a/front-end/src/components/elements/ElementAssignmentOptions.vue
+++ b/front-end/src/components/elements/ElementAssignmentOptions.vue
@@ -94,6 +94,7 @@ const handleProportionInput = (value: number) => {
                         class="datatype-dropdown"
                         :value="colIdxToSelectValue(assignmentOptions.emailColNameIdx)"
                         @change="setColIdx('emailColNameIdx', ($event.target as HTMLSelectElement).value)"
+                        data-testid="setup-options-email-select"
                     >
                         <option value=""></option>
                         <option
@@ -115,6 +116,7 @@ const handleProportionInput = (value: number) => {
                         class="datatype-dropdown"
                         :value="colIdxToSelectValue(assignmentOptions.tableChoiceColNameIdx)"
                         @change="setColIdx('tableChoiceColNameIdx', ($event.target as HTMLSelectElement).value)"
+                        data-testid="setup-options-table-choice-select"
                     >
                         <option value=""></option>
                         <option
@@ -136,6 +138,7 @@ const handleProportionInput = (value: number) => {
                         class="datatype-dropdown"
                         :value="colIdxToSelectValue(assignmentOptions.tableShareEmailColNameIdx)"
                         @change="setColIdx('tableShareEmailColNameIdx', ($event.target as HTMLSelectElement).value)"
+                        data-testid="setup-options-table-share-email-select"
                     >
                         <option value=""></option>
                         <option
@@ -182,7 +185,8 @@ const handleProportionInput = (value: number) => {
                     <div class="input-container">
                         <input type="text" v-model="assignmentOptions.maxAssignmentsPerVendor"
                             @input="handleDaysInput(Number(($event.target as HTMLInputElement)?.value || NaN))"
-                            style="all: unset; font-size: 14px; width: 100%;" />
+                            style="all: unset; font-size: 14px; width: 100%;"
+                            data-testid="setup-options-max-assignments-input" />
                     </div>
                 </div>
             </div>
@@ -194,7 +198,8 @@ const handleProportionInput = (value: number) => {
                     <div class="input-container">
                         <input type="text" v-model="assignmentOptions.maxHalfTableProportionPerSection"
                             @blur="handleProportionInput(Number(($event.target as HTMLInputElement)?.value || NaN))"
-                            style="all: unset; font-size: 14px; width: 100%;" />
+                            style="all: unset; font-size: 14px; width: 100%;"
+                            data-testid="setup-options-max-proportion-input" />
                     </div>
                 </div>
             </div>

--- a/front-end/src/components/elements/ElementFileDrop.vue
+++ b/front-end/src/components/elements/ElementFileDrop.vue
@@ -76,7 +76,7 @@ const readCSVFile = (file: File) => {
     <div class="file-drop-icons">
       <IconImport />
       <h3>
-        <span><button class="file-button" type="button" @click="open()">Choose a file</button></span>
+        <span><button class="file-button" type="button" @click="open()" data-testid="file-drop-choose-button">Choose a file</button></span>
         <span class="file-text"> or drag it here </span>
       </h3>
     </div>

--- a/front-end/src/components/elements/ElementLocationSetup.vue
+++ b/front-end/src/components/elements/ElementLocationSetup.vue
@@ -77,7 +77,8 @@ const removeRow = (index: number | null) => {
                 <div class="row-item">
                     <div class="input-container">
                         <input type="text" v-model="locationObjects[index].name"
-                            style="all: unset; font-size: 14px; width: 100%;" />
+                            style="all: unset; font-size: 14px; width: 100%;"
+                            :data-testid="'setup-location-name-input-' + index" />
                     </div>
                 </div>
                 <div
@@ -87,7 +88,7 @@ const removeRow = (index: number | null) => {
                 </div>
             </div>
             <div class="add-container">
-                <IconAddRound class="icon-add-round" @click="addRow" />
+                <IconAddRound class="icon-add-round" @click="addRow" data-testid="setup-location-add-button" />
             </div>
         </div>
     </div>

--- a/front-end/src/components/elements/ElementMarketDates.vue
+++ b/front-end/src/components/elements/ElementMarketDates.vue
@@ -79,11 +79,13 @@ const addRow = () => {
                         {{ getFormattedDate(marketDates[index].date) }}
                     </h4>
                     <input type="date" class="colname-input date-input" v-model="marketDates[index].date"
-                        onclick="this.showPicker()" />
+                        onclick="this.showPicker()"
+                        :data-testid="'setup-dates-date-input-' + index" />
 
                 </div>
                 <div class="row-item enum-item">
-                    <select class="datatype-dropdown" v-model="marketDates[index].colNameIdx">
+                    <select class="datatype-dropdown" v-model="marketDates[index].colNameIdx"
+                        :data-testid="'setup-dates-column-select-' + index">
                         <optgroup class="datatype-dropdown">
                             <option disabled value="">Values</option>
                             <option class="display-list" v-for="(value, index) in colNames" :key="index" :value="index">
@@ -99,7 +101,7 @@ const addRow = () => {
                 </div>
             </div>
             <div class="add-container">
-                <IconAddRound class="icon-add-round" @click="addRow" />
+                <IconAddRound class="icon-add-round" @click="addRow" data-testid="setup-dates-add-button" />
             </div>
         </div>
     </div>

--- a/front-end/src/components/elements/ElementSectionSetup.vue
+++ b/front-end/src/components/elements/ElementSectionSetup.vue
@@ -99,11 +99,13 @@ const countTables = () => {
                 @mouseover="hoverIndex = index" @mouseleave="hoverIndex = null">
                 <div class="row-item">
                     <div class="input-container">
-                        <input type="text" v-model="sections[index].name" style="all: unset; font-size: 14px; width: 100%;" />
+                        <input type="text" v-model="sections[index].name" style="all: unset; font-size: 14px; width: 100%;"
+                            :data-testid="'setup-section-name-input-' + index" />
                     </div>
                 </div>
                 <div class="row-item enum-item">
-                    <select class="dropdown" v-model="sections[index].location">
+                    <select class="dropdown" v-model="sections[index].location"
+                        :data-testid="'setup-section-location-select-' + index">
                         <option disabled value="">{{ "Select a location" }}</option>
                         <option class="display-list" v-for="(value, index) in locations" :key="index"
                             :value="value">
@@ -112,7 +114,8 @@ const countTables = () => {
                     </select>
                 </div>
                 <div class="row-item enum-item">
-                    <select class="dropdown" v-model="sections[index].tier">
+                    <select class="dropdown" v-model="sections[index].tier"
+                        :data-testid="'setup-section-tier-select-' + index">
                         <option disabled value="">{{ "Select a tier" }}</option>
                         <option class="display-list" v-for="(value, index) in tiers" :key="index"
                             :value="value">
@@ -127,7 +130,8 @@ const countTables = () => {
                         v-model="sections[index].count"
                         @input="handleCountInput(index, Number(($event.target as HTMLInputElement)?.value || NaN))"
                         style="font-size: 14px; width: 100%;"
-                        class="number-input" />
+                        class="number-input"
+                        :data-testid="'setup-section-count-input-' + index" />
                     </div>
                 </div>
                 <div
@@ -137,7 +141,7 @@ const countTables = () => {
                 </div>
             </div>
             <div class="add-container">
-                <IconAddRound class="icon-add-round" @click="addRow" />
+                <IconAddRound class="icon-add-round" @click="addRow" data-testid="setup-section-add-button" />
             </div>
         </div>
         <div ref="tableCount" style="position: absolute; left: 5px; bottom: -10px">

--- a/front-end/src/components/floorplan/ChoosePathOverlay.vue
+++ b/front-end/src/components/floorplan/ChoosePathOverlay.vue
@@ -12,7 +12,7 @@ defineEmits<{
 
       <div class="cards-row">
         <!-- ─── Manual Setup Card ─── -->
-        <div class="path-card" @click="$emit('select', 'manual')">
+        <div class="path-card" @click="$emit('select', 'manual')" data-testid="choose-path-manual">
           <div class="card-icon-wrapper">
             <i class="pi pi-list card-icon" />
           </div>

--- a/front-end/src/views/MarketSetupView.vue
+++ b/front-end/src/views/MarketSetupView.vue
@@ -110,7 +110,7 @@ onMounted(() => {
                 const uploadRow = uploadObject.data.data[j];
                 columnValues.push(uploadRow[uploadColName]);
             }
-            colValuesList.push([...new Set(columnValues)]);
+            colValuesList.push([...new Set(columnValues.filter(v => v != null))]);
             enumPriorityOrder.push([]);
         }
 


### PR DESCRIPTION
## Intent

Write a Playwright E2E test for the full market pipeline: login, create market with CSV upload via NewMarketOverlay, walk the 3-page setup wizard (columns/dates, tiers/locations/sections, priority/options), trigger assignment generation, and verify assignment results view shows summary stats and breakdowns. Land as PR against dev branch. Added 15 data-testid attributes across 6 Vue components to enable wizard driving. Created NewMarketPage page object, extended MarketSetupPage. Fixed pre-existing colValues null-filtering bug in MarketSetupView and used index-based tier selection to preserve TierObject id for backend validation. All 3 E2E tests green locally.

## What Changed

- Filter `null`/`undefined` out of column values before de-duplicating in `MarketSetupView`, so empty entries no longer surface as enum priority-order options in the setup wizard.
- Add a `market-pipeline.spec.ts` Playwright test that drives the end-to-end flow (login → `NewMarketOverlay` CSV upload → 3-page setup wizard → assignment generation → results view), backed by a new `NewMarketPage` page object and an extended `MarketSetupPage` with tier-label-aware helpers and index-parameterized date/location/section actions.
- Add `data-testid` attributes across the file-drop, market-dates, location, section, and assignment-options elements plus the choose-path overlay to make the wizard drivable, wire a test-vendors CSV fixture, and sync `docs/TESTING.md` / `AGENTS.md` with the new page objects and spec.

## Risk Assessment

✅ Low: The change is well-bounded, additive E2E test infrastructure (data-testid attributes and page objects) plus a single defensive null-filter in product code, with substantive helper concerns already resolved in prior rounds.

## Testing

Baseline: the pre-existing docker stack (conventioner-nm37) was volume-mounted from a different worktree whose source lacked the newly added data-testids, so the test failed immediately on getByTestId('file-drop-choose-button'). I resolved this setup problem by running a vite dev server from this worktree's source, proxied to the live backend (which already had the verified e2e test user), then ran the tests. The market-pipeline test drives the real end-user flow (login, CSV-upload market creation, the full 3-page setup wizard, assignment generation) and asserts the results view; it passes and produces an Assignment Results screenshot with real data (1 assignment, 1/1 tables, 1/5 vendors, 20.0% satisfaction, per-date/section/tier breakdowns, 4 unassigned vendors). All 3 E2E tests (market-pipeline + 2 smoke) pass. Transient artifacts and the dev server were cleaned up; worktree is clean.

- Evidence: Assignment Results view (final pipeline output) (local file: <code>/tmp/no-mistakes-evidence/01KWREST2SVYAEH5V674SBD4XG/assignment-results.png</code>)
- Evidence: Full market pipeline flow (login → create → wizard → assign → results) (local file: <code>/tmp/no-mistakes-evidence/01KWREST2SVYAEH5V674SBD4XG/market-pipeline-flow.webm</code>)
<details>
<summary>Evidence: Playwright run result</summary>

```text
Running 3 tests using 1 worker
✓ market-pipeline.spec.ts › create market, configure, assign, and view results (1.7s)
✓ smoke.spec.ts › login and access dashboard (520ms)
✓ smoke.spec.ts › navigate to markets and see seeded market (615ms)
3 passed (3.5s)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `front-end/e2e/pages/MarketSetupPage.ts:166` - addSection() accepts a `tierOptionLabel` argument but ignores it, always selecting `{ index: 1 }` (the first real tier option). The call site passes &#39;Gold&#39; expecting the Gold tier, and it only happens to work because Set-insertion order of the day_1 column puts Gold first. If tier ordering ever changes, the helper will silently assign the wrong tier while the test still reads as &#39;Gold&#39;, masking a real product/config bug. Either use the label to locate the option (then resolve its index) or drop the misleading unused parameter.
- ℹ️ `front-end/e2e/pages/MarketSetupPage.ts:117` - expectColumnCount(count) never asserts anything about `count`: it only waits for a row to be visible, and the local `rows` variable is unused. As written it is a no-op that would pass regardless of the actual column count. It is currently unused (the spec inlines toHaveCount(5)), so either make it actually assert `colRows.toHaveCount(count)` or remove it (and the unused getColumnCheckbox) to avoid a false-safety trap for future callers.

🔧 Fix: fix e2e helpers to honor tier label and assert column count
1 warning still open:
- ⚠️ `front-end/e2e/pages/MarketSetupPage.ts:92` - addMarketDate() always targets the row-0 testids (`setup-dates-date-input-0` / `setup-dates-column-select-0`) regardless of how many date rows already exist. Since ElementMarketDates.addRow() appends to the array, a second call would create a row at index 1 but then fill/select row 0&#39;s inputs, silently misconfiguring the wizard. Unlike the sibling addLocation()/addSection() helpers, it doesn&#39;t even accept an `index` param to disambiguate. It happens to work today because the spec adds exactly one date. Parameterize the row index (defaulting to 0) and build the testids from it, consistent with addLocation().

🔧 Fix: parameterize addMarketDate row index in e2e page object
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`FRONTEND_PORT=5273 npx playwright test market-pipeline.spec.ts` (full pipeline: login → NewMarketOverlay CSV upload → 3-page wizard → assign → results)</code>
- <code>`FRONTEND_PORT=5273 npx playwright test` (full suite: market-pipeline + smoke, 3 tests, all green)</code>
- <code>Served this worktree&#39;s front-end via `npx vite --port 5273` with VITE_BACKEND_URL=https://localhost:5040 after finding the docker frontend mounted a stale sibling worktree without the new data-testid attributes</code>
- `Captured the rendered Assignment Results view screenshot and a video of the full flow as evidence`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
