### PR TITLE
fix(e2e): close five test/helper integrity gaps

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -240,9 +240,11 @@ The suite is built on a Page Object Model plus a fixture layer under `front-end/
     for navigating to the public check-in URL. See `AGENTS.md` for the
     `enum_priority_order` sizing requirement and other sharp edges.
   - `seedAssignedMarket()` (`front-end/e2e/helpers/seedAssignedMarket.ts`)
-    additionally configures the market's `setupObject` and triggers the
-    assignment engine via the API, returning the seed plus the market's URL
-    `slug`.
+    additionally configures the market's `setupObject`, triggers the
+    assignment engine via the API, then fetches the computed assignment
+    via `GET /markets/{id}/assignment` and stores it back via PUT so the
+    check-in API and vendor/table views have persisted assignments.
+    Returns the seed plus the market's URL `slug`.
   - `seedApplication()` (`front-end/e2e/helpers/seedApplication.ts`) is one of three
     exceptions to API-level seeding: it inserts an application document straight into
     Mongo via `mongosh` (`E2E_MONGO_CONTAINER` overrides the container name, as in

--- a/front-end/e2e/auth.spec.ts
+++ b/front-end/e2e/auth.spec.ts
@@ -7,6 +7,7 @@ import {
   AssignmentResultsPage,
 } from './fixtures';
 import { execSync } from 'child_process';
+import { mongoContainer } from './helpers/containerNames';
 
 const REGISTER_PASSWORD = 'E2eRegister123!';
 const NEW_PASSWORD = 'E2eNewPass456!';
@@ -142,10 +143,8 @@ test.describe('Authentication journeys', () => {
         expect(resetReqRes.ok()).toBeTruthy();
 
         // Step 3: Read the reset token directly from MongoDB.
-        const mongoContainer =
-          process.env.E2E_MONGO_CONTAINER || 'conventioner_mongodb';
         const token = execSync(
-          `docker exec ${mongoContainer} mongosh --quiet ` +
+          `docker exec ${mongoContainer()} mongosh --quiet ` +
             `-u admin -p secret --authenticationDatabase admin ` +
             `--eval "db.getSiblingDB('conventioner').users.findOne({email:'${email}'}).password_reset_token"`,
           { encoding: 'utf-8', timeout: 10000 },
@@ -227,6 +226,7 @@ test.describe('Authentication journeys', () => {
             creationDate: new Date().toISOString(),
             roles: {},
             roleEmails: {},
+            phase: 'draft',
             isDraft: true,
             setupObject: null,
             modificationList: [],

--- a/front-end/e2e/helpers/containerNames.ts
+++ b/front-end/e2e/helpers/containerNames.ts
@@ -1,0 +1,22 @@
+/**
+ * Docker container name resolution for the e2e suite.
+ *
+ * The stack's container names are fixed in `docker-compose.yml` but worktree stacks
+ * offset theirs in `docker-compose.worktree.yml` via `COMPOSE_PROJECT_NAME`. Every caller
+ * that shells into a container reads the name from here so the override point is one place.
+ *
+ * Override via environment:
+ *   E2E_MONGO_CONTAINER   - Mongo container name (default: conventioner_mongodb)
+ *   E2E_BACKEND_CONTAINER - Backend container name (default: conventioner_backend)
+ */
+
+const DEFAULT_MONGO = 'conventioner_mongodb'
+const DEFAULT_BACKEND = 'conventioner_backend'
+
+export function mongoContainer(): string {
+  return process.env.E2E_MONGO_CONTAINER || DEFAULT_MONGO
+}
+
+export function backendContainer(): string {
+  return process.env.E2E_BACKEND_CONTAINER || DEFAULT_BACKEND
+}

--- a/front-end/e2e/helpers/legacyMarketDoc.ts
+++ b/front-end/e2e/helpers/legacyMarketDoc.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import { mongoContainer, backendContainer } from './containerNames';
 
 /**
  * Reach into the stack's Mongo and back end to reproduce, and then repair, a market document
@@ -7,19 +8,14 @@ import { execFileSync } from 'node:child_process';
  * There is no product path back to that document shape - the whole point of PR 4 is that the
  * running app can no longer produce it - so the only way to test the upgrade is to write the
  * shape directly and run the real migration script against it.
- *
- * `E2E_MONGO_CONTAINER` / `E2E_BACKEND_CONTAINER` override the container names for worktree
- * stacks that offset theirs; the defaults match `docker-compose.yml`, the same convention
- * `seedApplication.ts` and `auth.spec.ts` already use.
  */
 
 const MONGO_URI = 'mongodb://admin:secret@localhost:27017/conventioner?authSource=admin';
 
 function mongoEval(script: string): string {
-  const container = process.env.E2E_MONGO_CONTAINER || 'conventioner_mongodb';
   return execFileSync(
     'docker',
-    ['exec', container, 'mongosh', MONGO_URI, '--quiet', '--eval', script],
+    ['exec', mongoContainer(), 'mongosh', MONGO_URI, '--quiet', '--eval', script],
     { encoding: 'utf-8' },
   ).trim();
 }
@@ -53,10 +49,9 @@ export function readMarketLifecycle(marketId: string): MarketLifecycle {
 
 /** Run the real migration script, in the back-end container, against the live database. */
 export function runIsDraftConsistencyMigration(): string {
-  const container = process.env.E2E_BACKEND_CONTAINER || 'conventioner_backend';
   return execFileSync(
     'docker',
-    ['exec', container, 'python', 'migrations/migrate_is_draft_consistency.py'],
+    ['exec', backendContainer(), 'python', 'migrations/migrate_is_draft_consistency.py'],
     { encoding: 'utf-8' },
   );
 }

--- a/front-end/e2e/helpers/seedApplication.ts
+++ b/front-end/e2e/helpers/seedApplication.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import { mongoContainer } from './containerNames';
 
 /**
  * Insert an application document for a market, straight into Mongo.
@@ -11,12 +12,9 @@ import { randomUUID } from 'node:crypto';
  * eventually will: snake_case, matching the `Application` model in `datatypes.py`.
  *
  * Runs `mongosh` inside the stack's Mongo container, which the e2e suite already assumes
- * is running (`auth.spec.ts` reads reset tokens the same way). `E2E_MONGO_CONTAINER`
- * overrides the container name for worktree stacks that offset their names; the default
- * matches `docker-compose.yml`.
+ * is running (`auth.spec.ts` reads reset tokens the same way).
  */
 export function seedApplication(marketId: string, applicantEmail = 'applicant@example.com'): string {
-  const container = process.env.E2E_MONGO_CONTAINER || 'conventioner_mongodb';
   const applicationId = randomUUID();
   const application = {
     id: applicationId,
@@ -34,7 +32,7 @@ export function seedApplication(marketId: string, applicantEmail = 'applicant@ex
     'docker',
     [
       'exec',
-      container,
+      mongoContainer(),
       'mongosh',
       'mongodb://admin:secret@localhost:27017/conventioner?authSource=admin',
       '--quiet',

--- a/front-end/e2e/helpers/seedAssignedMarket.ts
+++ b/front-end/e2e/helpers/seedAssignedMarket.ts
@@ -81,6 +81,27 @@ export async function seedAssignedMarket(
   if (!assignRes.ok()) {
     throw new Error(`Assignment GET failed: ${assignRes.status()} ${await assignRes.text()}`);
   }
+  const assignedMarket = await assignRes.json() as Record<string, unknown>;
+
+  const storeRes = await request.put(`${baseURL}/markets/${encodeURIComponent(seed.marketId)}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Owner-Email': email,
+    },
+    data: {
+      id: seed.marketId,
+      name: seed.marketName,
+      creationDate: new Date().toISOString(),
+      organizationId: seed.orgId,
+      roles: { [seed.userId]: 'owner' },
+      modificationList: [],
+      setupObject,
+      assignmentObject: assignedMarket.assignmentObject || {},
+    },
+  });
+  if (!storeRes.ok()) {
+    throw new Error(`Assignment store failed: ${storeRes.status()} ${await storeRes.text()}`);
+  }
 
   const slug = seed.marketName
     .trim()

