### PR TITLE
feat(markets): require an organization at market creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,9 +44,21 @@ This file is the project's committed home for project-intrinsic agent knowledge:
   `front-end/e2e/helpers/seedAssignedMarket.ts` exports `seedAssignedMarket()`, which
   also configures the market `setupObject` and triggers assignment via the API.
   Requires a verified test user (created by `scripts/seed_fixture.sh`).
+- **Markets require an organization**: `POST /markets` rejects a payload with no
+  `organizationId`, an unknown organization, or an organization the caller is not a
+  member of (400 each).
+  Anything that creates a market must therefore attach one: `seeds.ts` exports
+  `ensureTestOrgAuthenticated()` (already-logged-in request context) and
+  `ensureTestOrg()` (logs in first), both of which reuse the user's first organization
+  or create `E2E Test Org`, and the seed helpers return it as `orgId`.
+  Specs that create a market through the UI must call `ensureTestOrg()` in `beforeAll`,
+  otherwise the overlay's org dropdown is empty and submit stays disabled.
 - **Test user creation**: The back-end `/register-user` endpoint does NOT set `email_verified`,
   so users created through it cannot log in.
   Test users must be created via `back-end/create_test_user.py` which sets `email_verified=True`.
+  `scripts/seed_fixture.sh` creates two verified users: `TEST_EMAIL` (owns `Seed Test Org`)
+  and `NO_ORG_EMAIL` (`e2e-noorg@example.com`), which is deliberately left in no organization
+  so `new-market-org.spec.ts` can exercise the zero-org fallback.
 - **Run E2E**: `./scripts/seed_fixture.sh` then `cd front-end && npm run test:e2e`.
   Playwright config auto-detects worktree port via `detectFrontendPort()`.
 

--- a/back-end/app.py
+++ b/back-end/app.py
@@ -560,7 +560,13 @@ def get_markets_by_owner_email() -> Response:
 @app.route('/markets', methods=['POST'])
 @login_required
 def create_market() -> Response:
-    """Create a new market."""
+    """Create a new market.
+
+    Every market belongs to an organization: the payload must carry an
+    `organizationId` that names an existing organization the requesting user
+    owns or belongs to (as admin or member). A missing, unknown, or
+    non-member organization is rejected with 400.
+    """
     try:
         data = request.json
         if not data:

--- a/back-end/app.py
+++ b/back-end/app.py
@@ -585,6 +585,19 @@ def create_market() -> Response:
         if owner_count != 1:
             return jsonify({"error": "Market must have exactly one owner in roles dict"}), 400
         
+        org_id = data.get('organization_id')
+        if not org_id:
+            return jsonify({"error": "organization_id is required"}), 400
+        
+        org = OrgsApi.get_organization(org_id)
+        if not org:
+            return jsonify({"error": "Organization not found"}), 400
+        
+        if (owner.id != org.get('owner')
+                and owner.id not in org.get('admins', [])
+                and owner.id not in org.get('members', [])):
+            return jsonify({"error": "User is not a member of this organization"}), 400
+        
         # Create the market
         result, market_id = MarketsApi.create_market(market, owner_email)
         

--- a/docs/ENTITY_RELATIONSHIP_REFINEMENT.md
+++ b/docs/ENTITY_RELATIONSHIP_REFINEMENT.md
@@ -138,6 +138,8 @@ class Organization(BaseModel):
 ### 3. Market-Organization Relationship
 **Requirement:** Market can belong to 0 or 1 organization.
 
+> **Superseded:** markets now belong to exactly 1 organization. `POST /markets` requires an `organizationId` naming an organization the caller belongs to, and the new-market form blocks submission until one is picked. The shipped field is `organization_id` (an id, not a name), and it is still typed `Optional[str]` only so org-less markets created before this rule stay readable. See [OBJECT_RELATIONSHIPS.md](./OBJECT_RELATIONSHIPS.md) for the current model.
+
 **New Field:**
 ```python
 class Market(BaseModel):

--- a/docs/OBJECT_RELATIONSHIPS.md
+++ b/docs/OBJECT_RELATIONSHIPS.md
@@ -57,7 +57,7 @@ Represents an organization that can contain multiple users and markets with hier
 
 **Relationships:**
 - **Many-to-Many with User**: Organizations contain multiple users with different roles (owner/admins/members)
-- **One-to-Many with Market**: Organizations can own multiple markets (via `markets` list and `Market.organization` field)
+- **One-to-Many with Market**: Organizations can own multiple markets (via `markets` list and `Market.organization_id` field). Because every new market requires an organization, a user must belong to at least one organization before they can create a market.
 - **Stored in**: MongoDB `organizations` collection
 
 **Role Hierarchy:**
@@ -85,7 +85,7 @@ The central entity representing a market event with configuration, assignments, 
 - `name: str` - Mutable display name
 - `creation_date: str` - ISO format date string when market was created
 - `roles: Dict[str, MarketRole]` - Map of user_id -> role (must contain exactly one OWNER)
-- `organization_id: Optional[str]` - Organization id if market belongs to an organization (None if standalone)
+- `organization_id: Optional[str]` - Organization id the market belongs to. **Required at creation**: `POST /markets` rejects a payload without `organizationId`, with an unknown organization id, or with an organization the requesting user does not belong to (all 400). The field stays `Optional` in the model only so that org-less markets created before this rule remain readable; new markets always have one.
 - `theme: Optional[ThemeObject]` - Market-specific theme (used if no organization, otherwise organization theme takes precedence)
 - `setup_object: Optional[SetupObject]` - Market configuration and setup data
 - `modification_list: List[ModificationObject]` - List of modifications (currently empty structure)
@@ -94,7 +94,7 @@ The central entity representing a market event with configuration, assignments, 
 
 **Relationships:**
 - **Many-to-Many with User**: Markets have multiple users with different roles (via `roles` dict, keys are user ids)
-- **Many-to-One with Organization**: Markets can belong to one organization (via `organization_id` field, optional)
+- **Many-to-One with Organization**: Every market belongs to exactly one organization (via `organization_id` field, enforced at creation)
 - **One-to-One with SetupObject**: Each market has one setup configuration (optional)
 - **One-to-One with AssignmentObject**: Each market has one assignment result object
 - **One-to-One with SourceData**: Each market can have one source data CSV (stored separately in MongoDB)
@@ -587,11 +587,12 @@ SourceData (CSV)
 
 1. **User** creates a new **Market** via API
 2. **Market** must have `roles` dict with exactly one OWNER role
-3. **Market** is stored in MongoDB `markets` collection (identified by `id` UUID)
-4. If market belongs to organization, it's added to `Organization.markets` list
-5. **SourceData** CSV is uploaded separately and stored in `source_data` collection (via `market_id`)
-6. **SetupObject** is configured within the Market
-7. **AssignmentObject** is initialized empty
+3. **Market** must carry an `organizationId`; the API rejects a missing organization id, an organization that does not exist, or an organization the requesting user is not a member of (400). The front-end enforces the same rule up front: the new-market overlay requires an organization to be picked from a dropdown before submission is enabled, and users with no organizations are linked to `/organizations` to create one.
+4. **Market** is stored in MongoDB `markets` collection (identified by `id` UUID)
+5. Market is added to its `Organization.markets` list
+6. **SourceData** CSV is uploaded separately and stored in `source_data` collection (via `market_id`)
+7. **SetupObject** is configured within the Market
+8. **AssignmentObject** is initialized empty
 
 ### Assignment Generation Flow
 
@@ -638,7 +639,7 @@ SourceData (CSV)
 2. Owner can add **Admins** (who can manage Members)
 3. Owner and Admins can add **Members**
 4. All organization users (Owner/Admin/Member) get View permission on organization markets
-5. Markets can be assigned to organization via `Market.organization` field
+5. Markets are assigned to the organization via `Market.organization_id`, chosen when the market is created (an organization is required, so a user with no organization must create one here first)
 6. Organization theme applies to all organization markets
 
 ---
@@ -665,7 +666,7 @@ SourceData (CSV)
 - `SetupObject` is optional (market can exist without configuration)
 - `AssignmentStatistics` is optional (assignment may not have statistics yet)
 - `SectionObject.location` and `tier` are optional (sections can exist independently)
-- `Market.organization_id` is optional (markets can be standalone)
+- `Market.organization_id` is `Optional` in the model but required by `POST /markets`: new markets always belong to an organization, and the optional typing only keeps pre-existing org-less markets readable
 - `Market.theme` and `Organization.theme` are optional
 
 ### 5. Permission Resolution

--- a/docs/STARTUP.md
+++ b/docs/STARTUP.md
@@ -194,7 +194,7 @@ The frontend will start on: **[http://localhost:5173](http://localhost:5173)** (
 ## Step 6: Testing the Application
 
 > **Automated test suites and a one-command seed fixture are documented in [TESTING.md](./TESTING.md).**
-> For a ready-to-use test environment (Docker stack + test user + seeded market + sample CSV), run `./scripts/seed_fixture.sh` from the repository root.
+> For a ready-to-use test environment (Docker stack + test users + test organization + seeded market + sample CSV), run `./scripts/seed_fixture.sh` from the repository root.
 
 ### Create a Test User
 
@@ -214,20 +214,21 @@ curl -k -X POST https://127.0.0.1:5000/register-user \
 ### Basic Workflow Test
 
 1. **Login**: Use the credentials you just created
-2. **Create Market**: Click "New Market" and fill in the market details
-3. **Upload CSV**: Upload a vendor CSV file with columns like:
+2. **Create Organization**: Open "Organizations" and create one. Every market belongs to an organization, so a brand-new user must do this before they can create a market. The new-market form links here when you have no organizations.
+3. **Create Market**: Click "New Market", select the organization, and fill in the market details. Submission stays disabled until an organization is selected.
+4. **Upload CSV**: Upload a vendor CSV file with columns like:
   - Email
   - Vendor name
   - Market date preferences
   - Table preferences
   - Other vendor attributes
-4. **Configure Market Setup**:
+5. **Configure Market Setup**:
   - Select columns to include
   - Set up market dates
   - Configure tiers, locations, and sections
   - Set assignment priorities
-5. **Generate Assignment**: Click "Assign" to run the assignment algorithm
-6. **View Results**: Review the assignment statistics and vendor assignments
+6. **Generate Assignment**: Click "Assign" to run the assignment algorithm
+7. **View Results**: Review the assignment statistics and vendor assignments
 
 ### Discord Webhook Setup
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -8,13 +8,21 @@ The fastest way to get a working test environment:
 ./scripts/seed_fixture.sh
 ```
 
-This brings up the Docker stack, creates a test user, creates a market, and uploads a sample CSV.
+This brings up the Docker stack, creates the test users, creates an organization
+(`Seed Test Org`, reused if the user already has one), creates a market in it, and
+uploads a sample CSV.
 The output prints the credentials and market ID.
