### PR TITLE
fix(floorplans): preserve auto-placed tables and calibration scale when editor mounts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,8 @@ This file is the project's committed home for project-intrinsic agent knowledge:
   - Section-grouping (Konva "lasso" selection) and the `FloorplanEditor` step
     are NOT reliably drivable via simulated mouse events.
     `floorplan.spec.ts` drives Pinia store state directly via `page.evaluate`
-    for those steps (`snapshotPlacedTables()`, `restorePlacedTables()`,
-    `groupAllTablesIntoSection()`).
+    for those steps (`groupAllTablesIntoSection()`), and uses
+    `snapshotPlacedTables()` to assert table state persists across wizard steps.
   - **Coverage gap**: section grouping and editor canvas interactions are
     validated at the state level, not as real user gestures. Anyone extending
     floorplan coverage should account for this.
@@ -81,6 +81,13 @@ This file is the project's committed home for project-intrinsic agent knowledge:
   market doc (the manual-setup path leaves it null). The fix uses
   `isinstance(existing_setup, dict)` to branch between updating the existing
   object and seeding a fresh one.
+- **Editor-mount table preservation**: `FloorplanEditor.vue`'s
+  `loadBackgroundImage()` only calls `store.initFloorplan()` when no floorplan
+  exists yet, spreading the existing store data (`placedTables`, `tableTypes`,
+  `sections`, `walls`, `obstacles`, scale) into the init so forward wizard
+  progression keeps auto-placed tables; when a floorplan already exists it just
+  refreshes the background image fields. This replaced an earlier
+  snapshot/restore workaround in the e2e page object.
 
 ## E2E Seed Helpers for Published Markets
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -162,7 +162,8 @@ Pushes and PRs to `main` or `dev` trigger `.github/workflows/test.yml`:
 - **Driving the Konva floorplan canvas**: `FloorplanWorkflowPage` calibrates the
   scale by issuing `page.mouse` drags over the Konva stage, but the lasso-based
   section grouping cannot be driven reliably through the canvas, so the page
-  object manipulates the Pinia store directly via `page.evaluate`. Because
-  `FloorplanEditor.initFloorplan()` clears `placedTables` when the table-placement
-  step mounts, the page object also snapshots and restores the store around that
-  transition.
+  object manipulates the Pinia store directly via `page.evaluate`. The
+  `FloorplanEditor` no longer resets the store on mount (it preserves the
+  existing `placedTables`, `tableTypes`, `sections`, `walls`, and `obstacles`),
+  so the spec uses `snapshotPlacedTables()` to assert tables survive the
+  step-2-to-step-3 transition rather than snapshotting and restoring around it.