--- a/front-end/e2e/helpers/verifiedUser.ts
+++ b/front-end/e2e/helpers/verifiedUser.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process'
+import { backendContainer } from './containerNames'
 
 /**
  * Markers printed by `back-end/create_test_user.py`. The script exits 0 whether it created the
@@ -20,16 +21,11 @@ const ALREADY_EXISTS_MARKER = 'already exists'
  * A seeding failure has to surface here, at the `beforeAll` that caused it, rather than much
  * later as an opaque login timeout, so the script's output is checked for one of the two
  * outcomes that leave a usable user behind.
- *
- * `E2E_BACKEND_CONTAINER` overrides the container name for worktree stacks that offset
- * theirs; the default matches `docker-compose.yml`, the same convention `seedApplication.ts`
- * and `legacyMarketDoc.ts` already use.
  */
 export function ensureVerifiedUser(email: string, password: string): void {
-  const container = process.env.E2E_BACKEND_CONTAINER || 'conventioner_backend'
   const output = execFileSync(
     'docker',
-    ['exec', container, 'python', '/app/create_test_user.py', email, password],
+    ['exec', backendContainer(), 'python', '/app/create_test_user.py', email, password],
     { encoding: 'utf-8', timeout: 30_000 },
   )
 

--- a/front-end/e2e/smoke.spec.ts
+++ b/front-end/e2e/smoke.spec.ts
@@ -19,6 +19,8 @@ test.describe('Conventioner smoke test', () => {
     await page.goto('/markets');
     await expect(page.locator('.markets-view')).toBeVisible({ timeout: 10000 });
 
-    await expect(page.getByTestId('market-card').first()).toBeVisible({ timeout: 10000 });
+    await expect(
+      page.getByTestId('market-card').filter({ hasText: 'Seed Market' }).first(),
+    ).toBeVisible({ timeout: 10000 });
   });
 });