+
+Two verified users are created: the main test user, and a second user that
+deliberately belongs to no organization (`e2e-noorg@example.com`) so the e2e suite can
+exercise the zero-organization state of the market-creation org picker.
 
 Override credentials:
 
 ```bash
-TEST_EMAIL=myuser@example.com TEST_PASSWORD=mypass ./scripts/seed_fixture.sh
+TEST_EMAIL=myuser@example.com TEST_PASSWORD=mypass \
+  NO_ORG_EMAIL=mynoorguser@example.com NO_ORG_PASSWORD=mynoorgpass \
+  ./scripts/seed_fixture.sh
 ```
 
 ## Back-End Tests
@@ -68,7 +76,13 @@ assignment CSV export (download and verify columns), and publishing a market
 (verify the check-in URL is reachable). Tier-3 authentication and robustness
 journeys (`auth.spec.ts`) cover new-user registration, the full password reset
 flow (including reading the real reset token from MongoDB), posting an assignment
-to Discord, and login/OTP error states. The floorplan suite
+to Discord, and login/OTP error states. The organization-required suite
+(`new-market-org.spec.ts`) covers the rule that every market must be created in an
+organization: it asserts the new-market overlay's org dropdown lists exactly the
+organizations from `GET /organizations`, that submission stays disabled until one is
+picked, that the created market is stamped with the chosen `organizationId`, and that
+a user belonging to no organization gets a disabled dropdown plus a link to
+`/organizations`. The floorplan suite
 (`floorplan.spec.ts`) drives the create-from-floorplan setup path end to end:
 it walks the Floorplan AI 5-step wizard (upload, scale calibration, table
 placement, section grouping, save) and verifies the resulting sections land
@@ -77,8 +91,9 @@ back in the setup wizard.
 Configuration: `front-end/playwright.config.ts` (auto-detects the worktree
 frontend port via `detectFrontendPort()`).
 
-**Prerequisite**: Docker stack running with seeded test user.
-Email: `e2e@example.com` (default, change via `TEST_EMAIL` env var when seeding).
+**Prerequisite**: Docker stack running with seeded test users.
+Email: `e2e@example.com` (default, change via `TEST_EMAIL` env var when seeding),
+plus the organization-less user `e2e-noorg@example.com` (change via `NO_ORG_EMAIL`).
 
 ### E2E Foundation
 
