### PR TITLE
docs: add floorplan workflow E2E patterns to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,38 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 - **Run E2E**: `./scripts/seed_fixture.sh` then `cd front-end && npm run test:e2e`.
   Playwright config auto-detects worktree port via `detectFrontendPort()`.
 
+### Floorplan Workflow E2E
+
+- **Deterministic - no AI mocking needed.** Despite the "Floorplan AI" name,
+  the front-end wizard makes no LLM/vision calls. Table auto-placement
+  (`POST /floorplans/place-tables`, `back-end/services/placement_service.py`)
+  is a pure geometry solver (Shapely + `pyckingsolver`). The
+  Gemini/GPT vision endpoint (`POST /floorplans/analyze`,
+  `back-end/api/floorplans_analysis.py`) exists but is not wired into the
+  front-end workflow (walls are drawn by hand). Consequence: the flow can be
+  exercised end-to-end for real in CI with no API keys and no stubbing.
+- **Konva canvas interactions and coverage gap.** The wizard's three canvas
+  steps have different testability:
+  - Calibration line drawing IS drivable with real Playwright `page.mouse`
+    drags on the Konva stage (see `FloorplanWorkflowPage.drawCalibrationLine()`).
+  - Section-grouping (Konva "lasso" selection) and the `FloorplanEditor` step
+    are NOT reliably drivable via simulated mouse events.
+    `floorplan.spec.ts` drives Pinia store state directly via `page.evaluate`
+    for those steps (`snapshotPlacedTables()`, `restorePlacedTables()`,
+    `groupAllTablesIntoSection()`).
+  - **Coverage gap**: section grouping and editor canvas interactions are
+    validated at the state level, not as real user gestures. Anyone extending
+    floorplan coverage should account for this.
+- **Artifacts** (PR #18 pattern to follow):
+  - Page object: `front-end/e2e/pages/FloorplanWorkflowPage.ts`
+  - Spec: `front-end/e2e/floorplan.spec.ts`
+  - Fixture: `front-end/e2e/fixtures/test-floorplan.png` (800×600 PNG)
+- **Save-path null-tolerance**: `POST /floorplans/save-to-market`
+  (`back-end/api/floorplans_save.py`) handles a null `setupObject` on the
+  market doc (the manual-setup path leaves it null). The fix uses
+  `isinstance(existing_setup, dict)` to branch between updating the existing
+  object and seeding a fresh one.
+
 ## E2E Seed Helpers for Published Markets
 
 - `seedPublishedMarketWithAssignments()` in `front-end/e2e/helpers/seeds.ts` creates a fully


### PR DESCRIPTION
## Intent

Record the durable, project-intrinsic knowledge learned from building the create-from-floorplan e2e test (merged in PR #18) into the project's committed AGENTS.md. This is a documentation-only change covering: (1) the floorplan flow is deterministic with no AI/LLM calls from frontend - pure geometry solver; (2) Konva canvas interaction coverage gap - calibration is mouse-drivable but section grouping and editor steps use Pinia store manipulation via page.evaluate; (3) artifact references for FloorplanWorkflowPage, floorplan.spec.ts, and test-floorplan.png fixture; (4) save-path null-tolerance note about the isinstance(dict) fix in floorplans_save.py. PR base is dev, never main. No code, test, or config changes - AGENTS.md only.

## What Changed

- Documented the create-from-floorplan E2E patterns in `AGENTS.md`: the floorplan flow is deterministic with no frontend LLM/vision calls (table placement is a pure Shapely + `pyckingsolver` geometry solver, and the Gemini/GPT `/floorplans/analyze` endpoint is not wired into the wizard), so it runs in CI with no API keys or stubbing.
- Recorded the Konva canvas testability gap: calibration line drawing is drivable with real Playwright `page.mouse` drags, while section grouping and the `FloorplanEditor` step are validated at Pinia store level via `page.evaluate` rather than as real gestures.
- Added artifact references (`FloorplanWorkflowPage.ts`, `floorplan.spec.ts`, `test-floorplan.png` 800×600 fixture) and a note on the save-path null-tolerance fix (`isinstance(existing_setup, dict)` branch in `floorplans_save.py`).

## Risk Assessment

✅ Low: Documentation-only addition to AGENTS.md whose every factual claim (file paths, method names, the isinstance(dict) fix location, and endpoint routes) was verified accurate against the codebase.

## Testing

This is a documentation-only change (+32 lines to AGENTS.md, the sole file in the diff), so validation was fact-checking each documented claim against source rather than running the app. No screenshot/GIF/video artifact was produced because the change has no UI or runtime surface - it edits a Markdown knowledge file; the reviewer-visible evidence is a claim-by-claim verification matrix mapping every assertion to the code that backs it. All eight claims (deterministic pure-geometry placement solver, unwired vision endpoint, Konva calibration-vs-Pinia coverage gap, the three artifact file references incl. the 800×600 PNG, and the isinstance(dict) save null-tolerance) verified accurate against the current tree. No transient artifacts were left in the working tree.

<details>
<summary>Evidence: AGENTS.md claim verification matrix</summary>

`All 8 documented claims verified PASS against source. Diff scope: only AGENTS.md changed. Key checks: placement_service.py = Shapely+pyckingsolver; /analyze (gemini-2.5-flash/gpt-4o-mini) exists but grep in front-end/src is EMPTY; drawCalibrationLine=page.mouse, snapshot/restore/group=page.evaluate; test-floorplan.png=800x600 PNG; floorplans_save.py L143 isinstance(existing_setup, dict).`

```text
# AGENTS.md Floorplan-E2E doc — claim verification

Change under test: docs-only, +32 lines to AGENTS.md (git diff range shows AGENTS.md
is the ONLY changed file). For a documentation change, "working" = every documented
claim is factually true against the current source tree. Result: all claims verified.

| # | Documented claim | Verified against source | Result |
|---|------------------|-------------------------|--------|
| 1 | place-tables solver is pure geometry (Shapely + pyckingsolver) | back-end/services/placement_service.py L4 "pure geometry logic using Shapely and pyckingsolver"; imports `from shapely...`, `from pyckingsolver import nest, Objective` | PASS |
| 1b| /place-tables endpoint delegates to that service | back-end/api/floorplans_placement.py L15 `from services.placement_service import auto_place_tables`, route L24 | PASS |
| 1c| /analyze vision endpoint exists (Gemini/GPT) but NOT wired into front-end | floorplans_analysis.py: `_call_gemini` (gemini-2.5-flash), `_call_openai` (gpt-4o-mini), route `/analyze`; grep for `floorplans/analyze` in front-end/src = EMPTY | PASS |
| 2 | drawCalibrationLine() driven by real page.mouse drags | FloorplanWorkflowPage.ts L212-229: page.mouse.move/down/move/up | PASS |
| 2b| section grouping + editor use Pinia via page.evaluate | FloorplanWorkflowPage.ts L295 snapshotPlacedTables, L312 restorePlacedTables, L352 groupAllTablesIntoSection all call page.evaluate | PASS |
| 3 | Artifact paths exist | FloorplanWorkflowPage.ts, floorplan.spec.ts, fixtures/test-floorplan.png all present | PASS |
| 3b| test-floorplan.png is 800×600 PNG | `file` → "PNG image data, 800 x 600, 8-bit/color RGBA" | PASS |
| 4 | save-to-market null-tolerance via isinstance(existing_setup, dict) | floorplans_save.py L141-143: `existing_setup = market_doc.get("setupObject")` then `if isinstance(existing_setup, dict):` | PASS |

Diff scope confirmation:
  $ git diff --name-only c09cceca 2b8c1823
  AGENTS.md
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --name-only c09cceca 2b8c1823` → only AGENTS.md changed</code>
- `Confirmed all referenced files exist: placement_service.py, floorplans_analysis.py, floorplans_save.py, FloorplanWorkflowPage.ts, floorplan.spec.ts, test-floorplan.png`
- <code>`file front-end/e2e/fixtures/test-floorplan.png` → PNG 800×600</code>
- <code>grep confirmed placement_service.py imports shapely + pyckingsolver; floorplans_placement.py delegates via `from services.placement_service import auto_place_tables`</code>
- <code>grep `floorplans/analyze` in front-end/src → empty (confirms vision endpoint not wired into front-end)</code>
- `grep FloorplanWorkflowPage.ts → drawCalibrationLine uses page.mouse (L212-229); snapshot/restore/groupAllTablesIntoSection use page.evaluate (L295-352)`
- <code>grep floorplans_save.py → `isinstance(existing_setup, dict)` at L143</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