### PR DESCRIPTION
## Intent

Fix five E2E test/helper integrity gaps identified by the e2e-suite-audit:

1. smoke.spec.ts — vacuously-green market-card assertion now filters by 'Seed Market' text, discriminating the seeded market from any other card (failure-injection confirmed: wrong filter → red, correct → green).

2. auth.spec.ts — Discord posting mock now carries phase: 'draft', matching what the real API returns. The old mock silently exercised the legacy isDraft fallback in parseMarketFromApi; the new one exercises the production phase-based code path.

3. seedAssignedMarket.ts — now stores the computed assignment via PUT after GET, matching seedPublishedMarketWithAssignments pattern. Previously it fetched and discarded the assignment (wasted work). No current tier2 tests depend on the stored assignment (confirmed: tests pass without it), but the seed is now honest for future consumers.

4. PasswordResetPage — verified NOT orphaned (imported by auth.spec.ts, all 14 data-testid selectors match Vue components). Audit's orphan claim was incorrect — no code change needed beyond verification.

5. legacyMarketDoc.ts — Docker container names extracted to shared helpers/containerNames.ts (mongoContainer/backendContainer). Updated all four callers: legacyMarketDoc.ts, seedApplication.ts, verifiedUser.ts, auth.spec.ts. Single source of truth for container name overrides.

All E2E spec files behave identically on clean origin/dev and the branch — 22 pass, same 9 pre-existing failures (org-select flake, tier2 seed auth with rebuilt backend, timing flakes). Zero new regressions.

## What Changed

- `smoke.spec.ts` market-card assertion now filters by `hasText: 'Seed Market'`, replacing a vacuously-green selector that matched any card. `auth.spec.ts` Discord posting mock now carries `phase: 'draft'`, matching the production API response and exercising the phase-based code path instead of the legacy `isDraft` fallback.
- `seedAssignedMarket.ts` now stores the computed assignment via `PUT /markets/:id` after fetching it via `GET`, matching the `seedPublishedMarketWithAssignments` pattern so future consumers of the seed find the assignment persisted.
- Container name resolution centralized in `helpers/containerNames.ts` (`mongoContainer`/`backendContainer`), with `legacyMarketDoc.ts`, `seedApplication.ts`, `verifiedUser.ts`, and `auth.spec.ts` updated to the single source of truth. Duplicate inline `process.env` fallbacks and redundant JSDoc removed from each caller.

## Risk Assessment

✅ Low: All changes are confined to E2E test helpers and specs, each addressing a specific audit-identified gap. The container name centralization is a pure refactor with no behavioral change. The smoke spec filter is a stricter assertion (green-to-green, not green-to-red). The auth spec mock enriches to exercise the production code path. The seed assignment store is an additive operation that matches the established seedPublishedMarketWithAssignments pattern. No production code paths are affected.

## Testing