@@ -100,8 +115,18 @@ The suite is built on a Page Object Model plus a fixture layer under `front-end/
 - **API-level seeding** (`front-end/e2e/helpers/seeds.ts`): all helpers use
   Playwright's `APIRequestContext` (cookies flow automatically) and require a
   verified test user created by `scripts/seed_fixture.sh`.
-  - `seedMarketWithVendors()` logs in, creates a market, and uploads a vendor
-    CSV via the back-end API.
+  - `loginViaApi()` logs in so the request context carries a Flask session cookie
+    and returns the user UUID.
+  - `ensureTestOrgAuthenticated()` returns the test user's first organization,
+    creating `E2E Test Org` if they have none. Use it when the request context has
+    already logged in; `ensureTestOrg()` wraps it with a login for contexts that have
+    not. Every market-creating helper and spec needs one of these, because
+    `POST /markets` rejects a payload without a valid `organizationId`. Specs that
+    create a market through the UI call it in `beforeAll` so the org dropdown is not
+    empty.
+  - `seedMarketWithVendors()` logs in, ensures an organization, creates a market in
+    it, and uploads a vendor CSV via the back-end API. The organization id is
+    returned as `orgId` on the seed result.
   - `seedPublishedMarketWithAssignments()` additionally configures the market's
     `setup_object` (column mapping, dates, sections, tiers, locations), publishes
     it (`isDraft: false`), then fetches the computed assignment via

--- a/front-end/e2e/floorplan.spec.ts
+++ b/front-end/e2e/floorplan.spec.ts
@@ -9,7 +9,7 @@ const CSV_PATH = path.resolve(__dirname, 'fixtures', 'test-vendors.csv')
 
 test.describe('Floorplan workflow E2E', () => {
   test.beforeAll(async ({ request }) => {
-    await ensureTestOrg(request, BACKEND_URL, TEST_USER.email)
+    await ensureTestOrg(request, BACKEND_URL, TEST_USER.email, TEST_USER.password)
   })
 
   test('create market from floorplan, complete wizard, and verify save', async ({

--- a/front-end/e2e/floorplan.spec.ts
+++ b/front-end/e2e/floorplan.spec.ts
@@ -1,12 +1,17 @@
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { test, expect, MarketSetupPage, NewMarketPage, FloorplanWorkflowPage } from './fixtures'
+import { test, expect, MarketSetupPage, NewMarketPage, FloorplanWorkflowPage, BACKEND_URL, TEST_USER } from './fixtures'
+import { ensureTestOrg } from './helpers/seeds'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const FLOORPLAN_PATH = path.resolve(__dirname, 'fixtures', 'test-floorplan.png')
 const CSV_PATH = path.resolve(__dirname, 'fixtures', 'test-vendors.csv')
 
 test.describe('Floorplan workflow E2E', () => {
+  test.beforeAll(async ({ request }) => {
+    await ensureTestOrg(request, BACKEND_URL, TEST_USER.email)
+  })
+
   test('create market from floorplan, complete wizard, and verify save', async ({
     authenticatedPage: page,
   }) => {
@@ -18,6 +23,7 @@ test.describe('Floorplan workflow E2E', () => {
     await newMarketPage.waitForOverlay()
     await newMarketPage.uploadCsv(CSV_PATH)
     await newMarketPage.waitForNameInput()
+    await newMarketPage.selectFirstOrg()
     await newMarketPage.fillMarketName(marketName)
     await newMarketPage.clickSubmit()
     await newMarketPage.waitForSetupRedirect()

--- a/front-end/e2e/helpers/seedAssignedMarket.ts
+++ b/front-end/e2e/helpers/seedAssignedMarket.ts
@@ -61,6 +61,7 @@ export async function seedAssignedMarket(
       id: seed.marketId,
       name: seed.marketName,
       creationDate: new Date().toISOString(),
+      organizationId: seed.orgId,
       roles: { [seed.userId]: 'owner' },
       modificationList: [],
       assignmentObject: {},

--- a/front-end/e2e/helpers/seeds.ts
+++ b/front-end/e2e/helpers/seeds.ts
@@ -57,28 +57,27 @@ export async function loginViaApi(
 
 /**
  * Helper: ensure the test user has at least one organization.
- * Logs in first, since the /organizations endpoints are login-protected and
- * the caller may pass a request context that has never authenticated.
+ * Assumes the request context already carries a Flask session cookie
+ * (the /organizations endpoints are login-protected).
  * Creates an organization named 'E2E Test Org' if none exist.
  * Returns the organization ID.
  */
-export async function ensureTestOrg(
+export async function ensureTestOrgAuthenticated(
   request: APIRequestContext,
   baseURL: string,
   email: string,
-  password: string,
 ): Promise<string> {
-  await loginViaApi(request, baseURL, email, password);
-
   const orgsRes = await request.get(`${baseURL}/organizations`, {
     headers: { 'X-Owner-Email': email },
   });
-  if (orgsRes.ok()) {
-    const body = await orgsRes.json() as { organizations: { id: string }[] };
-    if (body.organizations && body.organizations.length > 0) {
-      return body.organizations[0].id;
-    }
+  if (!orgsRes.ok()) {
+    throw new Error(`Organization list failed: ${orgsRes.status()} ${await orgsRes.text()}`);
   }
+  const body = await orgsRes.json() as { organizations: { id: string }[] };
+  if (body.organizations && body.organizations.length > 0) {
+    return body.organizations[0].id;
+  }
+
   const createRes = await request.post(`${baseURL}/organizations`, {
     headers: {
       'Content-Type': 'application/json',
@@ -91,6 +90,21 @@ export async function ensureTestOrg(
   }
   const createBody = await createRes.json() as { organization_id: string };
   return createBody.organization_id;
+}
+
+/**
+ * Helper: log in and ensure the test user has at least one organization.
+ * Use this from call sites whose request context has never authenticated.
+ * Returns the organization ID.
+ */
+export async function ensureTestOrg(
+  request: APIRequestContext,
+  baseURL: string,
+  email: string,
+  password: string,
+): Promise<string> {
+  await loginViaApi(request, baseURL, email, password);
+  return ensureTestOrgAuthenticated(request, baseURL, email);
 }
 
 /**
@@ -117,7 +131,7 @@ export async function seedMarketWithVendors(
   // Step 1: Login to get a session cookie and the user UUID
   const userId = await loginViaApi(request, baseURL, email, password);
 
-  const orgId = await ensureTestOrg(request, baseURL, email, password);
+  const orgId = await ensureTestOrgAuthenticated(request, baseURL, email);
 
   // Step 2: Create a market (user must own it)
   const marketName = `E2E Market ${Date.now()}`;
@@ -189,7 +203,7 @@ export async function seedPublishedMarketWithAssignments(
   // Step 1: Login
   const userId = await loginViaApi(request, baseURL, email, password);
 
-  const orgId = await ensureTestOrg(request, baseURL, email, password);
+  const orgId = await ensureTestOrgAuthenticated(request, baseURL, email);
 
   // Step 2: Create a market
   const marketName = `E2E Published ${Date.now()}`;

--- a/front-end/e2e/helpers/seeds.ts
+++ b/front-end/e2e/helpers/seeds.ts
@@ -33,15 +33,43 @@ function marketNameToSlug(name: string): string {
 }
 
 /**
+ * Log in via the API so the request context carries a Flask session cookie.
+ * Returns the user UUID.
+ */
+export async function loginViaApi(
+  request: APIRequestContext,
+  baseURL: string,
+  email: string,
+  password: string,
+): Promise<string> {
+  const loginRes = await request.post(`${baseURL}/login`, {
+    data: { email, password },
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!loginRes.ok()) {
+    throw new Error(`Login failed: ${loginRes.status()} ${await loginRes.text()}`);
+  }
+  const loginBody = await loginRes.json() as {
+    user_data: { id: string; email: string };
+  };
+  return loginBody.user_data.id;
+}
+
+/**
  * Helper: ensure the test user has at least one organization.
- * Creates one named 'E2E Test Org' if none exist.
+ * Logs in first, since the /organizations endpoints are login-protected and
+ * the caller may pass a request context that has never authenticated.
+ * Creates an organization named 'E2E Test Org' if none exist.
  * Returns the organization ID.
  */
 export async function ensureTestOrg(
   request: APIRequestContext,
   baseURL: string,
   email: string,
+  password: string,
 ): Promise<string> {
+  await loginViaApi(request, baseURL, email, password);
+
   const orgsRes = await request.get(`${baseURL}/organizations`, {
     headers: { 'X-Owner-Email': email },
   });
@@ -87,19 +115,9 @@ export async function seedMarketWithVendors(
   password: string,
 ): Promise<SeedResult> {
   // Step 1: Login to get a session cookie and the user UUID
-  const loginRes = await request.post(`${baseURL}/login`, {
-    data: { email, password },
-    headers: { 'Content-Type': 'application/json' },
-  });
-  if (!loginRes.ok()) {
-    throw new Error(`Login failed: ${loginRes.status()} ${await loginRes.text()}`);
-  }
-  const loginBody = await loginRes.json() as {
-    user_data: { id: string; email: string };
-  };
-  const userId = loginBody.user_data.id;
+  const userId = await loginViaApi(request, baseURL, email, password);
 
-  const orgId = await ensureTestOrg(request, baseURL, email);
+  const orgId = await ensureTestOrg(request, baseURL, email, password);
 
   // Step 2: Create a market (user must own it)
   const marketName = `E2E Market ${Date.now()}`;
@@ -169,19 +187,9 @@ export async function seedPublishedMarketWithAssignments(
   password: string,
 ): Promise<PublishedSeedResult> {
   // Step 1: Login
-  const loginRes = await request.post(`${baseURL}/login`, {
-    data: { email, password },
-    headers: { 'Content-Type': 'application/json' },
-  });
-  if (!loginRes.ok()) {
-    throw new Error(`Login failed: ${loginRes.status()} ${await loginRes.text()}`);
-  }
-  const loginBody = await loginRes.json() as {
-    user_data: { id: string; email: string };
-  };
-  const userId = loginBody.user_data.id;
+  const userId = await loginViaApi(request, baseURL, email, password);
 
-  const orgId = await ensureTestOrg(request, baseURL, email);
+  const orgId = await ensureTestOrg(request, baseURL, email, password);
 
   // Step 2: Create a market
   const marketName = `E2E Published ${Date.now()}`;
@@ -316,5 +324,5 @@ export async function seedPublishedMarketWithAssignments(
     throw new Error(`Assignment store failed: ${storeRes.status()} ${await storeRes.text()}`);
   }
 
-  return { marketId, userId, marketName, marketSlug };
+  return { marketId, userId, marketName, orgId, marketSlug };
 }

--- a/front-end/e2e/helpers/seeds.ts
+++ b/front-end/e2e/helpers/seeds.ts
@@ -7,6 +7,7 @@ export interface SeedResult {
   marketId: string;
   userId: string;
   marketName: string;
+  orgId: string;
 }
 
 /**
@@ -29,6 +30,39 @@ function marketNameToSlug(name: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '');
+}
+
+/**
+ * Helper: ensure the test user has at least one organization.
+ * Creates one named 'E2E Test Org' if none exist.
+ * Returns the organization ID.
+ */
+export async function ensureTestOrg(
+  request: APIRequestContext,
+  baseURL: string,
+  email: string,
+): Promise<string> {
+  const orgsRes = await request.get(`${baseURL}/organizations`, {
+    headers: { 'X-Owner-Email': email },
+  });
+  if (orgsRes.ok()) {
+    const body = await orgsRes.json() as { organizations: { id: string }[] };
+    if (body.organizations && body.organizations.length > 0) {
+      return body.organizations[0].id;
+    }
+  }
+  const createRes = await request.post(`${baseURL}/organizations`, {
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Owner-Email': email,
+    },
+    data: { name: 'E2E Test Org' },
+  });
+  if (!createRes.ok()) {
+    throw new Error(`Test org creation failed: ${createRes.status()} ${await createRes.text()}`);
+  }
+  const createBody = await createRes.json() as { organization_id: string };
+  return createBody.organization_id;
 }
 
 /**
@@ -65,6 +99,8 @@ export async function seedMarketWithVendors(
   };
   const userId = loginBody.user_data.id;
 
+  const orgId = await ensureTestOrg(request, baseURL, email);
+
   // Step 2: Create a market (user must own it)
   const marketName = `E2E Market ${Date.now()}`;
   const createRes = await request.post(`${baseURL}/markets`, {
@@ -75,6 +111,7 @@ export async function seedMarketWithVendors(
     data: {
       name: marketName,
       creationDate: new Date().toISOString(),
+      organizationId: orgId,
       roles: { [userId]: 'owner' },
       modificationList: [],
       assignmentObject: {},
@@ -108,7 +145,7 @@ export async function seedMarketWithVendors(
     throw new Error(`CSV upload failed: ${uploadRes.status()} ${await uploadRes.text()}`);
   }
 
-  return { marketId, userId, marketName };
+  return { marketId, userId, marketName, orgId };
 }
 
 /**
@@ -144,6 +181,8 @@ export async function seedPublishedMarketWithAssignments(
   };
   const userId = loginBody.user_data.id;
 
+  const orgId = await ensureTestOrg(request, baseURL, email);
+
   // Step 2: Create a market
   const marketName = `E2E Published ${Date.now()}`;
   const createRes = await request.post(`${baseURL}/markets`, {
@@ -154,6 +193,7 @@ export async function seedPublishedMarketWithAssignments(
     data: {
       name: marketName,
       creationDate: new Date().toISOString(),
+      organizationId: orgId,
       roles: { [userId]: 'owner' },
       modificationList: [],
       assignmentObject: {},

--- a/front-end/e2e/market-pipeline.spec.ts
+++ b/front-end/e2e/market-pipeline.spec.ts
@@ -1,11 +1,16 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { test, expect, MarketSetupPage, AssignmentResultsPage, NewMarketPage } from './fixtures';
+import { test, expect, MarketSetupPage, AssignmentResultsPage, NewMarketPage, BACKEND_URL, TEST_USER } from './fixtures';
+import { ensureTestOrg } from './helpers/seeds';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CSV_PATH = path.resolve(__dirname, 'fixtures', 'test-vendors.csv');
 
 test.describe('Market pipeline E2E', () => {
+  test.beforeAll(async ({ request }) => {
+    await ensureTestOrg(request, BACKEND_URL, TEST_USER.email);
+  });
+
   /**
    * Full end-to-end pipeline: create market with CSV upload, walk the 3-page
    * setup wizard, trigger assignment generation, and verify the results view.
@@ -28,6 +33,7 @@ test.describe('Market pipeline E2E', () => {
 
     // After CSV parsing, the name input appears
     await newMarketPage.waitForNameInput();
+    await newMarketPage.selectFirstOrg();
     await newMarketPage.fillMarketName(marketName);
 
     // Submit to create the market

--- a/front-end/e2e/market-pipeline.spec.ts
+++ b/front-end/e2e/market-pipeline.spec.ts
@@ -8,7 +8,7 @@ const CSV_PATH = path.resolve(__dirname, 'fixtures', 'test-vendors.csv');
 
 test.describe('Market pipeline E2E', () => {
   test.beforeAll(async ({ request }) => {
-    await ensureTestOrg(request, BACKEND_URL, TEST_USER.email);
+    await ensureTestOrg(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);
   });
 
   /**

--- a/front-end/e2e/new-market-org.spec.ts
+++ b/front-end/e2e/new-market-org.spec.ts
@@ -1,0 +1,103 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { test, expect, LoginPage, NewMarketPage, BACKEND_URL, TEST_USER } from './fixtures';
+import { ensureTestOrg, loginViaApi } from './helpers/seeds';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CSV_PATH = path.resolve(__dirname, 'fixtures', 'test-vendors.csv');
+
+/**
+ * Verified user that deliberately belongs to no organization.
+ * Created by scripts/seed_fixture.sh alongside TEST_USER.
+ */
+const NO_ORG_USER = {
+  email: 'e2e-noorg@example.com',
+  password: 'e2enoorg123',
+};
+
+/**
+ * D14: every market requires an organization at creation. An org-less market is
+ * not a valid state, so the overlay must block submission until one is picked,
+ * and a user with no organizations must be routed to create one first.
+ */
+test.describe('New market - organization is required', () => {
+  test.beforeAll(async ({ request }) => {
+    await ensureTestOrg(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);
+  });
+
+  test('org picker gates submission and the created market carries the org', async ({
+    authenticatedPage: page,
+    request,
+  }, testInfo) => {
+    await loginViaApi(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);
+    const orgsRes = await request.get(`${BACKEND_URL}/organizations`, {
+      headers: { 'X-Owner-Email': TEST_USER.email },
+    });
+    expect(orgsRes.ok()).toBe(true);
+    const orgs = (await orgsRes.json()).organizations as { id: string; name: string }[];
+    expect(orgs.length).toBeGreaterThan(0);
+
+    const newMarketPage = new NewMarketPage(page);
+    const marketName = `Org Required E2E ${Date.now()}`;
+
+    await page.goto('/markets');
+    await page.getByTestId('markets-create-button').click();
+    await newMarketPage.waitForOverlay();
+    await newMarketPage.uploadCsv(CSV_PATH);
+    await newMarketPage.waitForNameInput();
+
+    // The dropdown offers exactly the organizations GET /organizations returns.
+    expect((await newMarketPage.orgOptionLabels()).sort()).toEqual(orgs.map((o) => o.name).sort());
+
+    // Nothing selected yet, so the market cannot be created.
+    await expect(newMarketPage.orgSelect).toHaveValue('');
+    await expect(newMarketPage.submitButton).toBeDisabled();
+    await newMarketPage.fillMarketName(marketName);
+    await expect(newMarketPage.submitButton).toBeDisabled();
+    await page.screenshot({ path: testInfo.outputPath('01-submit-blocked-no-org.png') });
+
+    // Picking an organization unlocks submission.
+    await newMarketPage.selectFirstOrg();
+    await expect(newMarketPage.submitButton).toBeEnabled();
+    await page.screenshot({ path: testInfo.outputPath('02-org-selected-submit-enabled.png') });
+
+    const selectedOrgId = await newMarketPage.orgSelect.inputValue();
+    expect(orgs.map((o) => o.id)).toContain(selectedOrgId);
+
+    await newMarketPage.clickSubmit();
+    await newMarketPage.waitForSetupRedirect();
+
+    // The persisted market is stamped with the organization that was chosen.
+    const marketsRes = await request.get(`${BACKEND_URL}/markets`, {
+      headers: { 'X-Owner-Email': TEST_USER.email },
+    });
+    expect(marketsRes.ok()).toBe(true);
+    const markets = (await marketsRes.json()).markets as { name: string; organizationId?: string }[];
+    const created = markets.find((m) => m.name === marketName);
+    expect(created).toBeTruthy();
+    expect(created?.organizationId).toBe(selectedOrgId);
+  });
+
+  test('a user with no organizations is pointed at organization creation', async ({
+    page,
+  }, testInfo) => {
+    const loginPage = new LoginPage(page);
+    await loginPage.login(NO_ORG_USER.email, NO_ORG_USER.password);
+    await loginPage.waitForDashboardRedirect();
+
+    const newMarketPage = new NewMarketPage(page);
+    await page.goto('/markets');
+    await page.getByTestId('markets-create-button').click();
+    await newMarketPage.waitForOverlay();
+    await newMarketPage.uploadCsv(CSV_PATH);
+    await newMarketPage.waitForNameInput();
+
+    await expect(newMarketPage.orgEmptyHint).toBeVisible();
+    await expect(newMarketPage.orgSelect).toBeDisabled();
+    await expect(newMarketPage.submitButton).toBeDisabled();
+    await page.screenshot({ path: testInfo.outputPath('03-zero-org-fallback.png') });
+
+    await newMarketPage.orgCreateLink.click();
+    await expect(page).toHaveURL(/\/organizations/);
+  });
+});

--- a/front-end/e2e/pages/NewMarketPage.ts
+++ b/front-end/e2e/pages/NewMarketPage.ts
@@ -9,6 +9,7 @@ export class NewMarketPage {
 
   readonly overlayBackground: Locator;
   readonly chooseFileButton: Locator;
+  readonly orgSelect: Locator;
   readonly nameInput: Locator;
   readonly submitButton: Locator;
 
@@ -17,6 +18,7 @@ export class NewMarketPage {
 
     this.overlayBackground = page.getByTestId('new-market-overlay-background');
     this.chooseFileButton = page.getByTestId('file-drop-choose-button');
+    this.orgSelect = page.getByTestId('org-select-dropdown');
     this.nameInput = page.getByTestId('new-market-name-input');
     this.submitButton = page.getByTestId('new-market-submit-button');
   }
@@ -51,6 +53,12 @@ export class NewMarketPage {
   /** Wait for the name input to appear (indicating CSV was parsed). */
   async waitForNameInput(): Promise<void> {
     await this.nameInput.waitFor({ state: 'visible', timeout: 10000 });
+  }
+
+  /** Select an organization from the dropdown (first available option). */
+  async selectFirstOrg(): Promise<void> {
+    await this.orgSelect.waitFor({ state: 'visible', timeout: 5000 });
+    await this.orgSelect.selectOption({ index: 1 });
   }
 
   /** Wait for navigation to the market setup wizard after submission. */

--- a/front-end/e2e/pages/NewMarketPage.ts
+++ b/front-end/e2e/pages/NewMarketPage.ts
@@ -10,8 +10,11 @@ export class NewMarketPage {
   readonly overlayBackground: Locator;
   readonly chooseFileButton: Locator;
   readonly orgSelect: Locator;
+  readonly orgEmptyHint: Locator;
+  readonly orgCreateLink: Locator;
   readonly nameInput: Locator;
   readonly submitButton: Locator;
+  readonly errorMessage: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -19,8 +22,11 @@ export class NewMarketPage {
     this.overlayBackground = page.getByTestId('new-market-overlay-background');
     this.chooseFileButton = page.getByTestId('file-drop-choose-button');
     this.orgSelect = page.getByTestId('org-select-dropdown');
+    this.orgEmptyHint = page.getByTestId('org-select-empty-hint');
+    this.orgCreateLink = page.getByTestId('org-select-create-link');
     this.nameInput = page.getByTestId('new-market-name-input');
     this.submitButton = page.getByTestId('new-market-submit-button');
+    this.errorMessage = page.locator('.error-message');
   }
 
   /** Wait for the overlay to be visible. */
@@ -59,6 +65,13 @@ export class NewMarketPage {
   async selectFirstOrg(): Promise<void> {
     await this.orgSelect.waitFor({ state: 'visible', timeout: 5000 });
     await this.orgSelect.selectOption({ index: 1 });
+  }
+
+  /** Names of the organizations offered by the dropdown, excluding the placeholder. */
+  async orgOptionLabels(): Promise<string[]> {
+    await this.orgSelect.waitFor({ state: 'visible', timeout: 5000 });
+    const labels = await this.orgSelect.locator('option:not([disabled])').allTextContents();
+    return labels.map((label) => label.trim());
   }
 
   /** Wait for navigation to the market setup wizard after submission. */

--- a/front-end/e2e/tier2.spec.ts
+++ b/front-end/e2e/tier2.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, TEST_USER, OrganizationsPage, ManageMarketPage, BACKEND_URL } from './fixtures';
 import { seedAssignedMarket } from './helpers/seedAssignedMarket';
-import { ensureTestOrg } from './helpers/seeds';
+import { ensureTestOrgAuthenticated } from './helpers/seeds';
 
 const SECOND_USER = {
   email: 'e2e-second@example.com',
@@ -95,7 +95,7 @@ test.describe('Tier 2 - Market role management', () => {
     const loginBody = await loginRes.json() as { user_data: { id: string } };
     const userId = loginBody.user_data.id;
 
-    const orgId = await ensureTestOrg(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);
+    const orgId = await ensureTestOrgAuthenticated(request, BACKEND_URL, TEST_USER.email);
 
     marketName = `E2E Market Roles ${Date.now()}`;
     const marketRes = await request.post(`${BACKEND_URL}/markets`, {

--- a/front-end/e2e/tier2.spec.ts
+++ b/front-end/e2e/tier2.spec.ts
@@ -95,7 +95,7 @@ test.describe('Tier 2 - Market role management', () => {
     const loginBody = await loginRes.json() as { user_data: { id: string } };
     const userId = loginBody.user_data.id;
 
-    const orgId = await ensureTestOrg(request, BACKEND_URL, TEST_USER.email);
+    const orgId = await ensureTestOrg(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);
 
     marketName = `E2E Market Roles ${Date.now()}`;
     const marketRes = await request.post(`${BACKEND_URL}/markets`, {

--- a/front-end/e2e/tier2.spec.ts
+++ b/front-end/e2e/tier2.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, TEST_USER, OrganizationsPage, ManageMarketPage, BACKEND_URL } from './fixtures';
 import { seedAssignedMarket } from './helpers/seedAssignedMarket';
+import { ensureTestOrg } from './helpers/seeds';
 
 const SECOND_USER = {
   email: 'e2e-second@example.com',
@@ -94,12 +95,15 @@ test.describe('Tier 2 - Market role management', () => {
     const loginBody = await loginRes.json() as { user_data: { id: string } };
     const userId = loginBody.user_data.id;
 
+    const orgId = await ensureTestOrg(request, BACKEND_URL, TEST_USER.email);
+
     marketName = `E2E Market Roles ${Date.now()}`;
     const marketRes = await request.post(`${BACKEND_URL}/markets`, {
       headers: { 'Content-Type': 'application/json', 'X-Owner-Email': TEST_USER.email },
       data: {
         name: marketName,
         creationDate: new Date().toISOString(),
+        organizationId: orgId,
         roles: { [userId]: 'owner' },
         modificationList: [],
         assignmentObject: {},

--- a/front-end/src/components/elements/ElementOrgSelect.vue
+++ b/front-end/src/components/elements/ElementOrgSelect.vue
@@ -48,9 +48,9 @@ onMounted(() => {
         </select>
         <p v-if="loading" class="org-select-hint">Loading organizations...</p>
         <p v-else-if="errorMessage" class="org-select-error">{{ errorMessage }}</p>
-        <p v-else-if="organizations.length === 0" class="org-select-hint">
+        <p v-else-if="organizations.length === 0" class="org-select-hint" data-testid="org-select-empty-hint">
             No organizations available.
-            <RouterLink to="/organizations" class="org-select-link">Create an organization</RouterLink>
+            <RouterLink to="/organizations" class="org-select-link" data-testid="org-select-create-link">Create an organization</RouterLink>
         </p>
     </div>
 </template>
@@ -84,17 +84,20 @@ onMounted(() => {
     font-size: 12px;
     color: #666;
     margin: 0;
+    text-align: center;
 }
 
 .org-select-error {
     font-size: 12px;
     color: #d32f2f;
     margin: 0;
+    text-align: center;
 }
 
 .org-select-link {
     color: var(--mm-black);
     text-decoration: underline;
     font-weight: 600;
+    white-space: nowrap;
 }
 </style>

--- a/front-end/src/components/elements/ElementOrgSelect.vue
+++ b/front-end/src/components/elements/ElementOrgSelect.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import {
+    type Organization,
+    type OrganizationRoleType,
+    type ThemeObject,
+} from '@/assets/types/datatypes';
+import { api, getApiErrorMessage } from '@/utils/api';
+
+type RawOrganization = {
+    id: string;
+    name: string;
+    owner: string;
+    admins?: string[];
+    members?: string[];
+    markets?: string[];
+    ownerEmail?: string;
+    owner_email?: string;
+    adminEmails?: string[];
+    admin_emails?: string[];
+    memberEmails?: string[];
+    member_emails?: string[];
+    theme?: ThemeObject;
+    userRole?: OrganizationRoleType;
+    user_role?: OrganizationRoleType;
+};
+
+const model = defineModel<string>({ required: true });
+
+const organizations = ref<Organization[]>([]);
+const loading = ref(true);
+const errorMessage = ref('');
+
+function parseOrgFromApi(org: RawOrganization): Organization {
+    const userRole = org.userRole ?? org.user_role;
+    return {
+        id: org.id,
+        name: org.name,
+        owner: org.owner,
+        admins: org.admins || [],
+        members: org.members || [],
+        markets: org.markets || [],
+        ownerEmail: org.ownerEmail ?? org.owner_email,
+        adminEmails: org.adminEmails ?? org.admin_emails,
+        memberEmails: org.memberEmails ?? org.member_emails,
+        theme: org.theme,
+        userRole: userRole ?? undefined,
+    };
+}
+
+async function fetchOrganizations() {
+    loading.value = true;
+    errorMessage.value = '';
+    try {
+        const response = await api.get('/organizations');
+        organizations.value = (response.data.organizations || []).map(parseOrgFromApi);
+    } catch (err) {
+        errorMessage.value = getApiErrorMessage(err, 'Failed to load organizations');
+        organizations.value = [];
+    } finally {
+        loading.value = false;
+    }
+}
+
+onMounted(() => {
+    fetchOrganizations();
+});
+</script>
+
+<template>
+    <div class="org-select-wrapper">
+        <select
+            v-model="model"
+            class="org-select"
+            :disabled="loading || organizations.length === 0"
+            data-testid="org-select-dropdown"
+        >
+            <option value="" disabled>Select organization</option>
+            <option
+                v-for="org in organizations"
+                :key="org.id"
+                :value="org.id"
+            >
+                {{ org.name }}
+            </option>
+        </select>
+        <p v-if="loading" class="org-select-hint">Loading organizations...</p>
+        <p v-else-if="errorMessage" class="org-select-error">{{ errorMessage }}</p>
+        <p v-else-if="organizations.length === 0" class="org-select-hint">
+            No organizations available.
+            <a href="/organizations" class="org-select-link">Create an organization</a>
+        </p>
+    </div>
+</template>
+
+<style scoped>
+.org-select-wrapper {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+}
+
+.org-select {
+    width: 100%;
+    padding: 8px 12px;
+    border: 1.5px solid var(--mm-grey);
+    border-radius: 6px;
+    font-size: 14px;
+    font-family: 'Outfit Regular', sans-serif;
+    background: white;
+    text-align: center;
+}
+
+.org-select:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.org-select-hint {
+    font-size: 12px;
+    color: #666;
+    margin: 0;
+}
+
+.org-select-error {
+    font-size: 12px;
+    color: #d32f2f;
+    margin: 0;
+}
+
+.org-select-link {
+    color: var(--mm-black);
+    text-decoration: underline;
+    font-weight: 600;
+}
+</style>

--- a/front-end/src/components/elements/ElementOrgSelect.vue
+++ b/front-end/src/components/elements/ElementOrgSelect.vue
@@ -1,29 +1,9 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
-import {
-    type Organization,
-    type OrganizationRoleType,
-    type ThemeObject,
-} from '@/assets/types/datatypes';
-import { api, getApiErrorMessage } from '@/utils/api';
-
-type RawOrganization = {
-    id: string;
-    name: string;
-    owner: string;
-    admins?: string[];
-    members?: string[];
-    markets?: string[];
-    ownerEmail?: string;
-    owner_email?: string;
-    adminEmails?: string[];
-    admin_emails?: string[];
-    memberEmails?: string[];
-    member_emails?: string[];
-    theme?: ThemeObject;
-    userRole?: OrganizationRoleType;
-    user_role?: OrganizationRoleType;
-};
+import { RouterLink } from 'vue-router';
+import { type Organization } from '@/assets/types/datatypes';
+import { getApiErrorMessage } from '@/utils/api';
+import { fetchOrganizations } from '@/utils/organizations';
 
 const model = defineModel<string>({ required: true });
 
@@ -31,29 +11,11 @@ const organizations = ref<Organization[]>([]);
 const loading = ref(true);
 const errorMessage = ref('');
 
-function parseOrgFromApi(org: RawOrganization): Organization {
-    const userRole = org.userRole ?? org.user_role;
-    return {
-        id: org.id,
-        name: org.name,
-        owner: org.owner,
-        admins: org.admins || [],
-        members: org.members || [],
-        markets: org.markets || [],
-        ownerEmail: org.ownerEmail ?? org.owner_email,
-        adminEmails: org.adminEmails ?? org.admin_emails,
-        memberEmails: org.memberEmails ?? org.member_emails,
-        theme: org.theme,
-        userRole: userRole ?? undefined,
-    };
-}
-
-async function fetchOrganizations() {
+async function loadOrganizations() {
     loading.value = true;
     errorMessage.value = '';
     try {
-        const response = await api.get('/organizations');
-        organizations.value = (response.data.organizations || []).map(parseOrgFromApi);
+        organizations.value = await fetchOrganizations();
     } catch (err) {
         errorMessage.value = getApiErrorMessage(err, 'Failed to load organizations');
         organizations.value = [];
@@ -63,7 +25,7 @@ async function fetchOrganizations() {
 }
 
 onMounted(() => {
-    fetchOrganizations();
+    loadOrganizations();
 });
 </script>
 
@@ -88,7 +50,7 @@ onMounted(() => {
         <p v-else-if="errorMessage" class="org-select-error">{{ errorMessage }}</p>
         <p v-else-if="organizations.length === 0" class="org-select-hint">
             No organizations available.
-            <a href="/organizations" class="org-select-link">Create an organization</a>
+            <RouterLink to="/organizations" class="org-select-link">Create an organization</RouterLink>
         </p>
     </div>
 </template>

--- a/front-end/src/utils/organizations.ts
+++ b/front-end/src/utils/organizations.ts
@@ -1,0 +1,46 @@
+import {
+    type Organization,
+    type OrganizationRoleType,
+    type ThemeObject,
+} from '@/assets/types/datatypes';
+import { api } from '@/utils/api';
+
+export type RawOrganization = {
+    id: string;
+    name: string;
+    owner: string;
+    admins?: string[];
+    members?: string[];
+    markets?: string[];
+    ownerEmail?: string;
+    owner_email?: string;
+    adminEmails?: string[];
+    admin_emails?: string[];
+    memberEmails?: string[];
+    member_emails?: string[];
+    theme?: ThemeObject;
+    userRole?: OrganizationRoleType;
+    user_role?: OrganizationRoleType;
+};
+
+export function parseOrgFromApi(org: RawOrganization): Organization {
+    const userRole = org.userRole ?? org.user_role;
+    return {
+        id: org.id,
+        name: org.name,
+        owner: org.owner,
+        admins: org.admins || [],
+        members: org.members || [],
+        markets: org.markets || [],
+        ownerEmail: org.ownerEmail ?? org.owner_email,
+        adminEmails: org.adminEmails ?? org.admin_emails,
+        memberEmails: org.memberEmails ?? org.member_emails,
+        theme: org.theme,
+        userRole: userRole ?? undefined,
+    };
+}
+
+export async function fetchOrganizations(): Promise<Organization[]> {
+    const response = await api.get('/organizations');
+    return (response.data.organizations || []).map(parseOrgFromApi);
+}

--- a/front-end/src/views/NewMarketOverlay.vue
+++ b/front-end/src/views/NewMarketOverlay.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import ElementFileDrop from '@/components/elements/ElementFileDrop.vue';
+import ElementOrgSelect from '@/components/elements/ElementOrgSelect.vue';
 import { ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { type Market, MarketRole } from '@/assets/types/datatypes.ts'
@@ -15,6 +16,7 @@ const uploadedFiles = ref<unknown>([]);
 const uploadedSourceData = ref<File[]>([]);
 const next = ref(false);
 const marketName = ref("");
+const selectedOrgId = ref("");
 const errorMessage = ref("");
 
 const handleFileUploaded = (files: unknown) => {
@@ -29,6 +31,11 @@ const handleSourceDataUploaded = (sourceData: File[]) => {
 const handleSubmit = async () => {
     errorMessage.value = ""; // Clear previous error
     
+    if (!selectedOrgId.value) {
+        errorMessage.value = "Organization is required";
+        return;
+    }
+    
     if (!marketName.value.trim()) {
         errorMessage.value = "Market name is required";
         return;
@@ -40,6 +47,7 @@ const handleSubmit = async () => {
             name: marketName.value,
             creationDate: new Date().toISOString(),
             isDraft: true,
+            organizationId: selectedOrgId.value,
             roles: {
                 [userEmail]: MarketRole.Owner
             },
@@ -96,24 +104,29 @@ const handleSubmit = async () => {
         <template v-else>
             <div class="window">
                 <h2>
-                    Enter market name
+                    Create new market
                 </h2>
+                <div class="org-select-container">
+                    <label class="org-select-label">Organization</label>
+                    <ElementOrgSelect v-model="selectedOrgId" />
+                </div>
                 <div class="input-wrapper">
                     <div style="width: 100%; height: 30px; display: grid; grid-template-columns: 1fr 3fr 1fr;">
                         <div></div>
                         <div class="text-input-container">
                             <input type="text" v-model="marketName" @keydown.enter="handleSubmit" @input="errorMessage = ''"
-                                style="all: unset; font-size: 14px; width: 100%; text-align: center;" data-testid="new-market-name-input" />
+                                style="all: unset; font-size: 14px; width: 100%; text-align: center;" placeholder="Market name" data-testid="new-market-name-input" />
                         </div>
                         <div style="padding-left: 10px">
-                            <button @click="handleSubmit"
-                                style="all: unset; height: 100%; width: 100%; cursor: pointer; opacity: 75%;" data-testid="new-market-submit-button">Submit</button>
+                            <button @click="handleSubmit" :disabled="!selectedOrgId"
+                                style="all: unset; height: 100%; width: 100%; cursor: pointer;"
+                                :style="{ opacity: selectedOrgId ? '75%' : '30%', cursor: selectedOrgId ? 'pointer' : 'not-allowed' }" data-testid="new-market-submit-button">Submit</button>
                         </div>
                     </div>
                     <p v-show="errorMessage" class="error-message">{{ errorMessage }}</p>
                 </div>
             </div>
-        </template>>
+        </template>
     </div>
 </template>
 
@@ -158,6 +171,22 @@ h3 {
     background: white;
     border-radius: 8px;
     z-index: 1;
+}
+
+.org-select-container {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+}
+
+.org-select-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: #666;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
 }
 
 .input-wrapper {

--- a/front-end/src/views/NewMarketOverlay.vue
+++ b/front-end/src/views/NewMarketOverlay.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import ElementFileDrop from '@/components/elements/ElementFileDrop.vue';
 import ElementOrgSelect from '@/components/elements/ElementOrgSelect.vue';
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { type Market, MarketRole } from '@/assets/types/datatypes.ts'
 import axios from 'axios';
@@ -18,6 +18,10 @@ const next = ref(false);
 const marketName = ref("");
 const selectedOrgId = ref("");
 const errorMessage = ref("");
+
+watch(selectedOrgId, () => {
+    errorMessage.value = "";
+});
 
 const handleFileUploaded = (files: unknown) => {
     uploadedFiles.value = files;

--- a/front-end/src/views/OrganizationsView.vue
+++ b/front-end/src/views/OrganizationsView.vue
@@ -1,30 +1,9 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
-import {
-    type Organization,
-    type OrganizationRoleType,
-    type ThemeObject,
-} from '@/assets/types/datatypes';
+import { type Organization } from '@/assets/types/datatypes';
 import { api, getApiErrorMessage } from '@/utils/api';
+import { fetchOrganizations } from '@/utils/organizations';
 import ManageOrgOverlay from './ManageOrgOverlay.vue';
-
-type RawOrganization = {
-    id: string;
-    name: string;
-    owner: string;
-    admins?: string[];
-    members?: string[];
-    markets?: string[];
-    ownerEmail?: string;
-    owner_email?: string;
-    adminEmails?: string[];
-    admin_emails?: string[];
-    memberEmails?: string[];
-    member_emails?: string[];
-    theme?: ThemeObject;
-    userRole?: OrganizationRoleType;
-    user_role?: OrganizationRoleType;
-};
 
 const organizations = ref<Organization[]>([]);
 const loading = ref(true);
@@ -35,29 +14,11 @@ const manageOrg = ref<Organization | null>(null);
 const newOrgName = ref('');
 const newOrgError = ref('');
 
-function parseOrgFromApi(org: RawOrganization): Organization {
-    const userRole = org.userRole ?? org.user_role;
-    return {
-        id: org.id,
-        name: org.name,
-        owner: org.owner,
-        admins: org.admins || [],
-        members: org.members || [],
-        markets: org.markets || [],
-        ownerEmail: org.ownerEmail ?? org.owner_email,
-        adminEmails: org.adminEmails ?? org.admin_emails,
-        memberEmails: org.memberEmails ?? org.member_emails,
-        theme: org.theme,
-        userRole: userRole ?? undefined,
-    };
-}
-
-async function fetchOrganizations() {
+async function loadOrganizations() {
     loading.value = true;
     errorMessage.value = '';
     try {
-        const response = await api.get('/organizations');
-        organizations.value = (response.data.organizations || []).map(parseOrgFromApi);
+        organizations.value = await fetchOrganizations();
     } catch (err) {
         errorMessage.value = getApiErrorMessage(err, 'Failed to load organizations');
         organizations.value = [];
@@ -67,7 +28,7 @@ async function fetchOrganizations() {
 }
 
 onMounted(() => {
-    fetchOrganizations();
+    loadOrganizations();
 });
 
 async function handleCreateOrg() {
@@ -77,7 +38,7 @@ async function handleCreateOrg() {
         await api.post('/organizations', { name: newOrgName.value.trim() });
         newOpen.value = false;
         newOrgName.value = '';
-        await fetchOrganizations();
+        await loadOrganizations();
     } catch (err) {
         newOrgError.value = getApiErrorMessage(err, 'Failed to create organization');
     }
@@ -97,7 +58,7 @@ function handleManage(org: Organization) {
 function handleManageClose() {
     manageOpen.value = false;
     manageOrg.value = null;
-    fetchOrganizations();
+    loadOrganizations();
 }
 
 function canManage(org: Organization): boolean {

--- a/scripts/seed_fixture.sh
+++ b/scripts/seed_fixture.sh
@@ -7,6 +7,10 @@ FIXTURES_DIR="$SCRIPT_DIR/fixtures"
 COOKIE_JAR="$(mktemp /tmp/conventioner_seed.XXXXXX)"
 TEST_EMAIL="${TEST_EMAIL:-e2e@example.com}"
 TEST_PASSWORD="${TEST_PASSWORD:-e2epassword123}"
+# Verified user deliberately left without any organization, so e2e can exercise
+# the zero-org state of the market-creation org picker.
+NO_ORG_EMAIL="${NO_ORG_EMAIL:-e2e-noorg@example.com}"
+NO_ORG_PASSWORD="${NO_ORG_PASSWORD:-e2enoorg123}"
 CSV_FILE="${FIXTURES_DIR}/vendors.csv"
 
 # ── Detect worktree vs primary checkout ──
@@ -35,7 +39,7 @@ echo "=== Conventioner Seed Fixture ==="
 echo ""
 
 # ── 1. Ensure Docker stack is running ──
-echo "[1/5] Ensuring Docker stack is up..."
+echo "[1/6] Ensuring Docker stack is up..."
 cd "$PROJECT_DIR"
 if ! "${DOCKER_CMD[@]}" ps --format '{{.Service}}' 2>/dev/null | grep -q 'backend'; then
   echo "  Bringing up Docker stack..."
@@ -54,13 +58,14 @@ for i in $(seq 1 30); do
   sleep 1
 done
 
-# ── 2. Create test user ──
-echo "[2/5] Creating test user ($TEST_EMAIL)..."
+# ── 2. Create test users ──
+echo "[2/6] Creating test users ($TEST_EMAIL, $NO_ORG_EMAIL)..."
 "${DOCKER_CMD[@]}" exec -T backend python /app/reset_database.py 2>&1 | sed 's/^/  /'
 "${DOCKER_CMD[@]}" exec -T backend python /app/create_test_user.py "$TEST_EMAIL" "$TEST_PASSWORD" 2>&1 | sed 's/^/  /'
+"${DOCKER_CMD[@]}" exec -T backend python /app/create_test_user.py "$NO_ORG_EMAIL" "$NO_ORG_PASSWORD" 2>&1 | sed 's/^/  /'
 
 # ── 3. Login and get session ──
-echo "[3/5] Logging in..."
+echo "[3/6] Logging in..."
 LOGIN_RESPONSE=$(curl -k -s -c "$COOKIE_JAR" \
   -X POST "$BACKEND_URL/login" \
   -H "Content-Type: application/json" \
@@ -142,6 +147,7 @@ echo "Frontend:  $FRONTEND_URL"
 echo "Backend:   $BACKEND_URL"
 echo "Email:     $TEST_EMAIL"
 echo "Password:  $TEST_PASSWORD"
+echo "No-org:    $NO_ORG_EMAIL / $NO_ORG_PASSWORD (verified, belongs to no organization)"
 echo "Market ID: $MARKET_ID"
 echo ""
 echo "Next: open $FRONTEND_URL/login and log in to configure the market."

--- a/scripts/seed_fixture.sh
+++ b/scripts/seed_fixture.sh
@@ -96,6 +96,11 @@ if [ "$ORG_COUNT" -eq 0 ]; then
 else
   echo "  User already has $ORG_COUNT organization(s), skipping creation."
   ORG_ID=$(echo "$ORG_CHECK" | python3 -c "import sys,json; print(json.load(sys.stdin)['organizations'][0]['id'])" 2>/dev/null || echo "")
+  if [ -z "$ORG_ID" ]; then
+    echo "  ERROR: Could not extract existing organization ID"
+    exit 1
+  fi
+  echo "  Organization ID: $ORG_ID"
 fi
 
 # ── 4. Create a market ──

--- a/scripts/seed_fixture.sh
+++ b/scripts/seed_fixture.sh
@@ -74,8 +74,32 @@ if [ -z "$USER_ID" ]; then
 fi
 echo "  User ID: $USER_ID"
 
+# ── 3b. Create test organization ──
+echo "[3b/6] Setting up test organization..."
+ORG_CHECK=$(curl -k -s -b "$COOKIE_JAR" \
+  -X GET "$BACKEND_URL/organizations" \
+  -H "X-Owner-Email: $TEST_EMAIL")
+ORG_COUNT=$(echo "$ORG_CHECK" | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('organizations', [])))" 2>/dev/null || echo "0")
+if [ "$ORG_COUNT" -eq 0 ]; then
+  ORG_RESPONSE=$(curl -k -s -b "$COOKIE_JAR" \
+    -X POST "$BACKEND_URL/organizations" \
+    -H "Content-Type: application/json" \
+    -H "X-Owner-Email: $TEST_EMAIL" \
+    -d "{\"name\": \"Seed Test Org\"}")
+  echo "  $ORG_RESPONSE"
+  ORG_ID=$(echo "$ORG_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['organization_id'])" 2>/dev/null || echo "")
+  if [ -z "$ORG_ID" ]; then
+    echo "  ERROR: Could not create test organization"
+    exit 1
+  fi
+  echo "  Organization ID: $ORG_ID"
+else
+  echo "  User already has $ORG_COUNT organization(s), skipping creation."
+  ORG_ID=$(echo "$ORG_CHECK" | python3 -c "import sys,json; print(json.load(sys.stdin)['organizations'][0]['id'])" 2>/dev/null || echo "")
+fi
+
 # ── 4. Create a market ──
-echo "[4/5] Creating market..."
+echo "[4/6] Creating market..."
 MARKET_NAME="Seed Market $(date +%H%M%S)"
 CREATE_RESPONSE=$(curl -k -s -b "$COOKIE_JAR" \
   -X POST "$BACKEND_URL/markets" \
@@ -84,6 +108,7 @@ CREATE_RESPONSE=$(curl -k -s -b "$COOKIE_JAR" \
   -d "{
     \"name\": \"$MARKET_NAME\",
     \"creationDate\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",
+    \"organizationId\": \"$ORG_ID\",
     \"roles\": {\"$USER_ID\": \"owner\"},
     \"modificationList\": [],
     \"assignmentObject\": {}
@@ -98,7 +123,7 @@ fi
 echo "  Market ID: $MARKET_ID"
 
 # ── 5. Upload CSV fixture ──
-echo "[5/5] Uploading CSV fixture..."
+echo "[5/6] Uploading CSV fixture..."
 UPLOAD_RESPONSE=$(curl -k -s -b "$COOKIE_JAR" \
   -X POST "$BACKEND_URL/source-data/$MARKET_ID" \
   -H "X-Owner-Email: $TEST_EMAIL" \


### PR DESCRIPTION
## Intent

Implement D14 from Conventioner Phase 1: every market requires an organization at creation. Captain decision: an org-less market is not a valid state; there is no 'personal market' path. This PR enforces it by: (1) back-end validation in POST /markets - reject missing organization_id, nonexistent org, or user not a member of the org (all 400); (2) front-end ElementOrgSelect.vue reusable dropdown populated from GET /organizations with zero-org fallback link to /organizations; (3) NewMarketOverlay.vue now has a required org select, submit disabled until org chosen, including organizationId in the market creation payload; (4) existing CSV upload in the overlay preserved intact (its removal is PR 7); (5) E2E seed helpers and specs updated to create/use a test organization. No data model changes (organization_id already Optional[str]=None on Market), no migration of existing org-less markets (D7: read-only archives), no solver or assignment changes. The PR branch targets dev and is conflict-free with PR 1 (different files).

## What Changed

- `POST /markets` now rejects any creation payload without an `organizationId`, with an unknown organization, or with an organization the requesting user is not an owner/admin/member of (400 in each case), making "market with no organization" unreachable through the create path.
- The new-market overlay gains a required organization picker: a reusable `ElementOrgSelect.vue` populated from `GET /organizations`, submit disabled until an org is chosen, `organizationId` sent in the create payload, and a link to `/organizations` when the user belongs to no organization. The org-response parsing that `OrganizationsView.vue` used to own was extracted into `front-end/src/utils/organizations.ts` and is now shared by both.
- E2E and seeding infrastructure updated for the new requirement: `seeds.ts` exports `ensureTestOrg()` / `ensureTestOrgAuthenticated()` and returns an `orgId` from the seed helpers, existing specs attach an org before creating markets, `scripts/seed_fixture.sh` creates a seed org plus a deliberately org-less user, and a new `new-market-org.spec.ts` covers the dropdown, the disabled-submit gate, the persisted org id, and the zero-org fallback. Docs (`AGENTS.md`, `docs/TESTING.md`, `docs/OBJECT_RELATIONSHIPS.md`, `docs/STARTUP.md`) were synced to match.

Review flagged some adjacent items left open for follow-up: `PUT /markets/<id>` still performs no organization validation (so the "Remove organization" affordance in `ManageMarketOverlay` can still strip one), and `GET /markets` has a pre-existing `organization_id` vs `organizationId` field-name mismatch that keeps org markets out of the list. Neither is introduced here.

## Risk Assessment

⚠️ Medium: The creation-path enforcement, front-end org select, and e2e seeding are correct and well-bounded after the two fix rounds, but the D14 invariant is still only half-closed by design decisions you accepted (a market can be made org-less again through `PUT /markets/<id>` and the "Remove organization" button, and `get_markets_for_user` queries snake_case `organization_id` against camelCase-persisted docs so org-scoped market visibility silently matches nothing).

## Testing

Brought up an isolated Docker stack matching CI env flags and seeded it the way scripts/seed_fixture.sh does, then exercised D14 the way an end user hits it. Manual API calls confirm POST /markets rejects a missing organization_id, a nonexistent org, and a non-member caller with 400 and persists nothing, while a valid org creates a market stamped with that organizationId. The Playwright spec drives the real overlay: Submit is disabled until an organization is picked, the dropdown is populated from GET /organizations, and a user with no orgs gets a disabled select plus a working link to /organizations. The target commit's CSS fix was verified visually with a before/after render showing the 'Create an organization' link no longer breaking mid-phrase and the hint staying centered; the previous round's stale pre-fix screenshot was replaced with the post-fix render. Regression pass is clean: full E2E 24/24, back-end pytest 63/63, front-end unit 3/3. One setup issue I hit and fixed myself: auth.spec.ts's password-reset test fails unless the stack runs with DISABLE_EMAIL=true and DISABLE_CAPTCHA=true (as CI does); after recreating the stack with those flags it passes. Transient artifacts (Docker stack, test-results/, playwright-report/) were removed and the worktree is clean.

- Evidence: Zero-org hint wrap: before vs after the target commit&#39;s CSS fix (local file: <code>/tmp/no-mistakes-evidence/01KXB57M822MRRYH64VY0ATH54/hint-wrap-before-after.png</code>)
- Evidence: New market overlay: no org selected, Submit disabled (local file: <code>/tmp/no-mistakes-evidence/01KXB57M822MRRYH64VY0ATH54/01-submit-blocked-no-org.png</code>)
- Evidence: New market overlay: org selected, Submit enabled (local file: <code>/tmp/no-mistakes-evidence/01KXB57M822MRRYH64VY0ATH54/02-org-selected-submit-enabled.png</code>)
- Evidence: Zero-org fallback (post-fix): disabled select + centered &#39;Create an organization&#39; link (local file: <code>/tmp/no-mistakes-evidence/01KXB57M822MRRYH64VY0ATH54/03-zero-org-fallback.png</code>)
- Evidence: Video of the org-gated market creation flow (local file: <code>/tmp/no-mistakes-evidence/01KXB57M822MRRYH64VY0ATH54/new-market-org-required.webm</code>)
- Evidence: GIF of the org-gated market creation flow (local file: <code>/tmp/no-mistakes-evidence/01KXB57M822MRRYH64VY0ATH54/new-market-org-required.gif</code>)
<details>
<summary>Evidence: API transcript: POST /markets org validation + persisted state</summary>

<code>### 1. organizationId omitted -&gt; rejected&#10;--&gt; HTTP 400&#10;{&#34;error&#34;:&#34;organization_id is required&#34;}&#10;&#10;### 2. organizationId points at a nonexistent org -&gt; rejected&#10;--&gt; HTTP 400&#10;{&#34;error&#34;:&#34;Organization not found&#34;}&#10;&#10;### 3. caller is not a member of the org -&gt; rejected&#10;--&gt; HTTP 400&#10;{&#34;error&#34;:&#34;User is not a member of this organization&#34;}&#10;&#10;### 4. valid org the caller belongs to -&gt; accepted&#10;--&gt; HTTP 201&#10;{&#34;market_id&#34;:&#34;136c6b97-5d47-4260-9dd4-07ec6d0b24ee&#34;,&#34;message&#34;:&#34;Market created successfully&#34;}&#10;&#10;### Persisted state: GET /markets&#10;Seed Market 212913 organizationId=bc4e3a0f-76e8-446a-97c4-0dcbb4606d91&#10;Valid Org Market organizationId=bc4e3a0f-76e8-446a-97c4-0dcbb4606d91&#10;&#10;Only markets carrying an organizationId exist. The three rejected requests persisted nothing.</code>

```text
D14: POST /markets requires a valid organization the caller belongs to
user e2e@example.com   id=6a5396a81b72dec33dd0da40   org=bc4e3a0f-76e8-446a-97c4-0dcbb4606d91 (member)
user e2e-noorg@...     id=6a5396a91bd093846b2190b8   (belongs to no organization)