--- a/front-end/e2e/floorplan.spec.ts
+++ b/front-end/e2e/floorplan.spec.ts
@@ -38,6 +38,11 @@ test.describe('Floorplan workflow E2E', () => {
     await expect(page).toHaveURL(/\/market-setup/)
     await setupPage.waitForWizard()
 
+    // Verify placed tables survived the step-2 to step-3 transition.
+    // If the initFloorplan bug resets placedTables, this fails.
+    const survivingTables = await floorplanPage.snapshotPlacedTables()
+    expect(survivingTables.length).toBeGreaterThan(0)
+
     const sectionsContainer = page.locator('.triple-column-body')
     await sectionsContainer.waitFor({ state: 'visible', timeout: 5000 })
     const sectionRows = page.locator('.triple-column-body .priority-row')

--- a/front-end/e2e/pages/FloorplanWorkflowPage.ts
+++ b/front-end/e2e/pages/FloorplanWorkflowPage.ts
@@ -289,8 +289,8 @@ export class FloorplanWorkflowPage {
 
   /**
    * Capture the current placed tables from the store and return them
-   * as a JSON-serializable snapshot. Used to restore state after
-   * initFloorplan() resets the store when step 3 mounts.
+   * as a JSON-serializable snapshot. Used by the e2e spec to assert
+   * table persistence across wizard steps.
    */
   async snapshotPlacedTables(): Promise<PlacedTable[]> {
     return this.page.evaluate(() => {
@@ -303,48 +303,6 @@ export class FloorplanWorkflowPage {
       if (!store) return []
       return JSON.parse(JSON.stringify(store.placedTables))
     })
-  }
-
-  /**
-   * Restore placed tables (and optionally tableTypes/scale) from a snapshot.
-   * Used to recover state after the step-3 FloorplanEditor reset.
-   */
-  async restorePlacedTables(tables: PlacedTable[]): Promise<void> {
-    await this.page.evaluate((snapshot) => {
-      const appEl = document.querySelector('#app')
-      const vueApp = (appEl as unknown as { __vue_app__?: VueAppLike })?.__vue_app__
-      if (!vueApp) return
-      const pinia = vueApp.config.globalProperties.$pinia
-      if (!pinia) return
-      const store = pinia._s.get('floorplan')
-      if (!store) return
-      store.placedTables = snapshot
-    }, tables)
-    await this.page.waitForTimeout(200)
-  }
-
-  async restoreTableTypes(): Promise<void> {
-    await this.page.evaluate(() => {
-      const appEl = document.querySelector('#app')
-      const vueApp = (appEl as unknown as { __vue_app__?: VueAppLike })?.__vue_app__
-      if (!vueApp) return
-      const pinia = vueApp.config.globalProperties.$pinia
-      if (!pinia) return
-      const store = pinia._s.get('floorplan')
-      if (!store) return
-      if (store.tableTypes.length > 0) return
-      store.tableTypes = [
-        {
-          id: crypto.randomUUID(),
-          name: '6ft Table',
-          widthMm: 1800,
-          heightMm: 900,
-          maxCapacity: 2,
-          color: '#4A90D9',
-        },
-      ]
-    })
-    await this.page.waitForTimeout(200)
   }
 
   // ─── Step 3: Section Grouping ──────────────────────────────────
@@ -417,14 +375,11 @@ export class FloorplanWorkflowPage {
     await this.tableTypeAddBtn.waitFor({ state: 'visible', timeout: 5000 })
     await this.addTableType(tableTypeName, tableWidth, tableHeight)
     await this.autoPlaceTables()
-    const placedSnapshot = await this.snapshotPlacedTables()
     await this.waitForNextEnabled()
     await this.clickNext()
 
-    // Step 3: Restore state after FloorplanEditor.initFloorplan() reset
+    // Step 3: Edit Layout / Section Grouping
     await this.sectionGroupToggle.waitFor({ state: 'visible', timeout: 10000 })
-    await this.restorePlacedTables(placedSnapshot)
-    await this.restoreTableTypes()
     await this.groupAllTablesIntoSection(sectionName, sectionLocation)
     await this.waitForNextEnabled()
     await this.clickNext()

--- a/front-end/src/components/floorplan/FloorplanEditor.vue
+++ b/front-end/src/components/floorplan/FloorplanEditor.vue
@@ -106,11 +106,22 @@ async function loadBackgroundImage(gridfsId: string) {
       i.src = url
     })
     bgImage.value = img
-    store.initFloorplan({
-      imageGridfsId: gridfsId,
-      imageWidth: img.width,
-      imageHeight: img.height,
-    })
+    if (!store.floorplan) {
+      store.initFloorplan({
+        imageGridfsId: gridfsId,
+        imageWidth: img.width,
+        imageHeight: img.height,
+        ...(store.placedTables.length > 0 ? { placedTables: store.placedTables } : {}),
+        ...(store.tableTypes.length > 0 ? { tableTypes: store.tableTypes } : {}),
+        ...(store.sections.length > 0 ? { sections: store.sections } : {}),
+        ...(store.walls.length > 0 ? { walls: store.walls } : {}),
+        ...(store.obstacles.length > 0 ? { obstacles: store.obstacles } : {}),
+      })
+    } else {
+      store.floorplan.imageGridfsId = gridfsId
+      store.floorplan.imageWidth = img.width
+      store.floorplan.imageHeight = img.height
+    }
   } catch (_e: unknown) {
     const err = _e as {
       name?: string

--- a/front-end/src/components/floorplan/FloorplanEditor.vue
+++ b/front-end/src/components/floorplan/FloorplanEditor.vue
@@ -116,6 +116,7 @@ async function loadBackgroundImage(gridfsId: string) {
         ...(store.sections.length > 0 ? { sections: store.sections } : {}),
         ...(store.walls.length > 0 ? { walls: store.walls } : {}),
         ...(store.obstacles.length > 0 ? { obstacles: store.obstacles } : {}),
+        ...(store.scalePxPerMm !== 1 ? { scalePxPerUnit: store.scalePxPerMm } : {}),
       })
     } else {
       store.floorplan.imageGridfsId = gridfsId


### PR DESCRIPTION
## Intent

The developer was investigating and then fixing a bug where the floorplan layout editor loses a user's auto-placed tables: FloorplanEditor's initFloorplan() unconditionally reset placedTables to an empty array every time the "Edit Layout" wizard step mounted, and the create-from-floorplan e2e test had only masked this with a store snapshot/restore workaround. After confirming the bug, they wanted to ship the fix on branch fm/floorplan-editor-reset-q7 targeting dev (never main), remove the e2e workaround, and validate via the no-mistakes pipeline with the e2e test passing in CI as proof. When code review surfaced that the initial guard still let the first step-2-to-step-3 transition wipe tables, the developer directed a complete fix that spreads existing store data (placedTables, tableTypes, sections, walls, obstacles) through initFloorplan so forward progression preserves tables. They also required a real e2e persistence assertion that would fail on the un-fixed code, and chose to keep stale tables when the background image is swapped (accepting that edge case). The stated constraints included following conventional commits, not co-authoring commits, and ensuring the final commit's e2e test passes before reporting the PR as green.

## What Changed

- Reworked `FloorplanEditor.vue`'s `loadBackgroundImage()` so `store.initFloorplan()` is only called when no floorplan exists yet, spreading the existing store data (`placedTables`, `tableTypes`, `sections`, `walls`, `obstacles`, and `scalePxPerUnit` from the calibrated `scalePxPerMm`) into the init; when a floorplan already exists it only refreshes the background image fields, so forward wizard progression no longer wipes auto-placed tables or resets the calibration scale to 1.
- Removed the snapshot/restore workaround from `FloorplanWorkflowPage.ts` and added a real persistence assertion in `floorplan.spec.ts` (`survivingTables.length > 0`) that fails on the un-fixed editor, so the e2e test validates table preservation instead of masking the reset.
- Synced `AGENTS.md` and `docs/TESTING.md` with the editor-mount table-preservation behavior and updated floorplan E2E notes.

## Risk Assessment

✅ Low: A small, well-bounded fix that correctly preserves store state (including the calibration scale) across the editor mount, backed by a real e2e persistence assertion that replaces the prior test workaround; the only residual concern is an accepted, currently-unreachable image-swap edge case.

## Testing

Ran the committed floorplan create-from-floorplan e2e against an isolated docker stack for this worktree (the default 5000/5173 ports were held by the primary checkout, so I stood up a separate stack on 5040/5213 and seeded a verified test user). The committed floorplan.spec.ts passes with the fix, and reverting only the FloorplanEditor.vue change makes the same spec fail — demonstrating the new post-transition persistence assertion is a real regression guard, not the old workaround. A supplementary evidence run confirmed the auto-placed table count is preserved (1→1) across the Edit Layout mount and captured a render of the editor stage showing the preserved table. Full-page screenshots of the Edit Layout step render blank because a disabled Wall Editor overlay stage stacks over the editor canvas and the on-screen layer doesn't flush in a single headless frame; I verified via toCanvas pixel-sampling that the editor stage's scene graph contains the painted blue table and captured that stage render as the visual artifact. Working tree left clean; transient docker stack and volumes removed.

- Evidence: FloorplanEditor stage render — preserved auto-placed table after Edit Layout mount (local file: <code>/tmp/no-mistakes-evidence/01KWVYMNYJCV2DJWAEYDCE1HP6/floorplan-editor-stage-render.png</code>)
- Evidence: Place Tables step (6ft Table type + Auto-Place) — wizard context (local file: <code>/tmp/no-mistakes-evidence/01KWVYMNYJCV2DJWAEYDCE1HP6/floorplan-step2-place-tables.png</code>)
- Evidence: Passing floorplan e2e workflow video (fixed code) (local file: <code>/tmp/no-mistakes-evidence/01KWVYMNYJCV2DJWAEYDCE1HP6/floorplan-PASS-fixed.webm</code>)
- Evidence: Post-save market Settings step (workflow completed) (local file: <code>/tmp/no-mistakes-evidence/01KWVYMNYJCV2DJWAEYDCE1HP6/floorplan-PASS-final-screenshot.png</code>)
<details>
<summary>Evidence: Regression-guard proof: revert FloorplanEditor fix → floorplan.spec.ts fails</summary>

```text
1 failed\n [chromium] › e2e/floorplan.spec.ts:10:3 › Floorplan workflow E2E › create market from floorplan, complete wizard, and verify save\n\n(fixed code: 1 passed; buggy code: workflow cannot complete because auto-placed tables are wiped on Edit Layout mount)
```
</details>
<details>
<summary>Evidence: Table persistence across step-2→step-3 transition (fixed code)</summary>

```text
[EVIDENCE] tables auto-placed at step 2: 1\n[EVIDENCE] tables present after step-2 -> step-3 transition: 1\n[EVIDENCE] canvas state: {"scalePxPerMm":0.16,"table":{"x":0,"y":0,"widthMm":1800,"heightMm":900}}\n[EVIDENCE] editor stage table node: visible=true fill=#4A90D9
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `front-end/src/components/floorplan/FloorplanEditor.vue:114` - initFloorplan preserves placedTables/tableTypes/sections/walls/obstacles but omits scalePxPerUnit. When the Edit Layout step (step 3) mounts, store.floorplan is null (nothing sets it earlier - ScaleCalibration&#39;s setScale only writes scalePxPerMm), so this branch runs and initFloorplan resets scalePxPerMm to `scalePxPerUnit ?? 1` = 1 (store floorplan.ts:86), discarding the calibration done in step 2. All mm-&gt;px conversions in the editor (tableRectConfig, onTableDragEnd, walls) then use scale 1, so the preserved tables render at the wrong size/position over the background image; dragging a table writes back mm coords divided by 1, corrupting them, and SaveFlow persists scalePxPerUnit=1. Spread `scalePxPerUnit: store.scalePxPerMm` alongside the other fields to complete the fix. The new e2e assertion (only checks placedTables.length &gt; 0) will not catch this.

🔧 Fix: fix(floorplans): preserve calibration scale when editor mounts
1 info still open:
- ℹ️ `front-end/src/components/floorplan/FloorplanEditor.vue:121` - The else-branch (store.floorplan already exists) updates imageWidth/imageHeight to the new image but keeps the existing scalePxPerMm and placedTables. If a background image is ever swapped for one with different real-world dimensions while a floorplan is already initialized, tables render/persist at the old scale. Not reachable in the current wizard (image is chosen at step 0, editor only mounts at step 3 with no re-upload), and the author explicitly accepted this tradeoff. Noted for awareness only.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd front-end &amp;&amp; FRONTEND_PORT=5213 BACKEND_URL=https://localhost:5040 npx playwright test floorplan.spec.ts` — passes on the fixed code (includes the new `survivingTables.length &gt; 0` assertion)</code>
- <code>Temporarily reverted only the `FloorplanEditor.vue` initFloorplan fix and re-ran `floorplan.spec.ts` — test FAILS (workflow cannot complete; tables wiped), confirming the assertion catches the regression rather than masking it</code>
- `Evidence run driving the wizard through create-from-floorplan → calibrate → auto-place → Edit Layout: logged placed-table count 1 before and 1 after the step-2→step-3 transition (bug reset it to 0)`
- `Sampled the FloorplanEditor Konva stage via toCanvas(): table node present, visible, fill #4A90D9; captured the editor stage render showing the preserved auto-placed table`
- <code>Brought up isolated stack `docker compose -f docker-compose.yml -f docker-compose.worktree.yml up -d --wait` (project nm-01kwvym, backend 5040/frontend 5213) and seeded via reset_database.py + create_test_user.py; torn down with `down -v` afterward</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