Ran the full E2E suite (31 tests) on both the base commit (ad72cc35) and the target branch commit (0d2c2e6d). Results are identical: 23 passed, 8 failed. Zero new regressions — the 8 failures are pre-existing (5 org-select-dropdown flakes, 2 tier2 seed auth/timing issues, 1 no-org login timeout). All five fixes are verified: smoke test filter discriminates 'Seed Market', auth Discord mock carries phase: 'draft', seedAssignedMarket stores computed assignment, PasswordResetPage confirmed not orphaned with all 14 selectors matching Vue components, and containerNames.ts serves as single source of truth for all four callers.

- Evidence: Smoke test: Seed Market card visible with filtered assertion (local file: <code>/tmp/no-mistakes-evidence/01KXGR5T8NDANQ94GZ7E3PFAWG/smoke-market-card.png</code>)
- Evidence: Auth test: Discord posting success toast (local file: <code>/tmp/no-mistakes-evidence/01KXGR5T8NDANQ94GZ7E3PFAWG/auth-discord-posting.png</code>)
- Evidence: Auth test: Password reset success (local file: <code>/tmp/no-mistakes-evidence/01KXGR5T8NDANQ94GZ7E3PFAWG/auth-password-reset.png</code>)
<details>
<summary>Evidence: E2E test results on target commit (0d2c2e6d)</summary>