### 1. organizationId omitted -> rejected
POST /markets
{
    "name": "No Org Market",
    "creationDate": "2026-07-12T00:00:00Z",
    "roles": {
        "6a5396a81b72dec33dd0da40": "owner"
    },
    "modificationList": [],
    "assignmentObject": {}
}
--> HTTP 400
{"error":"organization_id is required"}


### 2. organizationId points at a nonexistent org -> rejected
POST /markets
{
    "name": "Ghost Org Market",
    "creationDate": "2026-07-12T00:00:00Z",
    "organizationId": "00000000-0000-0000-0000-000000000000",
    "roles": {
        "6a5396a81b72dec33dd0da40": "owner"
    },
    "modificationList": [],
    "assignmentObject": {}
}
--> HTTP 400
{"error":"Organization not found"}


### 3. caller is not a member of the org -> rejected
POST /markets
{
    "name": "Outsider Market",
    "creationDate": "2026-07-12T00:00:00Z",
    "organizationId": "bc4e3a0f-76e8-446a-97c4-0dcbb4606d91",
    "roles": {
        "6a5396a91bd093846b2190b8": "owner"
    },
    "modificationList": [],
    "assignmentObject": {}
}
--> HTTP 400
{"error":"User is not a member of this organization"}


### 4. valid org the caller belongs to -> accepted
POST /markets
{
    "name": "Valid Org Market",
    "creationDate": "2026-07-12T00:00:00Z",
    "organizationId": "bc4e3a0f-76e8-446a-97c4-0dcbb4606d91",
    "roles": {
        "6a5396a81b72dec33dd0da40": "owner"
    },
    "modificationList": [],
    "assignmentObject": {}
}
--> HTTP 201
{"market_id":"136c6b97-5d47-4260-9dd4-07ec6d0b24ee","message":"Market created successfully"}


