### PR TITLE
fix(e2e): enable TypeScript type-checking for e2e tests

### DIFF
--- a/front-end/e2e/helpers/seeds.ts
+++ b/front-end/e2e/helpers/seeds.ts
@@ -20,7 +20,7 @@ export interface PublishedSeedResult extends SeedResult {
 /**
  * Replicate the front-end marketNameToKebabSlug logic for URL-safe slugs.
  */
-function marketNameToSlug(name: string): string {
+export function marketNameToSlug(name: string): string {
   return name
     .trim()
     .replace(/\s+/g, ' ')

--- a/front-end/e2e/market-pipeline.spec.ts
+++ b/front-end/e2e/market-pipeline.spec.ts
@@ -1,14 +1,14 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { test, expect, MarketSetupPage, AssignmentResultsPage, NewMarketPage, BACKEND_URL, TEST_USER } from './fixtures';
-import { ensureTestOrg, seedPublishedMarketWithAssignments } from './helpers/seeds';
+import { ensureTestOrg, marketNameToSlug, seedPublishedMarketWithAssignments } from './helpers/seeds';
 import {
   makeLegacyPublishedMarket,
   readMarketLifecycle,
   runIsDraftConsistencyMigration,
 } from './helpers/legacyMarketDoc';
 import { CheckinPage } from './pages/CheckinPage';
-import { marketNameToKebabSlug } from '../src/utils/marketSlug';
+
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CSV_PATH = path.resolve(__dirname, 'fixtures', 'test-vendors.csv');
@@ -142,7 +142,7 @@ test.describe('Market pipeline E2E', () => {
     await resultsPage.clickDone();
 
     // A published market lands on its public slug URL, not back in the wizard.
-    const slug = marketNameToKebabSlug(marketName);
+    const slug = marketNameToSlug(marketName);
     await page.waitForURL(`**/${slug}`, { timeout: 10000 });
     await expect(page.getByRole('heading', { name: 'Market home' })).toBeVisible();
     await page.screenshot({ path: testInfo.outputPath('02-published-market-home.png'), fullPage: true });

--- a/front-end/tsconfig.e2e.json
+++ b/front-end/tsconfig.e2e.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@tsconfig/node22/tsconfig.json",
+  "include": [
+    "e2e/**/*.ts"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.e2e.tsbuildinfo",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["es2024", "ESNext.Array", "ESNext.Collection", "ESNext.Iterator", "dom"],
+    "types": ["node"]
+  }
+}

--- a/front-end/tsconfig.json
+++ b/front-end/tsconfig.json
@@ -12,6 +12,9 @@
     },
     {
       "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.e2e.json"
     }
   ]
 }


### PR DESCRIPTION
## Intent

Close the CI type-check gap where e2e/** was excluded from TypeScript checking because tsconfig.json's project references (tsconfig.app.json, tsconfig.node.json) had no coverage for the e2e directory. Create tsconfig.e2e.json extending @tsconfig/node22 with dom lib (needed for Playwright page.evaluate() callbacks), wire it into tsconfig.json references, and fix any real type errors that surface. No blanket suppressions - fix types, not the type-checker. The one cross-project import (marketNameToKebabSlug from ../src/utils/marketSlug in market-pipeline.spec.ts) was resolved by exporting the identical local marketNameToSlug from e2e/helpers/seeds.ts and using that instead.

## What Changed

- Added `tsconfig.e2e.json` extending `@tsconfig/node22` with DOM lib for Playwright `page.evaluate()` callbacks, wired into the root `tsconfig.json` project references
- Resolved the cross-project import of `marketNameToKebabSlug` from `../src/utils/marketSlug` by exporting the equivalent `marketNameToSlug` from `e2e/helpers/seeds.ts` and consuming it in `market-pipeline.spec.ts`

## Risk Assessment

✅ Low: Well-bounded type-checking infrastructure change following existing patterns; the only functional change (import swap) uses a byte-identical function with no behavioral drift.

## Testing

Type-check pipeline validated end-to-end. The new tsconfig.e2e.json is correctly wired into tsconfig.json references, vue-tsc --build succeeds with zero errors across all projects, and the full build passes. The cross-project import from e2e to src was removed by exporting the equivalent local marketNameToSlug from e2e/helpers/seeds.ts (verified functionally identical). No blanket type suppressions were introduced. The dom lib in tsconfig.e2e.json is justified by page.evaluate() usage across 6+ e2e spec files.

<details>
<summary>Evidence: Full type-check output (vue-tsc --build)</summary>

<code>&gt; conventioner-frontend@0.0.0 type-check&#10;&gt; vue-tsc --build&#10;&#10;(exit 0, zero errors)</code>

```text

> conventioner-frontend@0.0.0 type-check
> vue-tsc --build
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff aee4efb..2b54b425 --stat (verified 4 files changed, 22 insertions, 4 deletions)`
- `grep 'from "\.\.\/src\/' in front-end/e2e/**/*.ts (zero matches - no remaining cross-project imports)`
- `grep '@ts-ignore|@ts-expect-error|\\bas any\\b' in front-end/e2e/**/*.ts (zero matches - no blanket suppressions)`
- `npm run type-check (vue-tsc --build: exit 0, zero errors across all project references including tsconfig.e2e.json)`
- `npx vue-tsc --project tsconfig.e2e.json --noEmit (exit 0, zero errors on e2e project in isolation)`
- `VITE_ALLOW_INSECURE_LOCAL_DEV=true npm run build (exit 0, 408 modules transformed, type-check + vite build both pass)`
- `node equivalence check: marketNameToSlug vs marketNameToKebabSlug produce identical output for 7 test cases including unicode, whitespace, and edge cases`
- `verified @tsconfig/node22/tsconfig.json exists in node_modules (base config resolves correctly)`
- `verified page.evaluate() usage in 6 e2e files (dom lib inclusion justified)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