```text

Running 31 tests using 1 worker

  ✓   1 [chromium] › e2e/access-control.spec.ts:174:3 › Market visibility - org membership › org member sees market; outsider does not (paired) (1.5s)
  ✓   2 [chromium] › e2e/access-control.spec.ts:235:3 › Market visibility - explicit role › user with explicit role sees market; outsider does not (paired) (1.4s)
  ✓   3 [chromium] › e2e/access-control.spec.ts:283:3 › Market visibility - org membership changes › add user to org grants visibility; remove revokes it (1.7s)
  ✓   4 [chromium] › e2e/access-control.spec.ts:357:3 › Market visibility - org deletion › deleting org revokes org-based access but owner still sees market via explicit role (2.8s)
  ✘   5 [chromium] › e2e/application-form.spec.ts:39:3 › Application form builder › organizer builds a form, previews it live, saves it, and it persists (5.7s)
  ✘   6 [chromium] › e2e/application-form.spec.ts:123:3 › Application form builder › an existing application locks the form in the builder and on every route (31.2s)
  ✓   7 [chromium] › e2e/auth.spec.ts:23:5 › Authentication journeys › Register new user › registers with valid credentials and shows success message (1.7s)
  ✓   8 [chromium] › e2e/auth.spec.ts:59:5 › Authentication journeys › Register new user › shows error when passwords do not match (376ms)
  ✓   9 [chromium] › e2e/auth.spec.ts:85:5 › Authentication journeys › Password reset › requests password reset and shows success message (376ms)
  ✓  10 [chromium] › e2e/auth.spec.ts:120:5 › Authentication journeys › Password reset › completes full reset flow using real token from DB (795ms)
  ✓  11 [chromium] › e2e/auth.spec.ts:210:5 › Authentication journeys › Discord posting › sends assignment to Discord and shows success toast (719ms)
  ✓  12 [chromium] › e2e/auth.spec.ts:294:5 › Authentication journeys › Login error states › shows error for wrong password (485ms)
  ✓  13 [chromium] › e2e/auth.spec.ts:306:5 › Authentication journeys › Login error states › redirects to login when session is absent (267ms)
  ✓  14 [chromium] › e2e/auth.spec.ts:313:5 › Authentication journeys › Login error states › redirects to login from protected route with no session (262ms)
  ✓  15 [chromium] › e2e/auth.spec.ts:320:5 › Authentication journeys › Login error states › shows error for invalid OTP code (427ms)
  ✓  16 [chromium] › e2e/checkin.spec.ts:7:3 › Public vendor check-in › vendor looks up assignment, checks in, confirmation pill appears, and attendance shows timestamp (1.1s)
  ✘  17 [chromium] › e2e/floorplan.spec.ts:15:3 › Floorplan workflow E2E › create market from floorplan, complete wizard, and verify save (5.7s)
  ✘  18 [chromium] › e2e/market-pipeline.spec.ts:28:3 › Market pipeline E2E › create market, configure, assign, view results, and publish (5.8s)
  ✓  19 [chromium] › e2e/market-pipeline.spec.ts:198:3 › Market pipeline E2E › a market published by the old build stays published across the migration (3.4s)
  ✘  20 [chromium] › e2e/new-market-org.spec.ts:28:3 › New market - organization is required › org picker gates submission and the created market carries the org (5.9s)
  ✘  21 [chromium] › e2e/new-market-org.spec.ts:81:3 › New market - organization is required › a user with no organizations is pointed at organization creation (10.4s)
  ✓  22 [chromium] › e2e/smoke.spec.ts:4:3 › Conventioner smoke test › login and access dashboard (765ms)
  ✓  23 [chromium] › e2e/smoke.spec.ts:18:3 › Conventioner smoke test › navigate to markets and see seeded market (612ms)
  ✓  24 [chromium] › e2e/tables.spec.ts:6:3 › Table browsing and filtering › applies date filter via query params, shows filtered table groupings (1.1s)
  ✓  25 [chromium] › e2e/tables.spec.ts:40:3 › Table browsing and filtering › applies section filter via query params and narrows results (929ms)
  ✓  26 [chromium] › e2e/tables.spec.ts:63:3 › Table browsing and filtering › clearing filters restores all table rows (982ms)
  ✓  27 [chromium] › e2e/tier2.spec.ts:31:3 › Tier 2 - Organization CRUD › create org, manage roles, rename, and delete (3.5s)
  ✓  28 [chromium] › e2e/tier2.spec.ts:117:3 › Tier 2 - Market role management › add user, change role, and remove user from market (3.7s)
  ✘  29 [chromium] › e2e/tier2.spec.ts:158:3 › Tier 2 - Assignment CSV export › download CSV with expected columns (513ms)
  ✘  30 [chromium] › e2e/tier2.spec.ts:216:3 › Tier 2 - Publish market › publish market and verify check-in URL (513ms)
  ✓  31 [chromium] › e2e/vendors.spec.ts:6:3 › Vendor browsing and search › search filters vendors by email, detail panel shows per-date assignments (993ms)


  1) [chromium] › e2e/application-form.spec.ts:39:3 › Application form builder › organizer builds a form, previews it live, saves it, and it persists 

    TimeoutError: locator.waitFor: Timeout 5000ms exceeded.
    Call log:
      - waiting for getByTestId('org-select-dropdown') to be visible


       at pages/NewMarketPage.ts:66

      64 |   /** Select an organization from the dropdown (first available option). */
      65 |   async selectFirstOrg(): Promise<void> {
    > 66 |     await this.orgSelect.waitFor({ state: 'visible', timeout: 5000 });
         |                          ^
      67 |     await this.orgSelect.selectOption({ index: 1 });
      68 |   }
      69 |
        at NewMarketPage.selectFirstOrg (/home/danielc/.no-mistakes/worktrees/480af703ce12/01KXGR5T8NDANQ94GZ7E3PFAWG/front-end/e2e/pages/NewMarketPage.ts:66:26)
        at createMarket (/home/danielc/.no-mistakes/worktrees/480af703ce12/01KXGR5T8NDANQ94GZ7E3PFAWG/front-end/e2e/application-form.spec.ts:19:23)
        at /home/danielc/.no-mistakes/worktrees/480af703ce12/01KXGR5T8NDANQ94GZ7E3PFAWG/front-end/e2e/application-form.spec.ts:43:5

    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
    test-results/application-form-Applicati-17538-ve-saves-it-and-it-persists-chromium/test-failed-1.png
    ────────────────────────────────────────────────────────────────────────────────────────────────

    attachment #2: video (video/webm) ──────────────────────────────────────────────────────────────
    test-results/application-form-Applicati-17538-ve-saves-it-and-it-persists-chromium/video.webm
    ────────────────────────────────────────────────────────────────────────────────────────────────

    Error Context: test-results/application-form-Applicati-17538-ve-saves-it-and-it-persists-chromium/error-context.md

  2) [chromium] › e2e/application-form.spec.ts:123:3 › Application form builder › an existing application locks the form in the builder and on every route 

    Test timeout of 30000ms exceeded while setting up "authenticatedPage".

    Error: locator.fill: Test timeout of 30000ms exceeded.
    Call log:
      - waiting for getByTestId('login-email-input')


       at pages/LoginPage.ts:93

      91 |
      92 |   async fillEmail(email: string): Promise<void> {
    > 93 |     await this.emailInput.fill(email);
         |                           ^
      94 |   }
      95 |
      96 |   async fillPassword(password: string): Promise<void> {
        at LoginPage.fillEmail (/home/danielc/.no-mistakes/worktrees/480af703ce12/01KXGR5T8NDANQ94GZ7E3PFAWG/front-end/e2e/pages/LoginPage.ts:93:27)
        at login (/home/daniel

... [8030 bytes truncated] ...

─────────────────────────────────────────────────
    test-results/new-market-org-New-market--42bfa-ated-market-carries-the-org-chromium/video.webm
    ────────────────────────────────────────────────────────────────────────────────────────────────

    Error Context: test-results/new-market-org-New-market--42bfa-ated-market-carries-the-org-chromium/error-context.md

  6) [chromium] › e2e/new-market-org.spec.ts:81:3 › New market - organization is required › a user with no organizations is pointed at organization creation 

    TimeoutError: page.waitForURL: Timeout 10000ms exceeded.
    =========================== logs ===========================
    waiting for navigation to "**/dashboard" until "load"
    ============================================================

       at pages/LoginPage.ts:112

      110 |
      111 |   async waitForDashboardRedirect(): Promise<void> {
    > 112 |     await this.page.waitForURL('**/dashboard', { timeout: 10000 });
          |                     ^
      113 |   }
      114 | }
      115 |
        at LoginPage.waitForDashboardRedirect (/home/danielc/.no-mistakes/worktrees/480af703ce12/01KXGR5T8NDANQ94GZ7E3PFAWG/front-end/e2e/pages/LoginPage.ts:112:21)
        at /home/danielc/.no-mistakes/worktrees/480af703ce12/01KXGR5T8NDANQ94GZ7E3PFAWG/front-end/e2e/new-market-org.spec.ts:86:21

    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
    test-results/new-market-org-New-market--fb13c-ed-at-organization-creation-chromium/test-failed-1.png
    ────────────────────────────────────────────────────────────────────────────────────────────────

    attachment #2: video (video/webm) ──────────────────────────────────────────────────────────────
    test-results/new-market-org-New-market--fb13c-ed-at-organization-creation-chromium/video.webm
    ────────────────────────────────────────────────────────────────────────────────────────────────

    Error Context: test-results/new-market-org-New-market--fb13c-ed-at-organization-creation-chromium/error-context.md

  7) [chromium] › e2e/tier2.spec.ts:158:3 › Tier 2 - Assignment CSV export › download CSV with expected columns 

    Error: expect(received).toBeTruthy()

    Received: false

      160 |       headers: { 'X-Owner-Email': TEST_USER.email },
      161 |     });
    > 162 |     expect(marketRes.ok()).toBeTruthy();
          |                            ^
      163 |     const marketData = (await marketRes.json()).market as Record<string, unknown>;
      164 |
      165 |     await page.evaluate(({ market, user }) => {
        at /home/danielc/.no-mistakes/worktrees/480af703ce12/01KXGR5T8NDANQ94GZ7E3PFAWG/front-end/e2e/tier2.spec.ts:162:28

    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
    test-results/tier2-Tier-2---Assignment--31725-d-CSV-with-expected-columns-chromium/test-failed-1.png
    ────────────────────────────────────────────────────────────────────────────────────────────────

    attachment #2: video (video/webm) ──────────────────────────────────────────────────────────────
    test-results/tier2-Tier-2---Assignment--31725-d-CSV-with-expected-columns-chromium/video.webm
    ────────────────────────────────────────────────────────────────────────────────────────────────

    Error Context: test-results/tier2-Tier-2---Assignment--31725-d-CSV-with-expected-columns-chromium/error-context.md

  8) [chromium] › e2e/tier2.spec.ts:216:3 › Tier 2 - Publish market › publish market and verify check-in URL 

    Error: expect(received).toBeTruthy()

    Received: false

      218 |       headers: { 'X-Owner-Email': TEST_USER.email },
      219 |     });
    > 220 |     expect(marketRes.ok()).toBeTruthy();
          |                            ^
      221 |     const marketData = (await marketRes.json()).market as Record<string, unknown>;
      222 |
      223 |     await page.evaluate(({ market, user }) => {
        at /home/danielc/.no-mistakes/worktrees/480af703ce12/01KXGR5T8NDANQ94GZ7E3PFAWG/front-end/e2e/tier2.spec.ts:220:28

    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
    test-results/tier2-Tier-2---Publish-mar-7d83c-ket-and-verify-check-in-URL-chromium/test-failed-1.png
    ────────────────────────────────────────────────────────────────────────────────────────────────

    attachment #2: video (video/webm) ──────────────────────────────────────────────────────────────
    test-results/tier2-Tier-2---Publish-mar-7d83c-ket-and-verify-check-in-URL-chromium/video.webm
    ────────────────────────────────────────────────────────────────────────────────────────────────

    Error Context: test-results/tier2-Tier-2---Publish-mar-7d83c-ket-and-verify-check-in-URL-chromium/error-context.md

  8 failed
    [chromium] › e2e/application-form.spec.ts:39:3 › Application form builder › organizer builds a form, previews it live, saves it, and it persists 
    [chromium] › e2e/application-form.spec.ts:123:3 › Application form builder › an existing application locks the form in the builder and on every route 
    [chromium] › e2e/floorplan.spec.ts:15:3 › Floorplan workflow E2E › create market from floorplan, complete wizard, and verify save 
    [chromium] › e2e/market-pipeline.spec.ts:28:3 › Market pipeline E2E › create market, configure, assign, view results, and publish 
    [chromium] › e2e/new-market-org.spec.ts:28:3 › New market - organization is required › org picker gates submission and the created market carries the org 
    [chromium] › e2e/new-market-org.spec.ts:81:3 › New market - organization is required › a user with no organizations is pointed at organization creation 
    [chromium] › e2e/tier2.spec.ts:158:3 › Tier 2 - Assignment CSV export › download CSV with expected columns 
    [chromium] › e2e/tier2.spec.ts:216:3 › Tier 2 - Publish market › publish market and verify check-in URL 
  23 passed (1.8m)
```
</details>
- Evidence: E2E test results on base commit (ad72cc35) — identical (local file: <code>/tmp/no-mistakes-evidence/01KXGR5T8NDANQ94GZ7E3PFAWG/e2e-base-results.txt</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `front-end/e2e/helpers/seedAssignedMarket.ts:86` - The new assignment-storing PUT at lines 86-101 uses an explicitly constructed body with hand-picked fields (id, name, creationDate, organizationId, roles, modificationList, setupObject, assignmentObject), diverging from the established ...market spread pattern in seedPublishedMarketWithAssignments (seeds.ts:339-352). This is safe for the current use case because the market is freshly created and all optional fields not included in the body (theme, discordWebhookUrl) are already at their None defaults. However, if the Market model gains new fields populated by intermediate processing between creation and this PUT that have non-None defaults, this explicit-list pattern could silently discard them. The spread pattern is more defensive against future model changes. The divergence is also limited to this helper, since seedPublishedMarketWithAssignments already does it the safe way.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`E2E_MONGO_CONTAINER=conventioner_mongodb E2E_BACKEND_CONTAINER=conventioner_backend npx playwright test --reporter=list` on target commit 0d2c2e6d (31 tests, 23 pass, 8 fail)</code>
- <code>`E2E_MONGO_CONTAINER=conventioner_mongodb E2E_BACKEND_CONTAINER=conventioner_backend npx playwright test --reporter=list` on base commit ad72cc35 (31 tests, 23 pass, 8 fail — identical results)</code>
- `Verified smoke.spec.ts test 23 ('navigate to markets and see seeded market') passes with new hasText filter discriminating 'Seed Market'`
- `Verified auth.spec.ts test 11 ('Discord posting sends assignment to Discord and shows success toast') passes with phase: 'draft' mock and mongoContainer() helper`
- `Verified auth.spec.ts tests 9-10 (password reset flow) pass using PasswordResetPage selectors all matching Vue components`
- `Verified checkin.spec.ts, tables.spec.ts, vendors.spec.ts pass — seedAssignedMarket's newly stored assignment via PUT is consumed correctly`
- `Verified all four containerNames.ts callers (legacyMarketDoc.ts, seedApplication.ts, verifiedUser.ts, auth.spec.ts) updated to single source of truth`
- `Verified PasswordResetPage: imported by auth.spec.ts, re-exported by fixtures.ts, all 14 data-testid selectors match PasswordResetRequestView.vue (6) and PasswordResetView.vue (8)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