### Persisted state: GET /markets
  Seed Market 212913       organizationId=bc4e3a0f-76e8-446a-97c4-0dcbb4606d91
  Valid Org Market         organizationId=bc4e3a0f-76e8-446a-97c4-0dcbb4606d91

Only markets carrying an organizationId exist. The three rejected requests persisted nothing.
```
</details>
- Outcome: 🔧 2 issues found → auto-fixed ✅ across 2 runs (35m51s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 5 infos</summary>

- 🚨 `front-end/e2e/floorplan.spec.ts:12` - The new `test.beforeAll(async ({ request }) =&gt; ensureTestOrg(...))` runs on a fresh Playwright `request` context that has never logged in, so it has no flask session cookie. Both `GET /organizations` (back-end/app.py:155) and `POST /organizations` (app.py:169) are `@login_required`, and flask_login has no `login_view` configured (app.py:62-64), so it aborts with 401. In `ensureTestOrg` the GET returns 401 -&gt; `orgsRes.ok()` is false -&gt; it falls through to the POST -&gt; also 401 -&gt; it throws `Test org creation failed: 401`, failing the entire describe block at setup. The same bug is at front-end/e2e/market-pipeline.spec.ts:11. The tier2.spec.ts:97 call site is fine only because it does `POST /login` on the same `request` context first. Fix by logging in inside `ensureTestOrg` (front-end/e2e/helpers/seeds.ts:40) before hitting /organizations, or by logging in in each beforeAll.
- ⚠️ `back-end/api/markets.py:235` - `get_markets_for_user` queries `markets_collection.find({&#34;organization_id&#34;: {&#34;$in&#34;: org_ids}})` and reads `market.get(&#39;organization_id&#39;)` (lines 218, 243), but `create_market` persists market docs through `convert_keys_to_camel_case` (markets.py:286), so the stored field is `organizationId`. The org query therefore matches nothing and `organization_name` is never attached to listed markets. Pre-existing, but this PR makes the organization mandatory and load-bearing: after D14 every market belongs to an org, yet org members still cannot discover org markets in `GET /markets` (they can only reach one by direct id, since permissions.py correctly reads the Pydantic model). `delete_organization` (back-end/api/organizations.py:150) has the same snake_case mismatch. Worth deciding whether to fix here or explicitly defer.
- ⚠️ `back-end/app.py:588` - The &#34;a market always has an organization&#34; invariant is enforced only in `POST /markets`. `PUT /markets/&lt;id&gt;` (app.py:610) performs no organization validation, and `Market.organization_id` stays `Optional[str] = None`, so an org-less market is still reachable immediately after this change: `ManageMarketOverlay.vue:167` (`handleRemoveOrg`) still renders a &#34;Remove organization&#34; button (template line 314-320) that PUTs `organizationId: null`, and `delete_organization` intends to null out its markets&#39; org. If an org-less market is genuinely not a valid state, the update path and that UI affordance need to be closed too (or explicitly deferred to a later PR).
- ℹ️ `front-end/src/components/elements/ElementOrgSelect.vue:10` - `type RawOrganization` (lines 10-27), `parseOrgFromApi` (34-49) and `fetchOrganizations` (51-62) are copied verbatim from `front-end/src/views/OrganizationsView.vue:11-66`. Two independent copies of the snake/camel org-response normalization will drift as the org payload evolves. Extract them into a shared module (e.g. `@/utils/organizations.ts`) and have both OrganizationsView and ElementOrgSelect import it.
- ℹ️ `front-end/src/components/elements/ElementOrgSelect.vue:91` - The zero-org fallback uses a raw `&lt;a href=&#34;/organizations&#34;&gt;`, which triggers a full browser reload rather than a vue-router client-side navigation, dropping all SPA state. Use `&lt;RouterLink to=&#34;/organizations&#34;&gt;` to match how the rest of the app navigates.
- ℹ️ `scripts/seed_fixture.sh:98` - In the &#34;org already exists&#34; branch, a failed id extraction silently leaves `ORG_ID` empty (`|| echo &#34;&#34;`), and the script proceeds to create a market with `&#34;organizationId&#34;: &#34;&#34;`, which the new back-end validation now rejects with a confusing 400 at the market step. The create branch already guards this (line 91-94); add the same `if [ -z &#34;$ORG_ID&#34; ]` check after line 98.

🔧 Fix: fix e2e org seed auth, dedupe org parsing, guard seed script
4 issues (2 warnings, 2 infos) still open:
- ⚠️ `front-end/src/views/NewMarketOverlay.vue:104` - The organization select is only rendered inside the `v-else` branch (after `next` becomes true, i.e. after the CSV is uploaded). A user with zero organizations - which after D14 is exactly the new-user first-run path - uploads their CSV, reaches the name step, and only then discovers `No organizations available.` (ElementOrgSelect.vue:47). The single escape hatch is the `&lt;RouterLink to=&#34;/organizations&#34;&gt;`, which navigates away from `/markets`, unmounting `NewMarketOverlay` and discarding `uploadedFiles` / `uploadedSourceData` (lines 15-16). They must create the org, come back, and re-upload the CSV. Consider surfacing the org requirement before the file-drop step, or letting the user create an org inline from the overlay so the upload survives.
- ⚠️ `front-end/e2e/helpers/seeds.ts:76` - `ensureTestOrg` only reads the org list `if (orgsRes.ok())`; any non-OK response (401, 500) silently falls through to `POST /organizations`. Because `create_organization` (back-end/api/organizations.py:21) enforces a GLOBAL unique name (`find_one({&#34;name&#34;: name})`, not scoped to the user), that fallthrough either fails with a misleading `Test org creation failed: 400 Organization already exists` or creates a spurious org - in both cases hiding the actual cause. This is the same masking that made the round-1 auth bug hard to diagnose. Throw on `!orgsRes.ok()` with the status and body instead of falling through.
- ℹ️ `front-end/e2e/helpers/seeds.ts:120` - `seedMarketWithVendors` (line 118-120) and `seedPublishedMarketWithAssignments` (line 190-192) each call `loginViaApi(...)` and then `ensureTestOrg(...)`, which itself calls `loginViaApi(...)` again on the same request context (line 71). Every seed therefore performs two identical `POST /login` round-trips. Either have `ensureTestOrg` return `{ orgId, userId }` from a single login, or split out an `ensureTestOrgAuthenticated(request, baseURL, email)` that assumes an already-authenticated context and have `ensureTestOrg` be the thin login+delegate wrapper for the `beforeAll` call sites.
- ℹ️ `front-end/src/views/NewMarketOverlay.vue:34` - `errorMessage` is cleared on the name input&#39;s `@input` (line 117) but not when an organization is selected. Pressing Enter in the name field with no org chosen (which bypasses the `:disabled` submit button) sets `Organization is required`; picking an org afterwards leaves the stale error visible until the user types in the name field again. Add a watcher on `selectedOrgId` (or an `@update:modelValue` handler on `ElementOrgSelect`) that resets `errorMessage`.

🔧 Fix: harden e2e org seed errors, drop double login, clear stale org error
5 infos still open:
- ℹ️ `back-end/app.py:588` - The new organization validation lives in the Flask route and hand-rolls the membership test against a raw Mongo dict (`owner.id != org.get(&#39;owner&#39;) and owner.id not in org.get(&#39;admins&#39;, []) ...`). The route already duplicates the owner-count invariant that `MarketsApi.create_market` (back-end/api/markets.py:279) enforces, and `permissions.py` / `OrgsApi.get_organizations_for_user` already own the &#34;is this user in this org&#34; logic. Moving the org check into `MarketsApi.create_market` next to the owner-count check (raising `ValueError`, which the route already maps to 400) would enforce it for every caller and remove the third copy of business validation from the transport layer.
- ℹ️ `front-end/src/components/elements/ElementOrgSelect.vue:27` - `loadOrganizations()` runs once in `onMounted` and there is no retry path. `NewMarketOverlay` is never unmounted - `MarketsView.vue:115` keeps it in the tree and toggles CSS `visibility` - so if the `GET /organizations` call fails once (network blip, expired session), the select stays disabled (`:disabled=&#34;loading || organizations.length === 0&#34;`) and the Submit button stays disabled (`:disabled=&#34;!selectedOrgId&#34;`) for the rest of the page&#39;s life. The user cannot create a market until they hard-reload. Refetch when the overlay opens (watch the `newOpen` prop) or expose a retry action next to the error text.
- ℹ️ `back-end/app.py:596` - The new membership check resolves the acting user from the client-supplied `X-Owner-Email` header (`owner = UsersApi.get_user(owner_email)`) rather than from the authenticated `current_user`, so a logged-in user can create a market in an organization they do not belong to by passing a member&#39;s email in the header. This is consistent with every other endpoint in the app (`update_market`, `delete_market`, and the permission checks all key off `X-Owner-Email`), so this PR does not widen the hole - but the new check is an authorization check and it is worth being explicit that it is not a security boundary until `X-Owner-Email` is replaced by `current_user.email` app-wide.
- ℹ️ `front-end/e2e/tier2.spec.ts:88` - This `beforeAll` still hand-rolls the login block (`POST /login`, ok() check, parse `user_data.id`) that was just extracted into the exported `loginViaApi()` helper in `front-end/e2e/helpers/seeds.ts:38` and is already imported from that module for `ensureTestOrgAuthenticated`. Replace lines 88-96 with `const userId = await loginViaApi(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);`.
- ℹ️ `scripts/seed_fixture.sh:38` - The step counters are now inconsistent: steps 1-3 still print `[1/5]`, `[2/5]`, `[3/5]` while the new and renumbered steps print `[3b/6]`, `[4/6]`, `[5/6]` - and there is no step 6, so the script&#39;s last line reads `[5/6]` before printing &#34;Seed complete&#34;. Renumber to a single consistent scheme (e.g. 6 steps with the org step as step 4).

</details>

<details>
<summary>🔧 **Test** - 2 issues found → auto-fixed ✅</summary>

- ℹ️ `front-end/src/components/elements/ElementOrgSelect.vue:51` - Zero-org fallback copy wraps awkwardly inside the 320px overlay: the underlined link breaks mid-phrase across two lines (&#34;Create an&#34; / &#34;organization&#34;), and the second line left-aligns against the otherwise centered block. Visible in 03-zero-org-fallback.png. Purely cosmetic - behavior is correct and the link navigates to /organizations. Left alone since this pass is scoped to testing; flagging so the author can decide (e.g. white-space: nowrap on .org-select-link, or a slightly wider overlay).
- ℹ️ `front-end/e2e/new-market-org.spec.ts` - new test file written by agent: front-end/e2e/new-market-org.spec.ts
- <code>`docker compose -p nm-d14 ... up -d --wait` (isolated stack on backend 5030 / frontend 5203, so other running checkouts were untouched)</code>
- `Live API transcript against POST /markets: missing organization_id, nonexistent org, org owned by another user, and the user's own org (curl, logged-in session)`
- <code>`mongosh` query of the markets and organizations collections to confirm only the valid request persisted, with organizationId set and the org&#39;s markets back-reference updated</code>
- <code>`python -m pytest tests -q` in the backend container (63 passed; needed docs/ copied in for test_generate_market_schema.py, which resolves a repo-root path not present in the container mount)</code>
- <code>`npx playwright test` full suite against a freshly seeded DB (24 passed, incl. market-pipeline, floorplan, tier2, checkin, auth)</code>
- <code>`npx playwright test e2e/new-market-org.spec.ts` - new spec: org dropdown matches GET /organizations, Submit disabled until org chosen, created market carries the org id, zero-org user sees the create-organization fallback link</code>
- <code>`npx playwright test e2e/auth.spec.ts` re-run with DISABLE_EMAIL=true / E2E_MONGO_CONTAINER=nm-d14-mongodb (9 passed) after the initial failure turned out to be my missing env, which CI sets</code>
- `Manual screenshot capture of the overlay in three states (no org selected, org selected, zero-org fallback) plus video of the full org-gated creation flow`

🔧 Fix: fix org select hint wrap in zero-org fallback
✅ Re-checked - no issues remain.
- <code>`docker compose -f docker-compose.yml -f docker-compose.worktree.yml up -d --wait` on isolated ports (backend 5070 / frontend 5243) with `DISABLE_CAPTCHA=true DISABLE_EMAIL=true` to match CI</code>
- <code>Seeded the stack with the same steps as `scripts/seed_fixture.sh` (reset DB, create `e2e@example.com` + the new no-org user `e2e-noorg@example.com`, create org, create market, upload vendor CSV)</code>
- <code>Manual API verification of D14: four `POST /markets` requests via curl covering missing organization_id, nonexistent org, non-member caller, and a valid org, followed by `GET /markets` to confirm persisted `organizationId` (transcript: api-org-required.txt)</code>
- <code>`npx playwright test e2e/new-market-org.spec.ts` - org picker gates submission, created market carries the org, zero-org user is pointed at organization creation</code>
- <code>`npx playwright test` (full E2E suite, 24 tests incl. floorplan, market-pipeline, tier2, auth, checkin, tables, vendors) with `FRONTEND_PORT=5243 BACKEND_URL=https://localhost:5070 E2E_MONGO_CONTAINER=conventioner-nm7-mongodb`</code>
- <code>`python -m pytest tests/ -q` in the back-end container (63 passed)</code>
- <code>`npx vitest run` in front-end (3 passed)</code>
- <code>Manual visual before/after of the hint-wrap fix: drove the real zero-org overlay in Chromium and toggled off only the two CSS properties the fix added (`white-space: nowrap`, `text-align: center`) at runtime to render the pre-fix layout for comparison (no source change)</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/ENTITY_RELATIONSHIP_REFINEMENT.md:543` - docs/ENTITY_RELATIONSHIP_REFINEMENT.md&#39;s implementation checklist is entirely unchecked even for shipped work (organization CRUD, Market.organization_id, and now &#39;Add organization selection when creating market&#39; at line ~543). I added a scoped &#39;Superseded&#39; note to the one requirement that directly contradicts the new behavior (&#39;Market can belong to 0 or 1 organization&#39;), but did not reconcile the checklist: it needs a human call on whether this doc is a frozen historical planning artifact or a living tracker that should be updated per-PR.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `front-end/.prettierrc.json` - prettier --check fails on the 11 changed TS/Vue files, but it fails identically on all 73 files in front-end/src: .prettierrc.json specifies semi:false + 2-space indent while the entire codebase uses semicolons + 4-space indent. Prettier is not run in CI (test.yml runs only eslint and vue-tsc) and ESLint uses @vue/eslint-config-prettier/skip-formatting, so formatting is unenforced. The new files match the surrounding house style; reformatting only the changed files would make them inconsistent with every neighboring file. Left as-is - reconciling the Prettier config with the codebase is a repo-wide change, not part of this PR.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
