### PR TITLE
fix(front-end): prevent overlay elements from rendering behind background

### DIFF
--- a/front-end/e2e/new-market-org.spec.ts
+++ b/front-end/e2e/new-market-org.spec.ts
@@ -1,10 +1,10 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { test, expect, LoginPage, NewMarketPage, BACKEND_URL, TEST_USER } from './fixtures';
-import { ensureTestOrg, loginViaApi } from './helpers/seeds';
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { test, expect, LoginPage, NewMarketPage, BACKEND_URL, TEST_USER } from './fixtures'
+import { ensureTestOrg, loginViaApi } from './helpers/seeds'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const CSV_PATH = path.resolve(__dirname, 'fixtures', 'test-vendors.csv');
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CSV_PATH = path.resolve(__dirname, 'fixtures', 'test-vendors.csv')
 
 /**
  * Verified user that deliberately belongs to no organization.
@@ -13,7 +13,7 @@ const CSV_PATH = path.resolve(__dirname, 'fixtures', 'test-vendors.csv');
 const NO_ORG_USER = {
   email: 'e2e-noorg@example.com',
   password: 'e2enoorg123',
-};
+}
 
 /**
  * D14: every market requires an organization at creation. An org-less market is
@@ -22,91 +22,91 @@ const NO_ORG_USER = {
  */
 test.describe('New market - organization is required', () => {
   test.beforeAll(async ({ request }) => {
-    await ensureTestOrg(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);
-  });
+    await ensureTestOrg(request, BACKEND_URL, TEST_USER.email, TEST_USER.password)
+  })
 
   test('org picker gates submission and the created market carries the org', async ({
     authenticatedPage: page,
     request,
   }, testInfo) => {
-    await loginViaApi(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);
+    await loginViaApi(request, BACKEND_URL, TEST_USER.email, TEST_USER.password)
     const orgsRes = await request.get(`${BACKEND_URL}/organizations`, {
       headers: { 'X-Owner-Email': TEST_USER.email },
-    });
-    expect(orgsRes.ok()).toBe(true);
-    const orgs = (await orgsRes.json()).organizations as { id: string; name: string }[];
-    expect(orgs.length).toBeGreaterThan(0);
+    })
+    expect(orgsRes.ok()).toBe(true)
+    const orgs = (await orgsRes.json()).organizations as { id: string; name: string }[]
+    expect(orgs.length).toBeGreaterThan(0)
 
-    const newMarketPage = new NewMarketPage(page);
-    const marketName = `Org Required E2E ${Date.now()}`;
+    const newMarketPage = new NewMarketPage(page)
+    const marketName = `Org Required E2E ${Date.now()}`
 
-    await page.goto('/markets');
-    await page.getByTestId('markets-create-button').click();
-    await newMarketPage.waitForOverlay();
-    await newMarketPage.uploadCsv(CSV_PATH);
-    await newMarketPage.waitForNameInput();
+    await page.goto('/markets')
+    await page.getByTestId('markets-create-button').click()
+    await newMarketPage.waitForOverlay()
+    await newMarketPage.uploadCsv(CSV_PATH)
+    await newMarketPage.waitForNameInput()
 
     // The dropdown offers exactly the organizations GET /organizations returns.
-    expect((await newMarketPage.orgOptionLabels()).sort()).toEqual(orgs.map((o) => o.name).sort());
+    expect((await newMarketPage.orgOptionLabels()).sort()).toEqual(orgs.map((o) => o.name).sort())
 
     // Nothing selected yet, so the market cannot be created.
-    await expect(newMarketPage.orgSelect).toHaveValue('');
-    await expect(newMarketPage.submitButton).toBeDisabled();
-    await newMarketPage.fillMarketName(marketName);
-    await expect(newMarketPage.submitButton).toBeDisabled();
-    await page.screenshot({ path: testInfo.outputPath('01-submit-blocked-no-org.png') });
+    await expect(newMarketPage.orgSelect).toHaveValue('')
+    await expect(newMarketPage.submitButton).toBeDisabled()
+    await newMarketPage.fillMarketName(marketName)
+    await expect(newMarketPage.submitButton).toBeDisabled()
+    await page.screenshot({ path: testInfo.outputPath('01-submit-blocked-no-org.png') })
 
     // Picking an organization unlocks submission.
-    await newMarketPage.selectFirstOrg();
-    await expect(newMarketPage.submitButton).toBeEnabled();
-    await page.screenshot({ path: testInfo.outputPath('02-org-selected-submit-enabled.png') });
+    await newMarketPage.selectFirstOrg()
+    await expect(newMarketPage.submitButton).toBeEnabled()
+    await page.screenshot({ path: testInfo.outputPath('02-org-selected-submit-enabled.png') })
 
-    const selectedOrgId = await newMarketPage.orgSelect.inputValue();
-    expect(orgs.map((o) => o.id)).toContain(selectedOrgId);
+    const selectedOrgId = await newMarketPage.orgSelect.inputValue()
+    expect(orgs.map((o) => o.id)).toContain(selectedOrgId)
 
-    await newMarketPage.clickSubmit();
-    await newMarketPage.waitForSetupRedirect();
+    await newMarketPage.clickSubmit()
+    await newMarketPage.waitForSetupRedirect()
 
     // CSV must have been parsed — a silent failure is data-loss, not a pass.
     const uploadData = await page.evaluate(() => {
-      const stored = localStorage.getItem('upload');
-      return stored ? JSON.parse(stored) : null;
-    });
-    expect(uploadData, 'CSV parse result must be stored in localStorage').toBeTruthy();
-    expect(uploadData?.data?.data, 'PapaParse rows must be present').toBeTruthy();
-    expect(uploadData.data.data.length, 'Must have parsed CSV rows').toBeGreaterThan(0);
+      const stored = localStorage.getItem('upload')
+      return stored ? JSON.parse(stored) : null
+    })
+    expect(uploadData, 'CSV parse result must be stored in localStorage').toBeTruthy()
+    expect(uploadData?.data?.data, 'PapaParse rows must be present').toBeTruthy()
+    expect(uploadData.data.data.length, 'Must have parsed CSV rows').toBeGreaterThan(0)
 
     // The persisted market is stamped with the organization that was chosen.
     const marketsRes = await request.get(`${BACKEND_URL}/markets`, {
       headers: { 'X-Owner-Email': TEST_USER.email },
-    });
-    expect(marketsRes.ok()).toBe(true);
-    const markets = (await marketsRes.json()).markets as { name: string; organizationId?: string }[];
-    const created = markets.find((m) => m.name === marketName);
-    expect(created).toBeTruthy();
-    expect(created?.organizationId).toBe(selectedOrgId);
-  });
+    })
+    expect(marketsRes.ok()).toBe(true)
+    const markets = (await marketsRes.json()).markets as { name: string; organizationId?: string }[]
+    const created = markets.find((m) => m.name === marketName)
+    expect(created).toBeTruthy()
+    expect(created?.organizationId).toBe(selectedOrgId)
+  })
 
   test('a user with no organizations is pointed at organization creation', async ({
     page,
   }, testInfo) => {
-    const loginPage = new LoginPage(page);
-    await loginPage.login(NO_ORG_USER.email, NO_ORG_USER.password);
-    await loginPage.waitForDashboardRedirect();
+    const loginPage = new LoginPage(page)
+    await loginPage.login(NO_ORG_USER.email, NO_ORG_USER.password)
+    await loginPage.waitForDashboardRedirect()
 
-    const newMarketPage = new NewMarketPage(page);
-    await page.goto('/markets');
-    await page.getByTestId('markets-create-button').click();
-    await newMarketPage.waitForOverlay();
-    await newMarketPage.uploadCsv(CSV_PATH);
-    await newMarketPage.waitForNameInput();
+    const newMarketPage = new NewMarketPage(page)
+    await page.goto('/markets')
+    await page.getByTestId('markets-create-button').click()
+    await newMarketPage.waitForOverlay()
+    await newMarketPage.uploadCsv(CSV_PATH)
+    await newMarketPage.waitForNameInput()
 
-    await expect(newMarketPage.orgEmptyHint).toBeVisible();
-    await expect(newMarketPage.orgSelect).toBeDisabled();
-    await expect(newMarketPage.submitButton).toBeDisabled();
-    await page.screenshot({ path: testInfo.outputPath('03-zero-org-fallback.png') });
+    await expect(newMarketPage.orgEmptyHint).toBeVisible()
+    await expect(newMarketPage.orgSelect).toBeDisabled()
+    await expect(newMarketPage.submitButton).toBeDisabled()
+    await page.screenshot({ path: testInfo.outputPath('03-zero-org-fallback.png') })
 
-    await newMarketPage.orgCreateLink.click();
-    await expect(page).toHaveURL(/\/organizations/);
-  });
-});
+    await newMarketPage.orgCreateLink.click()
+    await expect(page).toHaveURL(/\/organizations/)
+  })
+})

--- a/front-end/e2e/new-market-org.spec.ts
+++ b/front-end/e2e/new-market-org.spec.ts
@@ -67,6 +67,15 @@ test.describe('New market - organization is required', () => {
     await newMarketPage.clickSubmit();
     await newMarketPage.waitForSetupRedirect();
 
+    // CSV must have been parsed — a silent failure is data-loss, not a pass.
+    const uploadData = await page.evaluate(() => {
+      const stored = localStorage.getItem('upload');
+      return stored ? JSON.parse(stored) : null;
+    });
+    expect(uploadData, 'CSV parse result must be stored in localStorage').toBeTruthy();
+    expect(uploadData?.data?.data, 'PapaParse rows must be present').toBeTruthy();
+    expect(uploadData.data.data.length, 'Must have parsed CSV rows').toBeGreaterThan(0);
+
     // The persisted market is stamped with the organization that was chosen.
     const marketsRes = await request.get(`${BACKEND_URL}/markets`, {
       headers: { 'X-Owner-Email': TEST_USER.email },

--- a/front-end/src/components/elements/ElementFileDrop.vue
+++ b/front-end/src/components/elements/ElementFileDrop.vue
@@ -1,19 +1,25 @@
 <script setup lang="ts">
-import Papa from 'papaparse';
+import Papa from 'papaparse'
 
-import IconImport from '@/components/icons/IconImport.vue';
+import IconImport from '@/components/icons/IconImport.vue'
 
 import { useDropZone } from '@vueuse/core'
 import { useFileDialog } from '@vueuse/core'
-import { shallowRef, useTemplateRef, defineEmits } from 'vue';
+import { shallowRef, useTemplateRef, defineEmits } from 'vue'
 
 defineProps<{
-  isOpen: boolean;
-}>();
+  isOpen: boolean
+}>()
 
-const emit = defineEmits(['file-uploaded', 'source-data-uploaded']);
+const emit = defineEmits(['file-uploaded', 'source-data-uploaded'])
 
-const fileData = shallowRef<{ name: string, size: number, type: string, lastModified: number, data: unknown }>()
+const fileData = shallowRef<{
+  name: string
+  size: number
+  type: string
+  lastModified: number
+  data: unknown
+}>()
 const dropZoneRef = useTemplateRef<HTMLElement>('dropZoneRef')
 
 const {} = useDropZone(dropZoneRef, { dataTypes: ['text/csv'], onDrop: onDrop })
@@ -24,22 +30,22 @@ const { open, onChange } = useFileDialog({
 })
 
 interface FileData {
-  name: string;
-  size: number;
-  type: string;
-  lastModified: number;
-  data: unknown;
+  name: string
+  size: number
+  type: string
+  lastModified: number
+  data: unknown
 }
 
 function onDrop(files: File[] | null) {
-  const file = files ? files[0] : null;
-  handleUpload(file);
+  const file = files ? files[0] : null
+  handleUpload(file)
 }
 
 onChange((files: FileList | null) => {
-  const file = files ? files[0] : null;
-  handleUpload(file);
-});
+  const file = files ? files[0] : null
+  handleUpload(file)
+})
 
 async function handleUpload(file: File | null) {
   if (file) {
@@ -49,26 +55,25 @@ async function handleUpload(file: File | null) {
       type: file.type,
       lastModified: file.lastModified,
       data: await readCSVFile(file),
-    }))(file);
+    }))(file)
 
-    emit('file-uploaded', fileData.value);
-    emit('source-data-uploaded', [file]);
+    emit('file-uploaded', fileData.value)
+    emit('source-data-uploaded', [file])
   }
 }
 
 const readCSVFile = (file: File) => {
   return new Promise((resolve, reject) => {
-    const reader = new FileReader();
+    const reader = new FileReader()
     reader.onload = () => {
-      const text: string = reader.result ? reader.result as string : "";
-      const result = Papa.parse(text, { header: true });
-      resolve(result);
-    };
-    reader.onerror = (error) => reject(error);
-    reader.readAsText(file);
-  });
-};
-
+      const text: string = reader.result ? (reader.result as string) : ''
+      const result = Papa.parse(text, { header: true })
+      resolve(result)
+    }
+    reader.onerror = (error) => reject(error)
+    reader.readAsText(file)
+  })
+}
 </script>
 
 <template>
@@ -76,7 +81,16 @@ const readCSVFile = (file: File) => {
     <div class="file-drop-icons">
       <IconImport />
       <h3>
-        <span><button class="file-button" type="button" @click="open()" data-testid="file-drop-choose-button">Choose a file</button></span>
+        <span
+          ><button
+            class="file-button"
+            type="button"
+            @click="open()"
+            data-testid="file-drop-choose-button"
+          >
+            Choose a file
+          </button></span
+        >
         <span class="file-text"> or drag it here </span>
       </h3>
     </div>
@@ -126,6 +140,6 @@ const readCSVFile = (file: File) => {
   line-height: 15px;
   text-align: center;
 
-  color: #FFFFFF;
+  color: #ffffff;
 }
 </style>

--- a/front-end/src/components/elements/ElementFileDrop.vue
+++ b/front-end/src/components/elements/ElementFileDrop.vue
@@ -85,6 +85,7 @@ const readCSVFile = (file: File) => {
 
 <style scoped>
 .file-container {
+  position: relative;
   width: 50%;
   height: 50%;
   display: flex;

--- a/front-end/src/views/LoadMarketOverlay.vue
+++ b/front-end/src/views/LoadMarketOverlay.vue
@@ -104,6 +104,7 @@ const formatDate = (dateString: string) => {
 }
 
 .window {
+    position: relative;
     width: 70%;
     max-width: 900px;
     height: 85%;

--- a/front-end/src/views/LoadMarketOverlay.vue
+++ b/front-end/src/views/LoadMarketOverlay.vue
@@ -1,289 +1,304 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
-import { useRouter } from 'vue-router';
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { type Market } from '@/assets/types/datatypes.ts'
-import { api } from '@/utils/api';
-import { parseMarketFromApi, pathAfterLoadingMarket } from '@/utils/market';
-import { getRoleDisplayName } from '@/utils/permissions';
+import { api } from '@/utils/api'
+import { parseMarketFromApi, pathAfterLoadingMarket } from '@/utils/market'
+import { getRoleDisplayName } from '@/utils/permissions'
 
 defineProps<{
-    loadOpen: boolean;
-}>();
+  loadOpen: boolean
+}>()
 
-const router = useRouter();
-const markets = ref<Market[]>([]);
+const router = useRouter()
+const markets = ref<Market[]>([])
 
 onMounted(async () => {
-    const response = await api.get('/markets');
+  const response = await api.get('/markets')
 
-    for (const market of response.data.markets) {
-        markets.value.push(parseMarketFromApi(market));
-    }
-});
+  for (const market of response.data.markets) {
+    markets.value.push(parseMarketFromApi(market))
+  }
+})
 
 const handleLoadMarket = async (market: Market) => {
-    localStorage.removeItem("market");
-    localStorage.setItem("market", JSON.stringify(market));
-    router.push(pathAfterLoadingMarket(market));
+  localStorage.removeItem('market')
+  localStorage.setItem('market', JSON.stringify(market))
+  router.push(pathAfterLoadingMarket(market))
 }
 
 const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', { 
-        year: 'numeric', 
-        month: 'long', 
-        day: 'numeric' 
-    });
+  const date = new Date(dateString)
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
 }
 </script>
 
 <template>
-    <div class="container" :style="{ visibility: loadOpen ? 'visible' : 'hidden' }">
-        <div class="background" @click="$emit('loadClose')" :style="{ opacity: loadOpen ? '100%' : '0%' }" data-testid="load-market-overlay-background">
-        </div>
-        <div class="window">
-            <div class="header">
-                <h2>Load Market</h2>
-                <p v-if="markets.length === 0" class="empty-state">No markets found</p>
+  <div class="container" :style="{ visibility: loadOpen ? 'visible' : 'hidden' }">
+    <div
+      class="background"
+      @click="$emit('loadClose')"
+      :style="{ opacity: loadOpen ? '100%' : '0%' }"
+      data-testid="load-market-overlay-background"
+    ></div>
+    <div class="window">
+      <div class="header">
+        <h2>Load Market</h2>
+        <p v-if="markets.length === 0" class="empty-state">No markets found</p>
+      </div>
+      <div class="markets-container">
+        <div v-for="market in markets" :key="market.id" class="market-card">
+          <div class="card-header">
+            <h3>{{ market.name }}</h3>
+          </div>
+          <div class="card-content">
+            <div class="info-group">
+              <div class="info-row">
+                <span class="info-label">Created:</span>
+                <span class="info-value">{{ formatDate(market.creationDate) }}</span>
+              </div>
+              <div v-if="market.organizationName" class="info-row">
+                <span class="info-label">Organization:</span>
+                <span class="info-value">{{ market.organizationName }}</span>
+              </div>
+              <div v-if="market.userRole" class="info-row">
+                <span class="info-label">Your role:</span>
+                <span
+                  class="info-value role-badge"
+                  :class="`role-${market.userRole.toLowerCase()}`"
+                >
+                  {{ getRoleDisplayName(market.userRole) }}
+                </span>
+              </div>
             </div>
-            <div class="markets-container">
-                <div v-for="market in markets" :key="market.id" class="market-card">
-                    <div class="card-header">
-                        <h3>{{ market.name }}</h3>
-                    </div>
-                    <div class="card-content">
-                        <div class="info-group">
-                            <div class="info-row">
-                                <span class="info-label">Created:</span>
-                                <span class="info-value">{{ formatDate(market.creationDate) }}</span>
-                            </div>
-                            <div v-if="market.organizationName" class="info-row">
-                                <span class="info-label">Organization:</span>
-                                <span class="info-value">{{ market.organizationName }}</span>
-                            </div>
-                            <div v-if="market.userRole" class="info-row">
-                                <span class="info-label">Your role:</span>
-                                <span class="info-value role-badge" :class="`role-${market.userRole.toLowerCase()}`">
-                                    {{ getRoleDisplayName(market.userRole) }}
-                                </span>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="card-footer">
-                        <button @click="handleLoadMarket(market)" class="load-button" data-testid="load-market-card-button">Load Market</button>
-                    </div>
-                </div>
-            </div>
+          </div>
+          <div class="card-footer">
+            <button
+              @click="handleLoadMarket(market)"
+              class="load-button"
+              data-testid="load-market-card-button"
+            >
+              Load Market
+            </button>
+          </div>
         </div>
+      </div>
     </div>
+  </div>
 </template>
 
 <style scoped>
 .container {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
 }
 
 .background {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.5);
-    opacity: 0%;
-    transition: opacity 0.15s ease-in-out, visibility 0.15s ease-in-out;
-    z-index: 0;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0%;
+  transition:
+    opacity 0.15s ease-in-out,
+    visibility 0.15s ease-in-out;
+  z-index: 0;
 }
 
 .window {
-    position: relative;
-    width: 70%;
-    max-width: 900px;
-    height: 85%;
-    display: flex;
-    flex-direction: column;
-    background: white;
-    border-radius: 12px;
-    z-index: 1;
-    padding: 0;
-    overflow: hidden;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+  position: relative;
+  width: 70%;
+  max-width: 900px;
+  height: 85%;
+  display: flex;
+  flex-direction: column;
+  background: white;
+  border-radius: 12px;
+  z-index: 1;
+  padding: 0;
+  overflow: hidden;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
 }
 
 .header {
-    padding: 32px 40px 24px;
-    border-bottom: 1px solid var(--mm-grey);
+  padding: 32px 40px 24px;
+  border-bottom: 1px solid var(--mm-grey);
 }
 
 .header h2 {
-    margin: 0;
-    font-size: 28px;
-    font-weight: 600;
-    color: var(--mm-black);
-    font-family: 'Outfit Regular', sans-serif;
+  margin: 0;
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--mm-black);
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .empty-state {
-    margin-top: 12px;
-    color: #666;
-    font-size: 14px;
+  margin-top: 12px;
+  color: #666;
+  font-size: 14px;
 }
 
 .markets-container {
-    flex: 1;
-    overflow-y: auto;
-    padding: 24px 40px 32px;
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px 40px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }
 
 .market-card {
-    width: 100%;
-    padding: 16px 24px;
-    border: 1.5px solid var(--mm-grey);
-    border-radius: 10px;
-    background: white;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 24px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  width: 100%;
+  padding: 16px 24px;
+  border: 1.5px solid var(--mm-grey);
+  border-radius: 10px;
+  background: white;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 24px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
 .market-card:hover {
-    border-color: var(--mm-green);
-    box-shadow: 0 4px 12px rgba(73, 176, 150, 0.15);
-    transform: translateY(-2px);
+  border-color: var(--mm-green);
+  box-shadow: 0 4px 12px rgba(73, 176, 150, 0.15);
+  transform: translateY(-2px);
 }
 
 .card-header {
-    flex-shrink: 0;
-    min-width: 200px;
+  flex-shrink: 0;
+  min-width: 200px;
 }
 
 .card-header h3 {
-    margin: 0;
-    color: var(--mm-black);
-    font-size: 18px;
-    font-weight: 600;
-    font-family: 'Outfit Regular', sans-serif;
+  margin: 0;
+  color: var(--mm-black);
+  font-size: 18px;
+  font-weight: 600;
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .card-content {
-    flex: 1;
-    display: flex;
-    align-items: center;
+  flex: 1;
+  display: flex;
+  align-items: center;
 }
 
 .info-group {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .info-row {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 12px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
 }
 
 .info-label {
-    font-weight: 500;
-    color: #666;
-    font-size: 13px;
-    min-width: 70px;
+  font-weight: 500;
+  color: #666;
+  font-size: 13px;
+  min-width: 70px;
 }
 
 .info-value {
-    color: var(--mm-black);
-    font-size: 14px;
+  color: var(--mm-black);
+  font-size: 14px;
 }
 
 .role-badge {
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 4px;
-    font-weight: 500;
-    font-size: 12px;
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-weight: 500;
+  font-size: 12px;
 }
 
 .role-owner {
-    background: #e3f2fd;
-    color: #1976d2;
+  background: #e3f2fd;
+  color: #1976d2;
 }
 
 .role-admin {
-    background: #f3e5f5;
-    color: #7b1fa2;
+  background: #f3e5f5;
+  color: #7b1fa2;
 }
 
 .role-editor {
-    background: #e8f5e9;
-    color: #388e3c;
+  background: #e8f5e9;
+  color: #388e3c;
 }
 
 .role-viewer {
-    background: #fff3e0;
-    color: #f57c00;
+  background: #fff3e0;
+  color: #f57c00;
 }
 
 .card-footer {
-    flex-shrink: 0;
-    display: flex;
-    justify-content: flex-end;
+  flex-shrink: 0;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .load-button {
-    padding: 8px 20px;
-    background: var(--mm-green);
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 14px;
-    font-weight: 500;
-    font-family: 'Outfit Regular', sans-serif;
-    box-shadow: 0 2px 4px rgba(73, 176, 150, 0.2);
-    white-space: nowrap;
+  padding: 8px 20px;
+  background: var(--mm-green);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  font-family: 'Outfit Regular', sans-serif;
+  box-shadow: 0 2px 4px rgba(73, 176, 150, 0.2);
+  white-space: nowrap;
 }
 
 .load-button:hover {
-    background: #3a9a82;
-    box-shadow: 0 4px 8px rgba(73, 176, 150, 0.3);
-    transform: translateY(-1px);
+  background: #3a9a82;
+  box-shadow: 0 4px 8px rgba(73, 176, 150, 0.3);
+  transform: translateY(-1px);
 }
 
 .load-button:active {
-    transform: translateY(0);
-    box-shadow: 0 2px 4px rgba(73, 176, 150, 0.2);
+  transform: translateY(0);
+  box-shadow: 0 2px 4px rgba(73, 176, 150, 0.2);
 }
 
 /* Scrollbar styling */
 .markets-container::-webkit-scrollbar {
-    width: 8px;
+  width: 8px;
 }
 
 .markets-container::-webkit-scrollbar-track {
-    background: #f1f1f1;
-    border-radius: 4px;
+  background: #f1f1f1;
+  border-radius: 4px;
 }
 
 .markets-container::-webkit-scrollbar-thumb {
-    background: var(--mm-grey);
-    border-radius: 4px;
+  background: var(--mm-grey);
+  border-radius: 4px;
 }
 
 .markets-container::-webkit-scrollbar-thumb:hover {
-    background: #999;
+  background: #999;
 }
 </style>

--- a/front-end/src/views/ManageMarketOverlay.vue
+++ b/front-end/src/views/ManageMarketOverlay.vue
@@ -419,6 +419,7 @@ function handleClose() {
 }
 
 .window {
+    position: relative;
     width: 70%;
     max-width: 600px;
     max-height: 85%;

--- a/front-end/src/views/ManageMarketOverlay.vue
+++ b/front-end/src/views/ManageMarketOverlay.vue
@@ -359,10 +359,7 @@ function handleClose() {
           </div>
           <button
             class="add-user-button"
-            @click="
-              showAddOrgForm = !showAddOrgForm
-              if (showAddOrgForm) fetchUserOrgs()
-            "
+            @click="(showAddOrgForm = !showAddOrgForm) && fetchUserOrgs()"
             data-testid="manage-market-add-org-button"
           >
             {{ showAddOrgForm ? 'Cancel' : 'Add organization' }}

--- a/front-end/src/views/ManageMarketOverlay.vue
+++ b/front-end/src/views/ManageMarketOverlay.vue
@@ -1,772 +1,839 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue';
-import { type Market, MarketRole } from '@/assets/types/datatypes';
-import { api, getApiErrorMessage } from '@/utils/api';
-import { parseMarketFromApi } from '@/utils/market';
-import { getRoleDisplayName, canManageRoles, canChangeRole, getRolesForChange } from '@/utils/permissions';
+import { ref, watch } from 'vue'
+import { type Market, MarketRole } from '@/assets/types/datatypes'
+import { api, getApiErrorMessage } from '@/utils/api'
+import { parseMarketFromApi } from '@/utils/market'
+import {
+  getRoleDisplayName,
+  canManageRoles,
+  canChangeRole,
+  getRolesForChange,
+} from '@/utils/permissions'
 
 const props = defineProps<{
-    manageOpen: boolean;
-    market: Market | null;
-}>();
+  manageOpen: boolean
+  market: Market | null
+}>()
 
 const emit = defineEmits<{
-    manageClose: [];
-}>();
+  manageClose: []
+}>()
 
-const marketData = ref<Market | null>(null);
-const loading = ref(false);
-const errorMessage = ref('');
-const renameValue = ref('');
-const showAddUserForm = ref(false);
-const newUserEmail = ref('');
-const newUserRole = ref<MarketRole>(MarketRole.Editor);
-const addUserError = ref('');
-const showAddOrgForm = ref(false);
-const newOrgName = ref('');
-const addOrgError = ref('');
-const userOrgs = ref<Array<{ id: string; name: string }>>([]);
-const renameError = ref('');
-const deleteConfirming = ref(false);
-const deleteError = ref('');
+const marketData = ref<Market | null>(null)
+const loading = ref(false)
+const errorMessage = ref('')
+const renameValue = ref('')
+const showAddUserForm = ref(false)
+const newUserEmail = ref('')
+const newUserRole = ref<MarketRole>(MarketRole.Editor)
+const addUserError = ref('')
+const showAddOrgForm = ref(false)
+const newOrgName = ref('')
+const addOrgError = ref('')
+const userOrgs = ref<Array<{ id: string; name: string }>>([])
+const renameError = ref('')
+const deleteConfirming = ref(false)
+const deleteError = ref('')
 
-const addableRoles = [MarketRole.Admin, MarketRole.Editor, MarketRole.Viewer];
+const addableRoles = [MarketRole.Admin, MarketRole.Editor, MarketRole.Viewer]
 
 watch(
-    () => [props.manageOpen, props.market] as const,
-    async ([open, market]) => {
-        if (open && market) {
-            marketData.value = market;
-            renameValue.value = market.name;
-            showAddUserForm.value = false;
-            showAddOrgForm.value = false;
-            deleteConfirming.value = false;
-            errorMessage.value = '';
-            addUserError.value = '';
-            addOrgError.value = '';
-            renameError.value = '';
-            deleteError.value = '';
-            await fetchMarket();
-        } else {
-            marketData.value = null;
-        }
-    },
-    { immediate: true }
-);
+  () => [props.manageOpen, props.market] as const,
+  async ([open, market]) => {
+    if (open && market) {
+      marketData.value = market
+      renameValue.value = market.name
+      showAddUserForm.value = false
+      showAddOrgForm.value = false
+      deleteConfirming.value = false
+      errorMessage.value = ''
+      addUserError.value = ''
+      addOrgError.value = ''
+      renameError.value = ''
+      deleteError.value = ''
+      await fetchMarket()
+    } else {
+      marketData.value = null
+    }
+  },
+  { immediate: true },
+)
 
 async function fetchMarket(showLoading = true) {
-    if (!marketData.value) return;
-    if (showLoading) loading.value = true;
-    errorMessage.value = '';
-    try {
-        const response = await api.get(`/markets/${encodeURIComponent(marketData.value.id)}`);
-        const m = response.data.market;
-        marketData.value = parseMarketFromApi(m);
-        renameValue.value = marketData.value.name;
-    } catch (err) {
-        errorMessage.value = getApiErrorMessage(err, 'Failed to load market');
-    } finally {
-        if (showLoading) loading.value = false;
-    }
+  if (!marketData.value) return
+  if (showLoading) loading.value = true
+  errorMessage.value = ''
+  try {
+    const response = await api.get(`/markets/${encodeURIComponent(marketData.value.id)}`)
+    const m = response.data.market
+    marketData.value = parseMarketFromApi(m)
+    renameValue.value = marketData.value.name
+  } catch (err) {
+    errorMessage.value = getApiErrorMessage(err, 'Failed to load market')
+  } finally {
+    if (showLoading) loading.value = false
+  }
 }
 
 function getUserList(): Array<{ userId: string; email: string; role: MarketRole }> {
-    if (!marketData.value?.roles) return [];
-    return Object.entries(marketData.value.roles).map(([userId, role]) => ({
-        userId,
-        email: marketData.value!.roleEmails?.[userId] ?? userId,
-        role: role as MarketRole,
-    }));
+  if (!marketData.value?.roles) return []
+  return Object.entries(marketData.value.roles).map(([userId, role]) => ({
+    userId,
+    email: marketData.value!.roleEmails?.[userId] ?? userId,
+    role: role as MarketRole,
+  }))
 }
 
 function getOrganizationList(): string[] {
-    if (!marketData.value?.organizationName) return [];
-    return [marketData.value.organizationName];
+  if (!marketData.value?.organizationName) return []
+  return [marketData.value.organizationName]
 }
 
 function getAvailableOrgsForAdd(): Array<{ id: string; name: string }> {
-    const currentId = marketData.value?.organizationId;
-    return userOrgs.value.filter((org) => org.id !== currentId);
+  const currentId = marketData.value?.organizationId
+  return userOrgs.value.filter((org) => org.id !== currentId)
 }
 
 async function fetchUserOrgs() {
-    try {
-        const response = await api.get('/organizations');
-        userOrgs.value = response.data.organizations || [];
-    } catch {
-        userOrgs.value = [];
-    }
+  try {
+    const response = await api.get('/organizations')
+    userOrgs.value = response.data.organizations || []
+  } catch {
+    userOrgs.value = []
+  }
 }
 
 function canRemoveUser(targetRole: MarketRole): boolean {
-    if (targetRole === MarketRole.Owner) return false;
-    const userRole = marketData.value?.userRole;
-    if (!userRole) return false;
-    return canManageRoles(userRole, targetRole);
+  if (targetRole === MarketRole.Owner) return false
+  const userRole = marketData.value?.userRole
+  if (!userRole) return false
+  return canManageRoles(userRole, targetRole)
 }
 
 async function handleAddUser() {
-    if (!marketData.value || !newUserEmail.value.trim()) return;
-    addUserError.value = '';
-    try {
-        await api.post(
-            `/markets/${encodeURIComponent(marketData.value.id)}/roles`,
-            { user_email: newUserEmail.value.trim(), role: newUserRole.value },
-        );
-        showAddUserForm.value = false;
-        newUserEmail.value = '';
-        newUserRole.value = MarketRole.Editor;
-        await fetchMarket(false);
-    } catch (err) {
-        addUserError.value = getApiErrorMessage(err, 'Failed to add user');
-    }
+  if (!marketData.value || !newUserEmail.value.trim()) return
+  addUserError.value = ''
+  try {
+    await api.post(`/markets/${encodeURIComponent(marketData.value.id)}/roles`, {
+      user_email: newUserEmail.value.trim(),
+      role: newUserRole.value,
+    })
+    showAddUserForm.value = false
+    newUserEmail.value = ''
+    newUserRole.value = MarketRole.Editor
+    await fetchMarket(false)
+  } catch (err) {
+    addUserError.value = getApiErrorMessage(err, 'Failed to add user')
+  }
 }
 
 async function handleRemoveUser(userId: string) {
-    if (!marketData.value) return;
-    try {
-        await api.delete(
-            `/markets/${encodeURIComponent(marketData.value.id)}/roles/${encodeURIComponent(userId)}`,
-        );
-        await fetchMarket(false);
-    } catch (err) {
-        errorMessage.value = getApiErrorMessage(err, 'Failed to remove user');
-    }
+  if (!marketData.value) return
+  try {
+    await api.delete(
+      `/markets/${encodeURIComponent(marketData.value.id)}/roles/${encodeURIComponent(userId)}`,
+    )
+    await fetchMarket(false)
+  } catch (err) {
+    errorMessage.value = getApiErrorMessage(err, 'Failed to remove user')
+  }
 }
 
 async function handleRoleChange(userId: string, newRole: MarketRole) {
-    if (!marketData.value) return;
-    try {
-        await api.put(
-            `/markets/${encodeURIComponent(marketData.value.id)}/roles/${encodeURIComponent(userId)}`,
-            { role: newRole },
-        );
-        await fetchMarket(false);
-    } catch (err) {
-        errorMessage.value = getApiErrorMessage(err, 'Failed to update role');
-    }
+  if (!marketData.value) return
+  try {
+    await api.put(
+      `/markets/${encodeURIComponent(marketData.value.id)}/roles/${encodeURIComponent(userId)}`,
+      { role: newRole },
+    )
+    await fetchMarket(false)
+  } catch (err) {
+    errorMessage.value = getApiErrorMessage(err, 'Failed to update role')
+  }
 }
 
 async function handleAddOrg() {
-    if (!marketData.value || !newOrgName.value.trim()) return;
-    addOrgError.value = '';
-    try {
-        const org = userOrgs.value.find((o) => o.name === newOrgName.value.trim());
-        const orgId = org?.id ?? newOrgName.value.trim();
-        const updated = { ...marketData.value, organizationId: orgId };
-        await api.put(`/markets/${encodeURIComponent(marketData.value.id)}`, updated);
-        marketData.value = { ...marketData.value, organizationId: orgId, organizationName: org?.name ?? newOrgName.value.trim() };
-        showAddOrgForm.value = false;
-        newOrgName.value = '';
-        await fetchMarket(false);
-    } catch (err) {
-        addOrgError.value = getApiErrorMessage(err, 'Failed to add organization');
+  if (!marketData.value || !newOrgName.value.trim()) return
+  addOrgError.value = ''
+  try {
+    const org = userOrgs.value.find((o) => o.name === newOrgName.value.trim())
+    const orgId = org?.id ?? newOrgName.value.trim()
+    const updated = { ...marketData.value, organizationId: orgId }
+    await api.put(`/markets/${encodeURIComponent(marketData.value.id)}`, updated)
+    marketData.value = {
+      ...marketData.value,
+      organizationId: orgId,
+      organizationName: org?.name ?? newOrgName.value.trim(),
     }
+    showAddOrgForm.value = false
+    newOrgName.value = ''
+    await fetchMarket(false)
+  } catch (err) {
+    addOrgError.value = getApiErrorMessage(err, 'Failed to add organization')
+  }
 }
 
 async function handleRemoveOrg() {
-    if (!marketData.value) return;
-    try {
-        const updated = { ...marketData.value, organizationId: null };
-        await api.put(`/markets/${encodeURIComponent(marketData.value.id)}`, updated);
-        marketData.value = { ...marketData.value, organizationId: undefined, organizationName: undefined };
-        await fetchMarket(false);
-    } catch (err) {
-        errorMessage.value = getApiErrorMessage(err, 'Failed to remove organization');
+  if (!marketData.value) return
+  try {
+    const updated = { ...marketData.value, organizationId: null }
+    await api.put(`/markets/${encodeURIComponent(marketData.value.id)}`, updated)
+    marketData.value = {
+      ...marketData.value,
+      organizationId: undefined,
+      organizationName: undefined,
     }
+    await fetchMarket(false)
+  } catch (err) {
+    errorMessage.value = getApiErrorMessage(err, 'Failed to remove organization')
+  }
 }
 
 function canRemoveOrg(): boolean {
-    const userRole = marketData.value?.userRole;
-    if (!userRole) return false;
-    return userRole === MarketRole.Owner || userRole === MarketRole.Admin;
+  const userRole = marketData.value?.userRole
+  if (!userRole) return false
+  return userRole === MarketRole.Owner || userRole === MarketRole.Admin
 }
 
 async function handleRename() {
-    if (!marketData.value || renameValue.value.trim() === marketData.value.name) return;
-    renameError.value = '';
-    try {
-        const updated = { ...marketData.value, name: renameValue.value.trim() };
-        await api.put(`/markets/${encodeURIComponent(marketData.value.id)}`, updated);
-        marketData.value = { ...marketData.value, name: renameValue.value.trim() };
-    } catch (err) {
-        const msg = getApiErrorMessage(err, '');
-        renameError.value = msg.toLowerCase().includes('already exists') ? 'A market with this name already exists' : msg || 'Failed to rename';
-    }
+  if (!marketData.value || renameValue.value.trim() === marketData.value.name) return
+  renameError.value = ''
+  try {
+    const updated = { ...marketData.value, name: renameValue.value.trim() }
+    await api.put(`/markets/${encodeURIComponent(marketData.value.id)}`, updated)
+    marketData.value = { ...marketData.value, name: renameValue.value.trim() }
+  } catch (err) {
+    const msg = getApiErrorMessage(err, '')
+    renameError.value = msg.toLowerCase().includes('already exists')
+      ? 'A market with this name already exists'
+      : msg || 'Failed to rename'
+  }
 }
 
 async function handleDeleteConfirm() {
-    if (!marketData.value) return;
-    deleteError.value = '';
-    try {
-        await api.delete(`/markets/${encodeURIComponent(marketData.value.id)}`);
-        emit('manageClose');
-    } catch (err) {
-        deleteError.value = getApiErrorMessage(err, 'Failed to delete market');
-    }
+  if (!marketData.value) return
+  deleteError.value = ''
+  try {
+    await api.delete(`/markets/${encodeURIComponent(marketData.value.id)}`)
+    emit('manageClose')
+  } catch (err) {
+    deleteError.value = getApiErrorMessage(err, 'Failed to delete market')
+  }
 }
 
 function handleDeleteCancel() {
-    deleteConfirming.value = false;
-    deleteError.value = '';
+  deleteConfirming.value = false
+  deleteError.value = ''
 }
 
 function handleClose() {
-    emit('manageClose');
+  emit('manageClose')
 }
 </script>
 
 <template>
-    <div class="container" :style="{ visibility: manageOpen ? 'visible' : 'hidden' }">
-        <div class="background" @click="handleClose" :style="{ opacity: manageOpen ? '100%' : '0%' }" data-testid="manage-market-overlay-background" />
-        <div v-if="manageOpen && market" class="window">
-            <div class="header">
-                <h2>Manage market</h2>
-                <p v-if="marketData" class="market-name">{{ marketData.name }}</p>
-                <p v-if="errorMessage" class="error-state">{{ errorMessage }}</p>
+  <div class="container" :style="{ visibility: manageOpen ? 'visible' : 'hidden' }">
+    <div
+      class="background"
+      @click="handleClose"
+      :style="{ opacity: manageOpen ? '100%' : '0%' }"
+      data-testid="manage-market-overlay-background"
+    />
+    <div v-if="manageOpen && market" class="window">
+      <div class="header">
+        <h2>Manage market</h2>
+        <p v-if="marketData" class="market-name">{{ marketData.name }}</p>
+        <p v-if="errorMessage" class="error-state">{{ errorMessage }}</p>
+      </div>
+      <div v-if="loading" class="loading-state">Loading...</div>
+      <div v-else-if="marketData" class="content">
+        <section class="section">
+          <h3>Users with access</h3>
+          <div class="users-list">
+            <div v-for="{ userId, email, role } in getUserList()" :key="userId" class="user-card">
+              <span class="user-email">{{ email }}</span>
+              <span
+                v-if="!marketData?.userRole || !canChangeRole(marketData.userRole, role)"
+                class="role-badge"
+                :class="`role-${(role as string).toLowerCase()}`"
+              >
+                {{ getRoleDisplayName(role) }}
+              </span>
+              <span
+                v-else
+                class="role-badge role-badge-dropdown"
+                :class="`role-${(role as string).toLowerCase()}`"
+              >
+                <select
+                  :value="role"
+                  class="role-select"
+                  data-testid="manage-market-role-select"
+                  @change="
+                    handleRoleChange(
+                      userId,
+                      ($event.target as HTMLSelectElement).value as MarketRole,
+                    )
+                  "
+                >
+                  <option :value="role">{{ getRoleDisplayName(role) }}</option>
+                  <option
+                    v-for="r in getRolesForChange(role, marketData!.userRole!)"
+                    :key="r"
+                    :value="r"
+                  >
+                    {{ getRoleDisplayName(r) }}
+                  </option>
+                </select>
+                <span class="role-chevron">▼</span>
+              </span>
+              <button
+                v-if="canRemoveUser(role)"
+                class="remove-button"
+                @click="handleRemoveUser(userId)"
+                title="Remove user"
+                data-testid="manage-market-remove-user-button"
+              >
+                Remove
+              </button>
             </div>
-            <div v-if="loading" class="loading-state">Loading...</div>
-            <div v-else-if="marketData" class="content">
-                <section class="section">
-                    <h3>Users with access</h3>
-                    <div class="users-list">
-                        <div
-                            v-for="{ userId, email, role } in getUserList()"
-                            :key="userId"
-                            class="user-card"
-                        >
-                            <span class="user-email">{{ email }}</span>
-                            <span
-                                v-if="!marketData?.userRole || !canChangeRole(marketData.userRole, role)"
-                                class="role-badge"
-                                :class="`role-${(role as string).toLowerCase()}`"
-                            >
-                                {{ getRoleDisplayName(role) }}
-                            </span>
-                            <span
-                                v-else
-                                class="role-badge role-badge-dropdown"
-                                :class="`role-${(role as string).toLowerCase()}`"
-                            >
-                                <select
-                                    :value="role"
-                                    class="role-select"
-                                    data-testid="manage-market-role-select"
-                                    @change="handleRoleChange(userId, ($event.target as HTMLSelectElement).value as MarketRole)"
-                                >
-                                    <option :value="role">{{ getRoleDisplayName(role) }}</option>
-                                    <option
-                                        v-for="r in getRolesForChange(role, marketData!.userRole!)"
-                                        :key="r"
-                                        :value="r"
-                                    >
-                                        {{ getRoleDisplayName(r) }}
-                                    </option>
-                                </select>
-                                <span class="role-chevron">▼</span>
-                            </span>
-                            <button
-                                v-if="canRemoveUser(role)"
-                                class="remove-button"
-                                @click="handleRemoveUser(userId)"
-                                title="Remove user"
-                                data-testid="manage-market-remove-user-button"
-                            >
-                                Remove
-                            </button>
-                        </div>
-                        <p v-if="getUserList().length === 0" class="empty-state">No users with explicit access</p>
-                    </div>
-                    <button class="add-user-button" @click="showAddUserForm = !showAddUserForm" data-testid="manage-market-add-user-button">
-                        {{ showAddUserForm ? 'Cancel' : 'Add user' }}
-                    </button>
-                    <div v-if="showAddUserForm" class="add-user-form">
-                        <div class="add-org-row">
-                            <input
-                                v-model="newUserEmail"
-                                type="email"
-                                placeholder="User email"
-                                class="form-input"
-                                data-testid="manage-market-add-user-input"
-                            />
-                            <select v-model="newUserRole" class="form-select" data-testid="manage-market-add-user-select">
-                                <option v-for="r in addableRoles" :key="r" :value="r">
-                                    {{ getRoleDisplayName(r) }}
-                                </option>
-                            </select>
-                            <button class="submit-button" @click="handleAddUser" data-testid="manage-market-add-user-submit">Add</button>
-                        </div>
-                        <p v-if="addUserError" class="form-error">{{ addUserError }}</p>
-                    </div>
-                </section>
-
-                <section class="section">
-                    <h3>Organizations with access</h3>
-                    <div class="users-list">
-                        <div
-                            v-for="orgName in getOrganizationList()"
-                            :key="orgName"
-                            class="user-card"
-                        >
-                            <span class="user-email">{{ orgName }}</span>
-                            <span class="role-badge role-viewer">Viewer</span>
-                            <button
-                                v-if="canRemoveOrg()"
-                                class="remove-button"
-                                @click="handleRemoveOrg()"
-                                title="Remove organization"
-                                data-testid="manage-market-remove-org-button"
-                            >
-                                Remove
-                            </button>
-                        </div>
-                        <p v-if="getOrganizationList().length === 0" class="empty-state">No organizations with access</p>
-                    </div>
-                    <button
-                        class="add-user-button"
-                        @click="showAddOrgForm = !showAddOrgForm; if (showAddOrgForm) fetchUserOrgs()"
-                        data-testid="manage-market-add-org-button"
-                    >
-                        {{ showAddOrgForm ? 'Cancel' : 'Add organization' }}
-                    </button>
-                    <div v-if="showAddOrgForm" class="add-user-form">
-                        <div class="add-org-row">
-                            <select
-                                v-model="newOrgName"
-                                class="form-select"
-                                :disabled="getAvailableOrgsForAdd().length === 0"
-                                data-testid="manage-market-add-org-select"
-                            >
-                                <option value="">Select organization</option>
-                                <option
-                                    v-for="org in getAvailableOrgsForAdd()"
-                                    :key="org.name"
-                                    :value="org.name"
-                                >
-                                    {{ org.name }}
-                                </option>
-                            </select>
-                            <button
-                                class="submit-button"
-                                @click="handleAddOrg"
-                                :disabled="!newOrgName.trim()"
-                                data-testid="manage-market-add-org-submit"
-                            >
-                                Add
-                            </button>
-                        </div>
-                        <p v-if="getAvailableOrgsForAdd().length === 0 && getOrganizationList().length > 0" class="form-hint">All your organizations already have access</p>
-                        <p v-else-if="getAvailableOrgsForAdd().length === 0" class="form-hint">Create an organization first</p>
-                        <p v-if="addOrgError" class="form-error">{{ addOrgError }}</p>
-                    </div>
-                </section>
-
-                <section class="section">
-                    <h3>Rename market</h3>
-                    <div class="rename-row">
-                        <input v-model="renameValue" class="form-input rename-input" data-testid="manage-market-rename-input" />
-                        <button class="save-button" @click="handleRename" data-testid="manage-market-rename-save-button">Save</button>
-                    </div>
-                    <p v-if="renameError" class="form-error">{{ renameError }}</p>
-                </section>
-
-                <section class="section danger-section">
-                    <h3>Delete market</h3>
-                    <div v-if="!deleteConfirming">
-                        <button class="delete-button" @click="deleteConfirming = true" data-testid="manage-market-delete-button">
-                            Delete market
-                        </button>
-                    </div>
-                    <div v-else class="delete-confirm">
-                        <p class="confirm-text">Are you sure? This cannot be undone.</p>
-                        <div class="confirm-buttons">
-                            <button class="confirm-delete-button" @click="handleDeleteConfirm" data-testid="manage-market-delete-confirm-button">
-                                Confirm
-                            </button>
-                            <button class="cancel-button" @click="handleDeleteCancel" data-testid="manage-market-delete-cancel-button">Cancel</button>
-                        </div>
-                        <p v-if="deleteError" class="form-error">{{ deleteError }}</p>
-                    </div>
-                </section>
+            <p v-if="getUserList().length === 0" class="empty-state">
+              No users with explicit access
+            </p>
+          </div>
+          <button
+            class="add-user-button"
+            @click="showAddUserForm = !showAddUserForm"
+            data-testid="manage-market-add-user-button"
+          >
+            {{ showAddUserForm ? 'Cancel' : 'Add user' }}
+          </button>
+          <div v-if="showAddUserForm" class="add-user-form">
+            <div class="add-org-row">
+              <input
+                v-model="newUserEmail"
+                type="email"
+                placeholder="User email"
+                class="form-input"
+                data-testid="manage-market-add-user-input"
+              />
+              <select
+                v-model="newUserRole"
+                class="form-select"
+                data-testid="manage-market-add-user-select"
+              >
+                <option v-for="r in addableRoles" :key="r" :value="r">
+                  {{ getRoleDisplayName(r) }}
+                </option>
+              </select>
+              <button
+                class="submit-button"
+                @click="handleAddUser"
+                data-testid="manage-market-add-user-submit"
+              >
+                Add
+              </button>
             </div>
-        </div>
+            <p v-if="addUserError" class="form-error">{{ addUserError }}</p>
+          </div>
+        </section>
+
+        <section class="section">
+          <h3>Organizations with access</h3>
+          <div class="users-list">
+            <div v-for="orgName in getOrganizationList()" :key="orgName" class="user-card">
+              <span class="user-email">{{ orgName }}</span>
+              <span class="role-badge role-viewer">Viewer</span>
+              <button
+                v-if="canRemoveOrg()"
+                class="remove-button"
+                @click="handleRemoveOrg()"
+                title="Remove organization"
+                data-testid="manage-market-remove-org-button"
+              >
+                Remove
+              </button>
+            </div>
+            <p v-if="getOrganizationList().length === 0" class="empty-state">
+              No organizations with access
+            </p>
+          </div>
+          <button
+            class="add-user-button"
+            @click="
+              showAddOrgForm = !showAddOrgForm
+              if (showAddOrgForm) fetchUserOrgs()
+            "
+            data-testid="manage-market-add-org-button"
+          >
+            {{ showAddOrgForm ? 'Cancel' : 'Add organization' }}
+          </button>
+          <div v-if="showAddOrgForm" class="add-user-form">
+            <div class="add-org-row">
+              <select
+                v-model="newOrgName"
+                class="form-select"
+                :disabled="getAvailableOrgsForAdd().length === 0"
+                data-testid="manage-market-add-org-select"
+              >
+                <option value="">Select organization</option>
+                <option v-for="org in getAvailableOrgsForAdd()" :key="org.name" :value="org.name">
+                  {{ org.name }}
+                </option>
+              </select>
+              <button
+                class="submit-button"
+                @click="handleAddOrg"
+                :disabled="!newOrgName.trim()"
+                data-testid="manage-market-add-org-submit"
+              >
+                Add
+              </button>
+            </div>
+            <p
+              v-if="getAvailableOrgsForAdd().length === 0 && getOrganizationList().length > 0"
+              class="form-hint"
+            >
+              All your organizations already have access
+            </p>
+            <p v-else-if="getAvailableOrgsForAdd().length === 0" class="form-hint">
+              Create an organization first
+            </p>
+            <p v-if="addOrgError" class="form-error">{{ addOrgError }}</p>
+          </div>
+        </section>
+
+        <section class="section">
+          <h3>Rename market</h3>
+          <div class="rename-row">
+            <input
+              v-model="renameValue"
+              class="form-input rename-input"
+              data-testid="manage-market-rename-input"
+            />
+            <button
+              class="save-button"
+              @click="handleRename"
+              data-testid="manage-market-rename-save-button"
+            >
+              Save
+            </button>
+          </div>
+          <p v-if="renameError" class="form-error">{{ renameError }}</p>
+        </section>
+
+        <section class="section danger-section">
+          <h3>Delete market</h3>
+          <div v-if="!deleteConfirming">
+            <button
+              class="delete-button"
+              @click="deleteConfirming = true"
+              data-testid="manage-market-delete-button"
+            >
+              Delete market
+            </button>
+          </div>
+          <div v-else class="delete-confirm">
+            <p class="confirm-text">Are you sure? This cannot be undone.</p>
+            <div class="confirm-buttons">
+              <button
+                class="confirm-delete-button"
+                @click="handleDeleteConfirm"
+                data-testid="manage-market-delete-confirm-button"
+              >
+                Confirm
+              </button>
+              <button
+                class="cancel-button"
+                @click="handleDeleteCancel"
+                data-testid="manage-market-delete-cancel-button"
+              >
+                Cancel
+              </button>
+            </div>
+            <p v-if="deleteError" class="form-error">{{ deleteError }}</p>
+          </div>
+        </section>
+      </div>
     </div>
+  </div>
 </template>
 
 <style scoped>
 .container {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
 }
 
 .background {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.5);
-    opacity: 0%;
-    transition: opacity 0.15s ease-in-out, visibility 0.15s ease-in-out;
-    z-index: 0;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0%;
+  transition:
+    opacity 0.15s ease-in-out,
+    visibility 0.15s ease-in-out;
+  z-index: 0;
 }
 
 .window {
-    position: relative;
-    width: 70%;
-    max-width: 600px;
-    max-height: 85%;
-    display: flex;
-    flex-direction: column;
-    background: white;
-    border-radius: 12px;
-    z-index: 1;
-    padding: 0;
-    overflow: hidden;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+  position: relative;
+  width: 70%;
+  max-width: 600px;
+  max-height: 85%;
+  display: flex;
+  flex-direction: column;
+  background: white;
+  border-radius: 12px;
+  z-index: 1;
+  padding: 0;
+  overflow: hidden;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
 }
 
 .header {
-    padding: 32px 40px 24px;
-    border-bottom: 1px solid var(--mm-grey);
+  padding: 32px 40px 24px;
+  border-bottom: 1px solid var(--mm-grey);
 }
 
 .header h2 {
-    margin: 0;
-    font-size: 28px;
-    font-weight: 600;
-    color: var(--mm-black);
-    font-family: 'Outfit Regular', sans-serif;
+  margin: 0;
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--mm-black);
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .market-name {
-    margin: 8px 0 0;
-    color: #666;
-    font-size: 14px;
+  margin: 8px 0 0;
+  color: #666;
+  font-size: 14px;
 }
 
 .error-state {
-    margin-top: 12px;
-    color: #d32f2f;
-    font-size: 14px;
+  margin-top: 12px;
+  color: #d32f2f;
+  font-size: 14px;
 }
 
 .loading-state {
-    padding: 40px;
-    text-align: center;
-    color: #666;
+  padding: 40px;
+  text-align: center;
+  color: #666;
 }
 
 .content {
-    flex: 1;
-    overflow-y: auto;
-    padding: 24px 40px 32px;
-    display: flex;
-    flex-direction: column;
-    gap: 28px;
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px 40px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
 }
 
 .section h3 {
-    margin: 0 0 12px;
-    font-size: 16px;
-    font-weight: 600;
-    color: var(--mm-black);
-    font-family: 'Outfit Regular', sans-serif;
+  margin: 0 0 12px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--mm-black);
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .users-list {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    margin-bottom: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 12px;
 }
 
 .user-card {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 10px 14px;
-    border: 1.5px solid var(--mm-grey);
-    border-radius: 8px;
-    background: #fafafa;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border: 1.5px solid var(--mm-grey);
+  border-radius: 8px;
+  background: #fafafa;
 }
 
 .user-email {
-    flex: 1;
-    font-size: 14px;
-    color: var(--mm-black);
+  flex: 1;
+  font-size: 14px;
+  color: var(--mm-black);
 }
 
 .role-badge {
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 4px;
-    font-weight: 500;
-    font-size: 12px;
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-weight: 500;
+  font-size: 12px;
 }
 
 .role-badge-dropdown {
-    display: inline-flex;
-    align-items: center;
-    gap: 2px;
-    padding-right: 4px;
-    cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding-right: 4px;
+  cursor: pointer;
 }
 
 .role-select {
-    appearance: none;
-    background: transparent;
-    border: none;
-    outline: none;
-    font: inherit;
-    font-weight: 500;
-    font-size: 12px;
-    color: inherit;
-    cursor: pointer;
-    padding: 0;
-    margin: 0;
+  appearance: none;
+  background: transparent;
+  border: none;
+  outline: none;
+  font: inherit;
+  font-weight: 500;
+  font-size: 12px;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
 }
 
 .role-select:focus {
-    outline: none;
-    border: none;
-    box-shadow: none;
+  outline: none;
+  border: none;
+  box-shadow: none;
 }
 
 .role-select option {
-    color: black;
-    padding: 0 4px;
-    text-align: center;
+  color: black;
+  padding: 0 4px;
+  text-align: center;
 }
 
 .role-chevron {
-    font-size: 8px;
-    opacity: 0.8;
+  font-size: 8px;
+  opacity: 0.8;
 }
 
 .role-owner {
-    background: #e3f2fd;
-    color: #1976d2;
+  background: #e3f2fd;
+  color: #1976d2;
 }
 
 .role-admin {
-    background: #f3e5f5;
-    color: #7b1fa2;
+  background: #f3e5f5;
+  color: #7b1fa2;
 }
 
 .role-editor {
-    background: #e8f5e9;
-    color: #388e3c;
+  background: #e8f5e9;
+  color: #388e3c;
 }
 
 .role-viewer {
-    background: #fff3e0;
-    color: #f57c00;
+  background: #fff3e0;
+  color: #f57c00;
 }
 
 .remove-button {
-    padding: 4px 12px;
-    font-size: 12px;
-    background: transparent;
-    color: #d32f2f;
-    border: 1px solid #d32f2f;
-    border-radius: 4px;
-    cursor: pointer;
-    font-family: 'Outfit Regular', sans-serif;
+  padding: 4px 12px;
+  font-size: 12px;
+  background: transparent;
+  color: #d32f2f;
+  border: 1px solid #d32f2f;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .remove-button:hover {
-    background: rgba(211, 47, 47, 0.08);
+  background: rgba(211, 47, 47, 0.08);
 }
 
 .empty-state {
-    color: #666;
-    font-size: 14px;
-    margin: 0;
+  color: #666;
+  font-size: 14px;
+  margin: 0;
 }
 
 .add-user-button {
-    padding: 8px 16px;
-    font-size: 14px;
-    background: var(--mm-green);
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-family: 'Outfit Regular', sans-serif;
+  padding: 8px 16px;
+  font-size: 14px;
+  background: var(--mm-green);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .add-user-button:hover {
-    background: #3a9a82;
+  background: #3a9a82;
 }
 
 .add-user-form {
-    margin-top: 12px;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .add-org-row {
-    display: flex;
-    gap: 10px;
-    align-items: center;
+  display: flex;
+  gap: 10px;
+  align-items: center;
 }
 
 .form-input {
-    padding: 8px 12px;
-    border: 1.5px solid var(--mm-grey);
-    border-radius: 6px;
-    font-size: 14px;
-    font-family: 'Outfit Regular', sans-serif;
-    min-width: 180px;
+  padding: 8px 12px;
+  border: 1.5px solid var(--mm-grey);
+  border-radius: 6px;
+  font-size: 14px;
+  font-family: 'Outfit Regular', sans-serif;
+  min-width: 180px;
 }
 
 .form-select {
-    padding: 8px 12px;
-    border: 1.5px solid var(--mm-grey);
-    border-radius: 6px;
-    font-size: 14px;
-    font-family: 'Outfit Regular', sans-serif;
+  padding: 8px 12px;
+  border: 1.5px solid var(--mm-grey);
+  border-radius: 6px;
+  font-size: 14px;
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .submit-button {
-    padding: 8px 16px;
-    font-size: 14px;
-    background: var(--mm-black);
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-family: 'Outfit Regular', sans-serif;
+  padding: 8px 16px;
+  font-size: 14px;
+  background: var(--mm-black);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .submit-button:hover {
-    opacity: 0.9;
+  opacity: 0.9;
 }
 
 .rename-row {
-    display: flex;
-    gap: 10px;
-    align-items: center;
+  display: flex;
+  gap: 10px;
+  align-items: center;
 }
 
 .rename-input {
-    flex: 1;
+  flex: 1;
 }
 
 .save-button {
-    padding: 8px 20px;
-    font-size: 14px;
-    background: var(--mm-green);
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-family: 'Outfit Regular', sans-serif;
+  padding: 8px 20px;
+  font-size: 14px;
+  background: var(--mm-green);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .save-button:hover {
-    background: #3a9a82;
+  background: #3a9a82;
 }
 
 .form-error {
-    margin: 8px 0 0;
-    color: #d32f2f;
-    font-size: 13px;
+  margin: 8px 0 0;
+  color: #d32f2f;
+  font-size: 13px;
 }
 
 .form-hint {
-    margin: 8px 0 0;
-    color: #666;
-    font-size: 13px;
+  margin: 8px 0 0;
+  color: #666;
+  font-size: 13px;
 }
 
 .danger-section {
-    padding-top: 20px;
-    border-top: 1px solid var(--mm-grey);
+  padding-top: 20px;
+  border-top: 1px solid var(--mm-grey);
 }
 
 .delete-button {
-    padding: 8px 20px;
-    font-size: 14px;
-    background: #d32f2f;
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-family: 'Outfit Regular', sans-serif;
+  padding: 8px 20px;
+  font-size: 14px;
+  background: #d32f2f;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .delete-button:hover {
-    background: #b71c1c;
+  background: #b71c1c;
 }
 
 .delete-confirm {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .confirm-text {
-    margin: 0;
-    font-size: 14px;
-    color: var(--mm-black);
+  margin: 0;
+  font-size: 14px;
+  color: var(--mm-black);
 }
 
 .confirm-buttons {
-    display: flex;
-    gap: 10px;
+  display: flex;
+  gap: 10px;
 }
 
 .confirm-delete-button {
-    padding: 8px 20px;
-    font-size: 14px;
-    background: #d32f2f;
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-family: 'Outfit Regular', sans-serif;
+  padding: 8px 20px;
+  font-size: 14px;
+  background: #d32f2f;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .confirm-delete-button:hover {
-    background: #b71c1c;
+  background: #b71c1c;
 }
 
 .cancel-button {
-    padding: 8px 20px;
-    font-size: 14px;
-    background: #666;
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-family: 'Outfit Regular', sans-serif;
+  padding: 8px 20px;
+  font-size: 14px;
+  background: #666;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .cancel-button:hover {
-    background: #555;
+  background: #555;
 }
 
 .content::-webkit-scrollbar {
-    width: 8px;
+  width: 8px;
 }
 
 .content::-webkit-scrollbar-track {
-    background: #f1f1f1;
-    border-radius: 4px;
+  background: #f1f1f1;
+  border-radius: 4px;
 }
 
 .content::-webkit-scrollbar-thumb {
-    background: var(--mm-grey);
-    border-radius: 4px;
+  background: var(--mm-grey);
+  border-radius: 4px;
 }
 </style>

--- a/front-end/src/views/ManageOrgOverlay.vue
+++ b/front-end/src/views/ManageOrgOverlay.vue
@@ -1,575 +1,639 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue';
-import { type Organization, type OrganizationRoleType } from '@/assets/types/datatypes';
-import { api, getApiErrorMessage } from '@/utils/api';
+import { ref, watch } from 'vue'
+import { type Organization, type OrganizationRoleType } from '@/assets/types/datatypes'
+import { api, getApiErrorMessage } from '@/utils/api'
 
 const props = defineProps<{
-    manageOpen: boolean;
-    org: Organization | null;
-}>();
+  manageOpen: boolean
+  org: Organization | null
+}>()
 
 const emit = defineEmits<{
-    manageClose: [];
-}>();
+  manageClose: []
+}>()
 
-const orgData = ref<Organization | null>(null);
-const errorMessage = ref('');
-const renameValue = ref('');
-const renameError = ref('');
-const showAddAdminForm = ref(false);
-const showAddMemberForm = ref(false);
-const newAdminEmail = ref('');
-const newMemberEmail = ref('');
-const addAdminError = ref('');
-const addMemberError = ref('');
-const deleteConfirming = ref(false);
-const deleteError = ref('');
+const orgData = ref<Organization | null>(null)
+const errorMessage = ref('')
+const renameValue = ref('')
+const renameError = ref('')
+const showAddAdminForm = ref(false)
+const showAddMemberForm = ref(false)
+const newAdminEmail = ref('')
+const newMemberEmail = ref('')
+const addAdminError = ref('')
+const addMemberError = ref('')
+const deleteConfirming = ref(false)
+const deleteError = ref('')
 
 watch(
-    () => [props.manageOpen, props.org] as const,
-    ([open, org]) => {
-        if (open && org) {
-            orgData.value = org;
-            renameValue.value = org.name;
-            showAddAdminForm.value = false;
-            showAddMemberForm.value = false;
-            deleteConfirming.value = false;
-            errorMessage.value = '';
-            renameError.value = '';
-            addAdminError.value = '';
-            addMemberError.value = '';
-            deleteError.value = '';
-        } else {
-            orgData.value = null;
-        }
-    },
-    { immediate: true }
-);
+  () => [props.manageOpen, props.org] as const,
+  ([open, org]) => {
+    if (open && org) {
+      orgData.value = org
+      renameValue.value = org.name
+      showAddAdminForm.value = false
+      showAddMemberForm.value = false
+      deleteConfirming.value = false
+      errorMessage.value = ''
+      renameError.value = ''
+      addAdminError.value = ''
+      addMemberError.value = ''
+      deleteError.value = ''
+    } else {
+      orgData.value = null
+    }
+  },
+  { immediate: true },
+)
 
 function canManage(): boolean {
-    const role = orgData.value?.userRole;
-    return role === 'owner' || role === 'admin';
+  const role = orgData.value?.userRole
+  return role === 'owner' || role === 'admin'
 }
 
 function isOwner(): boolean {
-    return orgData.value?.userRole === 'owner';
+  return orgData.value?.userRole === 'owner'
 }
 
 async function handleRename() {
-    if (!orgData.value || renameValue.value.trim() === orgData.value.name) return;
-    renameError.value = '';
-    try {
-        await api.put(`/organizations/${encodeURIComponent(orgData.value.id)}`, { name: renameValue.value.trim() });
-        orgData.value = { ...orgData.value, name: renameValue.value.trim() };
-    } catch (err) {
-        renameError.value = getApiErrorMessage(err, 'Failed to rename');
-    }
+  if (!orgData.value || renameValue.value.trim() === orgData.value.name) return
+  renameError.value = ''
+  try {
+    await api.put(`/organizations/${encodeURIComponent(orgData.value.id)}`, {
+      name: renameValue.value.trim(),
+    })
+    orgData.value = { ...orgData.value, name: renameValue.value.trim() }
+  } catch (err) {
+    renameError.value = getApiErrorMessage(err, 'Failed to rename')
+  }
 }
 
 async function handleAddAdmin() {
-    if (!orgData.value || !newAdminEmail.value.trim()) return;
-    addAdminError.value = '';
-    try {
-        await api.post(`/organizations/${encodeURIComponent(orgData.value.id)}/admins`, { user_email: newAdminEmail.value.trim() });
-        showAddAdminForm.value = false;
-        newAdminEmail.value = '';
-        emit('manageClose');
-    } catch (err) {
-        addAdminError.value = getApiErrorMessage(err, 'Failed to add admin');
-    }
+  if (!orgData.value || !newAdminEmail.value.trim()) return
+  addAdminError.value = ''
+  try {
+    await api.post(`/organizations/${encodeURIComponent(orgData.value.id)}/admins`, {
+      user_email: newAdminEmail.value.trim(),
+    })
+    showAddAdminForm.value = false
+    newAdminEmail.value = ''
+    emit('manageClose')
+  } catch (err) {
+    addAdminError.value = getApiErrorMessage(err, 'Failed to add admin')
+  }
 }
 
 async function handleAddMember() {
-    if (!orgData.value || !newMemberEmail.value.trim()) return;
-    addMemberError.value = '';
-    try {
-        await api.post(`/organizations/${encodeURIComponent(orgData.value.id)}/members`, { user_email: newMemberEmail.value.trim() });
-        showAddMemberForm.value = false;
-        newMemberEmail.value = '';
-        emit('manageClose');
-    } catch (err) {
-        addMemberError.value = getApiErrorMessage(err, 'Failed to add member');
-    }
+  if (!orgData.value || !newMemberEmail.value.trim()) return
+  addMemberError.value = ''
+  try {
+    await api.post(`/organizations/${encodeURIComponent(orgData.value.id)}/members`, {
+      user_email: newMemberEmail.value.trim(),
+    })
+    showAddMemberForm.value = false
+    newMemberEmail.value = ''
+    emit('manageClose')
+  } catch (err) {
+    addMemberError.value = getApiErrorMessage(err, 'Failed to add member')
+  }
 }
 
 async function handleRemoveUser(userId: string) {
-    if (!orgData.value) return;
-    try {
-        await api.delete(`/organizations/${encodeURIComponent(orgData.value.id)}/users/${encodeURIComponent(userId)}`);
-        emit('manageClose');
-    } catch (err) {
-        errorMessage.value = getApiErrorMessage(err, 'Failed to remove user');
-    }
+  if (!orgData.value) return
+  try {
+    await api.delete(
+      `/organizations/${encodeURIComponent(orgData.value.id)}/users/${encodeURIComponent(userId)}`,
+    )
+    emit('manageClose')
+  } catch (err) {
+    errorMessage.value = getApiErrorMessage(err, 'Failed to remove user')
+  }
 }
 
 function canRemoveUser(userId: string, role: OrganizationRoleType): boolean {
-    if (role === 'owner') return false;
-    if (!isOwner()) return role === 'member';
-    return true;
+  if (role === 'owner') return false
+  if (!isOwner()) return role === 'member'
+  return true
 }
 
 async function handleDeleteConfirm() {
-    if (!orgData.value) return;
-    deleteError.value = '';
-    try {
-        await api.delete(`/organizations/${encodeURIComponent(orgData.value.id)}`);
-        emit('manageClose');
-    } catch (err) {
-        deleteError.value = getApiErrorMessage(err, 'Failed to delete organization');
-    }
+  if (!orgData.value) return
+  deleteError.value = ''
+  try {
+    await api.delete(`/organizations/${encodeURIComponent(orgData.value.id)}`)
+    emit('manageClose')
+  } catch (err) {
+    deleteError.value = getApiErrorMessage(err, 'Failed to delete organization')
+  }
 }
 
 function handleDeleteCancel() {
-    deleteConfirming.value = false;
-    deleteError.value = '';
+  deleteConfirming.value = false
+  deleteError.value = ''
 }
 
 function handleClose() {
-    emit('manageClose');
+  emit('manageClose')
 }
 </script>
 
 <template>
-    <div class="container" :style="{ visibility: manageOpen ? 'visible' : 'hidden' }">
-        <div class="background" @click="handleClose" :style="{ opacity: manageOpen ? '100%' : '0%' }" data-testid="manage-org-overlay-background" />
-        <div v-if="manageOpen && org" class="window">
-            <div class="header">
-                <h2>Manage organization</h2>
-                <p v-if="orgData" class="org-name">{{ orgData.name }}</p>
-                <p v-if="errorMessage" class="error-state">{{ errorMessage }}</p>
+  <div class="container" :style="{ visibility: manageOpen ? 'visible' : 'hidden' }">
+    <div
+      class="background"
+      @click="handleClose"
+      :style="{ opacity: manageOpen ? '100%' : '0%' }"
+      data-testid="manage-org-overlay-background"
+    />
+    <div v-if="manageOpen && org" class="window">
+      <div class="header">
+        <h2>Manage organization</h2>
+        <p v-if="orgData" class="org-name">{{ orgData.name }}</p>
+        <p v-if="errorMessage" class="error-state">{{ errorMessage }}</p>
+      </div>
+      <div v-if="orgData" class="content">
+        <section class="section">
+          <h3>Owner</h3>
+          <div class="user-card">
+            <span class="user-email">{{ orgData.ownerEmail || 'Unknown' }}</span>
+            <span class="role-badge role-owner">Owner</span>
+          </div>
+        </section>
+
+        <section v-if="canManage()" class="section">
+          <h3>Admins</h3>
+          <div class="users-list">
+            <div
+              v-for="(email, idx) in orgData.adminEmails || []"
+              :key="orgData.admins?.[idx] ?? idx"
+              class="user-card"
+            >
+              <span class="user-email">{{ email }}</span>
+              <span class="role-badge role-admin">Admin</span>
+              <button
+                v-if="isOwner() && canRemoveUser(orgData.admins![idx], 'admin')"
+                class="remove-button"
+                @click="handleRemoveUser(orgData.admins![idx])"
+                title="Remove admin"
+                data-testid="manage-org-remove-user-button"
+              >
+                Remove
+              </button>
             </div>
-            <div v-if="orgData" class="content">
-                <section class="section">
-                    <h3>Owner</h3>
-                    <div class="user-card">
-                        <span class="user-email">{{ orgData.ownerEmail || 'Unknown' }}</span>
-                        <span class="role-badge role-owner">Owner</span>
-                    </div>
-                </section>
-
-                <section v-if="canManage()" class="section">
-                    <h3>Admins</h3>
-                    <div class="users-list">
-                        <div
-                            v-for="(email, idx) in (orgData.adminEmails || [])"
-                            :key="orgData.admins?.[idx] ?? idx"
-                            class="user-card"
-                        >
-                            <span class="user-email">{{ email }}</span>
-                            <span class="role-badge role-admin">Admin</span>
-                            <button
-                                v-if="isOwner() && canRemoveUser(orgData.admins![idx], 'admin')"
-                                class="remove-button"
-                                @click="handleRemoveUser(orgData.admins![idx])"
-                                title="Remove admin"
-                                data-testid="manage-org-remove-user-button"
-                            >
-                                Remove
-                            </button>
-                        </div>
-                        <p v-if="!(orgData.adminEmails?.length) && !showAddAdminForm" class="empty-state">No admins</p>
-                    </div>
-                    <button v-if="isOwner()" class="add-user-button" @click="showAddAdminForm = !showAddAdminForm" data-testid="manage-org-add-admin-button">
-                        {{ showAddAdminForm ? 'Cancel' : 'Add admin' }}
-                    </button>
-                    <div v-if="showAddAdminForm" class="add-user-form">
-                        <div class="add-org-row">
-                            <input
-                                v-model="newAdminEmail"
-                                type="email"
-                                placeholder="User email"
-                                class="form-input"
-                                data-testid="manage-org-add-admin-input"
-                            />
-                            <button class="submit-button" @click="handleAddAdmin" data-testid="manage-org-add-admin-submit">Add</button>
-                        </div>
-                        <p v-if="addAdminError" class="form-error">{{ addAdminError }}</p>
-                    </div>
-                </section>
-
-                <section v-if="canManage()" class="section">
-                    <h3>Members</h3>
-                    <div class="users-list">
-                        <div
-                            v-for="(email, idx) in (orgData.memberEmails || [])"
-                            :key="orgData.members?.[idx] ?? idx"
-                            class="user-card"
-                        >
-                            <span class="user-email">{{ email }}</span>
-                            <span class="role-badge role-member">Member</span>
-                            <button
-                                v-if="canRemoveUser(orgData.members![idx], 'member')"
-                                class="remove-button"
-                                @click="handleRemoveUser(orgData.members![idx])"
-                                title="Remove member"
-                                data-testid="manage-org-remove-member-button"
-                            >
-                                Remove
-                            </button>
-                        </div>
-                        <p v-if="!(orgData.memberEmails?.length) && !showAddMemberForm" class="empty-state">No members</p>
-                    </div>
-                    <button class="add-user-button" @click="showAddMemberForm = !showAddMemberForm" data-testid="manage-org-add-member-button">
-                        {{ showAddMemberForm ? 'Cancel' : 'Add member' }}
-                    </button>
-                    <div v-if="showAddMemberForm" class="add-user-form">
-                        <div class="add-org-row">
-                            <input
-                                v-model="newMemberEmail"
-                                type="email"
-                                placeholder="User email"
-                                class="form-input"
-                                data-testid="manage-org-add-member-input"
-                            />
-                            <button class="submit-button" @click="handleAddMember" data-testid="manage-org-add-member-submit">Add</button>
-                        </div>
-                        <p v-if="addMemberError" class="form-error">{{ addMemberError }}</p>
-                    </div>
-                </section>
-
-                <section v-if="canManage()" class="section">
-                    <h3>Rename organization</h3>
-                    <div class="rename-row">
-                        <input v-model="renameValue" class="form-input rename-input" data-testid="manage-org-rename-input" />
-                        <button class="save-button" @click="handleRename" data-testid="manage-org-rename-save-button">Save</button>
-                    </div>
-                    <p v-if="renameError" class="form-error">{{ renameError }}</p>
-                </section>
-
-                <section v-if="isOwner()" class="section danger-section">
-                    <h3>Delete organization</h3>
-                    <div v-if="!deleteConfirming">
-                        <button class="delete-button" @click="deleteConfirming = true" data-testid="manage-org-delete-button">
-                            Delete organization
-                        </button>
-                    </div>
-                    <div v-else class="delete-confirm">
-                        <p class="confirm-text">Are you sure? This cannot be undone.</p>
-                        <div class="confirm-buttons">
-                            <button class="confirm-delete-button" @click="handleDeleteConfirm" data-testid="manage-org-delete-confirm-button">
-                                Confirm
-                            </button>
-                            <button class="cancel-button" @click="handleDeleteCancel" data-testid="manage-org-delete-cancel-button">Cancel</button>
-                        </div>
-                        <p v-if="deleteError" class="form-error">{{ deleteError }}</p>
-                    </div>
-                </section>
+            <p v-if="!orgData.adminEmails?.length && !showAddAdminForm" class="empty-state">
+              No admins
+            </p>
+          </div>
+          <button
+            v-if="isOwner()"
+            class="add-user-button"
+            @click="showAddAdminForm = !showAddAdminForm"
+            data-testid="manage-org-add-admin-button"
+          >
+            {{ showAddAdminForm ? 'Cancel' : 'Add admin' }}
+          </button>
+          <div v-if="showAddAdminForm" class="add-user-form">
+            <div class="add-org-row">
+              <input
+                v-model="newAdminEmail"
+                type="email"
+                placeholder="User email"
+                class="form-input"
+                data-testid="manage-org-add-admin-input"
+              />
+              <button
+                class="submit-button"
+                @click="handleAddAdmin"
+                data-testid="manage-org-add-admin-submit"
+              >
+                Add
+              </button>
             </div>
-        </div>
+            <p v-if="addAdminError" class="form-error">{{ addAdminError }}</p>
+          </div>
+        </section>
+
+        <section v-if="canManage()" class="section">
+          <h3>Members</h3>
+          <div class="users-list">
+            <div
+              v-for="(email, idx) in orgData.memberEmails || []"
+              :key="orgData.members?.[idx] ?? idx"
+              class="user-card"
+            >
+              <span class="user-email">{{ email }}</span>
+              <span class="role-badge role-member">Member</span>
+              <button
+                v-if="canRemoveUser(orgData.members![idx], 'member')"
+                class="remove-button"
+                @click="handleRemoveUser(orgData.members![idx])"
+                title="Remove member"
+                data-testid="manage-org-remove-member-button"
+              >
+                Remove
+              </button>
+            </div>
+            <p v-if="!orgData.memberEmails?.length && !showAddMemberForm" class="empty-state">
+              No members
+            </p>
+          </div>
+          <button
+            class="add-user-button"
+            @click="showAddMemberForm = !showAddMemberForm"
+            data-testid="manage-org-add-member-button"
+          >
+            {{ showAddMemberForm ? 'Cancel' : 'Add member' }}
+          </button>
+          <div v-if="showAddMemberForm" class="add-user-form">
+            <div class="add-org-row">
+              <input
+                v-model="newMemberEmail"
+                type="email"
+                placeholder="User email"
+                class="form-input"
+                data-testid="manage-org-add-member-input"
+              />
+              <button
+                class="submit-button"
+                @click="handleAddMember"
+                data-testid="manage-org-add-member-submit"
+              >
+                Add
+              </button>
+            </div>
+            <p v-if="addMemberError" class="form-error">{{ addMemberError }}</p>
+          </div>
+        </section>
+
+        <section v-if="canManage()" class="section">
+          <h3>Rename organization</h3>
+          <div class="rename-row">
+            <input
+              v-model="renameValue"
+              class="form-input rename-input"
+              data-testid="manage-org-rename-input"
+            />
+            <button
+              class="save-button"
+              @click="handleRename"
+              data-testid="manage-org-rename-save-button"
+            >
+              Save
+            </button>
+          </div>
+          <p v-if="renameError" class="form-error">{{ renameError }}</p>
+        </section>
+
+        <section v-if="isOwner()" class="section danger-section">
+          <h3>Delete organization</h3>
+          <div v-if="!deleteConfirming">
+            <button
+              class="delete-button"
+              @click="deleteConfirming = true"
+              data-testid="manage-org-delete-button"
+            >
+              Delete organization
+            </button>
+          </div>
+          <div v-else class="delete-confirm">
+            <p class="confirm-text">Are you sure? This cannot be undone.</p>
+            <div class="confirm-buttons">
+              <button
+                class="confirm-delete-button"
+                @click="handleDeleteConfirm"
+                data-testid="manage-org-delete-confirm-button"
+              >
+                Confirm
+              </button>
+              <button
+                class="cancel-button"
+                @click="handleDeleteCancel"
+                data-testid="manage-org-delete-cancel-button"
+              >
+                Cancel
+              </button>
+            </div>
+            <p v-if="deleteError" class="form-error">{{ deleteError }}</p>
+          </div>
+        </section>
+      </div>
     </div>
+  </div>
 </template>
 
 <style scoped>
 .container {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
 }
 
 .background {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.5);
-    opacity: 0%;
-    transition: opacity 0.15s ease-in-out, visibility 0.15s ease-in-out;
-    z-index: 0;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0%;
+  transition:
+    opacity 0.15s ease-in-out,
+    visibility 0.15s ease-in-out;
+  z-index: 0;
 }
 
 .window {
-    position: relative;
-    width: 70%;
-    max-width: 600px;
-    max-height: 85%;
-    display: flex;
-    flex-direction: column;
-    background: white;
-    border-radius: 12px;
-    z-index: 1;
-    padding: 0;
-    overflow: hidden;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+  position: relative;
+  width: 70%;
+  max-width: 600px;
+  max-height: 85%;
+  display: flex;
+  flex-direction: column;
+  background: white;
+  border-radius: 12px;
+  z-index: 1;
+  padding: 0;
+  overflow: hidden;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
 }
 
 .header {
-    padding: 32px 40px 24px;
-    border-bottom: 1px solid var(--mm-grey);
+  padding: 32px 40px 24px;
+  border-bottom: 1px solid var(--mm-grey);
 }
 
 .header h2 {
-    margin: 0;
-    font-size: 28px;
-    font-weight: 600;
-    color: var(--mm-black);
-    font-family: 'Outfit Regular', sans-serif;
+  margin: 0;
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--mm-black);
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .org-name {
-    margin: 8px 0 0;
-    color: #666;
-    font-size: 14px;
+  margin: 8px 0 0;
+  color: #666;
+  font-size: 14px;
 }
 
 .error-state {
-    margin-top: 12px;
-    color: #d32f2f;
-    font-size: 14px;
+  margin-top: 12px;
+  color: #d32f2f;
+  font-size: 14px;
 }
 
 .content {
-    flex: 1;
-    overflow-y: auto;
-    padding: 24px 40px 32px;
-    display: flex;
-    flex-direction: column;
-    gap: 28px;
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px 40px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
 }
 
 .section h3 {
-    margin: 0 0 12px;
-    font-size: 16px;
-    font-weight: 600;
-    color: var(--mm-black);
-    font-family: 'Outfit Regular', sans-serif;
+  margin: 0 0 12px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--mm-black);
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .users-list {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    margin-bottom: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 12px;
 }
 
 .user-card {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 10px 14px;
-    border: 1.5px solid var(--mm-grey);
-    border-radius: 8px;
-    background: #fafafa;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border: 1.5px solid var(--mm-grey);
+  border-radius: 8px;
+  background: #fafafa;
 }
 
 .user-email {
-    flex: 1;
-    font-size: 14px;
-    color: var(--mm-black);
+  flex: 1;
+  font-size: 14px;
+  color: var(--mm-black);
 }
 
 .role-badge {
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 4px;
-    font-weight: 500;
-    font-size: 12px;
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-weight: 500;
+  font-size: 12px;
 }
 
 .role-owner {
-    background: #e3f2fd;
-    color: #1976d2;
+  background: #e3f2fd;
+  color: #1976d2;
 }
 
 .role-admin {
-    background: #f3e5f5;
-    color: #7b1fa2;
+  background: #f3e5f5;
+  color: #7b1fa2;
 }
 
 .role-member {
-    background: #e8f5e9;
-    color: #388e3c;
+  background: #e8f5e9;
+  color: #388e3c;
 }
 
 .remove-button {
-    padding: 4px 12px;
-    font-size: 12px;
-    background: transparent;
-    color: #d32f2f;
-    border: 1px solid #d32f2f;
-    border-radius: 4px;
-    cursor: pointer;
-    font-family: 'Outfit Regular', sans-serif;
+  padding: 4px 12px;
+  font-size: 12px;
+  background: transparent;
+  color: #d32f2f;
+  border: 1px solid #d32f2f;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .remove-button:hover {
-    background: rgba(211, 47, 47, 0.08);
+  background: rgba(211, 47, 47, 0.08);
 }
 
 .empty-state {
-    color: #666;
-    font-size: 14px;
-    margin: 0;
+  color: #666;
+  font-size: 14px;
+  margin: 0;
 }
 
 .add-user-button {
-    padding: 8px 16px;
-    font-size: 14px;
-    background: var(--mm-green);
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-family: 'Outfit Regular', sans-serif;
+  padding: 8px 16px;
+  font-size: 14px;
+  background: var(--mm-green);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .add-user-button:hover {
-    background: #3a9a82;
+  background: #3a9a82;
 }
 
 .add-user-form {
-    margin-top: 12px;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .add-org-row {
-    display: flex;
-    gap: 10px;
-    align-items: center;
+  display: flex;
+  gap: 10px;
+  align-items: center;
 }
 
 .form-input {
-    flex: 1;
-    padding: 8px 12px;
-    border: 1.5px solid var(--mm-grey);
-    border-radius: 6px;
-    font-size: 14px;
-    font-family: 'Outfit Regular', sans-serif;
-    min-width: 180px;
+  flex: 1;
+  padding: 8px 12px;
+  border: 1.5px solid var(--mm-grey);
+  border-radius: 6px;
+  font-size: 14px;
+  font-family: 'Outfit Regular', sans-serif;
+  min-width: 180px;
 }
 
 .submit-button {
-    padding: 8px 16px;
-    font-size: 14px;
-    background: var(--mm-black);
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-family: 'Outfit Regular', sans-serif;
+  padding: 8px 16px;
+  font-size: 14px;
+  background: var(--mm-black);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .submit-button:hover {
-    opacity: 0.9;
+  opacity: 0.9;
 }
 
 .rename-row {
-    display: flex;
-    gap: 10px;
-    align-items: center;
+  display: flex;
+  gap: 10px;
+  align-items: center;
 }
 
 .rename-input {
-    flex: 1;
+  flex: 1;
 }
 
 .save-button {
-    padding: 8px 20px;
-    font-size: 14px;
-    background: var(--mm-green);
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-family: 'Outfit Regular', sans-serif;
+  padding: 8px 20px;
+  font-size: 14px;
+  background: var(--mm-green);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .save-button:hover {
-    background: #3a9a82;
+  background: #3a9a82;
 }
 
 .form-error {
-    margin: 8px 0 0;
-    color: #d32f2f;
-    font-size: 13px;
+  margin: 8px 0 0;
+  color: #d32f2f;
+  font-size: 13px;
 }
 
 .danger-section {
-    padding-top: 20px;
-    border-top: 1px solid var(--mm-grey);
+  padding-top: 20px;
+  border-top: 1px solid var(--mm-grey);
 }
 
 .delete-button {
-    padding: 8px 20px;
-    font-size: 14px;
-    background: #d32f2f;
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-family: 'Outfit Regular', sans-serif;
+  padding: 8px 20px;
+  font-size: 14px;
+  background: #d32f2f;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .delete-button:hover {
-    background: #b71c1c;
+  background: #b71c1c;
 }
 
 .delete-confirm {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .confirm-text {
-    margin: 0;
-    font-size: 14px;
-    color: var(--mm-black);
+  margin: 0;
+  font-size: 14px;
+  color: var(--mm-black);
 }
 
 .confirm-buttons {
-    display: flex;
-    gap: 10px;
+  display: flex;
+  gap: 10px;
 }
 
 .confirm-delete-button {
-    padding: 8px 20px;
-    font-size: 14px;
-    background: #d32f2f;
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-family: 'Outfit Regular', sans-serif;
+  padding: 8px 20px;
+  font-size: 14px;
+  background: #d32f2f;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .confirm-delete-button:hover {
-    background: #b71c1c;
+  background: #b71c1c;
 }
 
 .cancel-button {
-    padding: 8px 20px;
-    font-size: 14px;
-    background: #666;
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-family: 'Outfit Regular', sans-serif;
+  padding: 8px 20px;
+  font-size: 14px;
+  background: #666;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Outfit Regular', sans-serif;
 }
 
 .cancel-button:hover {
-    background: #555;
+  background: #555;
 }
 
 .content::-webkit-scrollbar {
-    width: 8px;
+  width: 8px;
 }
 
 .content::-webkit-scrollbar-track {
-    background: #f1f1f1;
-    border-radius: 4px;
+  background: #f1f1f1;
+  border-radius: 4px;
 }
 
 .content::-webkit-scrollbar-thumb {
-    background: var(--mm-grey);
-    border-radius: 4px;
+  background: var(--mm-grey);
+  border-radius: 4px;
 }
 </style>

--- a/front-end/src/views/ManageOrgOverlay.vue
+++ b/front-end/src/views/ManageOrgOverlay.vue
@@ -285,6 +285,7 @@ function handleClose() {
 }
 
 .window {
+    position: relative;
     width: 70%;
     max-width: 600px;
     max-height: 85%;

--- a/front-end/src/views/NewMarketOverlay.vue
+++ b/front-end/src/views/NewMarketOverlay.vue
@@ -164,6 +164,7 @@ h3 {
 }
 
 .window {
+    position: relative;
     width: 25%;
     min-height: 140px;
     padding: 25px;

--- a/front-end/src/views/NewMarketOverlay.vue
+++ b/front-end/src/views/NewMarketOverlay.vue
@@ -1,225 +1,253 @@
 <script setup lang="ts">
-import ElementFileDrop from '@/components/elements/ElementFileDrop.vue';
-import ElementOrgSelect from '@/components/elements/ElementOrgSelect.vue';
-import { ref, watch } from 'vue';
-import { useRouter } from 'vue-router';
+import ElementFileDrop from '@/components/elements/ElementFileDrop.vue'
+import ElementOrgSelect from '@/components/elements/ElementOrgSelect.vue'
+import { ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import { type Market, MarketRole } from '@/assets/types/datatypes.ts'
-import axios from 'axios';
-import { api } from '@/utils/api';
+import axios from 'axios'
+import { api } from '@/utils/api'
 
 defineProps<{
-    newOpen: boolean;
-}>();
+  newOpen: boolean
+}>()
 
-const router = useRouter();
-const uploadedFiles = ref<unknown>([]);
-const uploadedSourceData = ref<File[]>([]);
-const next = ref(false);
-const marketName = ref("");
-const selectedOrgId = ref("");
-const errorMessage = ref("");
+const router = useRouter()
+const uploadedFiles = ref<unknown>([])
+const uploadedSourceData = ref<File[]>([])
+const next = ref(false)
+const marketName = ref('')
+const selectedOrgId = ref('')
+const errorMessage = ref('')
 
 watch(selectedOrgId, () => {
-    errorMessage.value = "";
-});
+  errorMessage.value = ''
+})
 
 const handleFileUploaded = (files: unknown) => {
-    uploadedFiles.value = files;
-    next.value = true;
-};
+  uploadedFiles.value = files
+  next.value = true
+}
 
 const handleSourceDataUploaded = (sourceData: File[]) => {
-    uploadedSourceData.value = sourceData;
-};
+  uploadedSourceData.value = sourceData
+}
 
 const handleSubmit = async () => {
-    errorMessage.value = ""; // Clear previous error
-    
-    if (!selectedOrgId.value) {
-        errorMessage.value = "Organization is required";
-        return;
+  errorMessage.value = '' // Clear previous error
+
+  if (!selectedOrgId.value) {
+    errorMessage.value = 'Organization is required'
+    return
+  }
+
+  if (!marketName.value.trim()) {
+    errorMessage.value = 'Market name is required'
+    return
+  }
+
+  try {
+    const userEmail = JSON.parse(localStorage.getItem('user') || 'null')
+    const newMarket: Omit<Market, 'id'> & { id?: string } = {
+      name: marketName.value,
+      creationDate: new Date().toISOString(),
+      isDraft: true,
+      organizationId: selectedOrgId.value,
+      roles: {
+        [userEmail]: MarketRole.Owner,
+      },
+      setupObject: null,
+      modificationList: [],
+      assignmentObject: {
+        vendorAssignments: [],
+        assignmentDate: '',
+        totalVendorsAssigned: 0,
+        totalTablesAssigned: 0,
+        assignmentStatistics: null,
+      },
     }
-    
-    if (!marketName.value.trim()) {
-        errorMessage.value = "Market name is required";
-        return;
+
+    const createResponse = await api.post('/markets', newMarket)
+    const marketId = createResponse.data.market_id
+
+    const formData = new FormData()
+    if (uploadedSourceData.value.length > 0) {
+      formData.append('file', uploadedSourceData.value[0])
+      await api.post(`/source-data/${marketId}`, formData)
     }
 
-    try {
-        const userEmail = JSON.parse(localStorage.getItem("user") || "null");
-        const newMarket: Omit<Market, 'id'> & { id?: string } = {
-            name: marketName.value,
-            creationDate: new Date().toISOString(),
-            isDraft: true,
-            organizationId: selectedOrgId.value,
-            roles: {
-                [userEmail]: MarketRole.Owner
-            },
-            setupObject: null,
-            modificationList: [],
-            assignmentObject: {
-                vendorAssignments: [],
-                assignmentDate: "",
-                totalVendorsAssigned: 0,
-                totalTablesAssigned: 0,
-                assignmentStatistics: null,
-            },
-        }
-        
-        const createResponse = await api.post('/markets', newMarket);
-        const marketId = createResponse.data.market_id;
+    localStorage.removeItem('upload')
+    localStorage.setItem('upload', JSON.stringify(uploadedFiles.value))
 
-        const formData = new FormData();
-        if (uploadedSourceData.value.length > 0) {
-            formData.append('file', uploadedSourceData.value[0]);
-            await api.post(`/source-data/${marketId}`, formData);
-        }
+    const marketWithId: Market = { ...newMarket, id: marketId }
+    localStorage.removeItem('market')
+    localStorage.setItem('market', JSON.stringify(marketWithId))
 
-        localStorage.removeItem("upload");
-        localStorage.setItem("upload", JSON.stringify(uploadedFiles.value));
-
-        const marketWithId: Market = { ...newMarket, id: marketId };
-        localStorage.removeItem("market");
-        localStorage.setItem("market", JSON.stringify(marketWithId));
-
-        router.push('/market-setup');
-    } catch (error) {
-        if (axios.isAxiosError(error) && error.response?.status === 400 && error.response?.data?.error) {
-            const errorText = error.response.data.error.toLowerCase();
-            if (errorText.includes('already exists') || errorText.includes('market already')) {
-                errorMessage.value = "A market with this name already exists";
-            } else {
-                errorMessage.value = error.response.data.error;
-            }
-        } else {
-            errorMessage.value = "An error occurred. Please try again.";
-        }
+    router.push('/market-setup')
+  } catch (error) {
+    if (
+      axios.isAxiosError(error) &&
+      error.response?.status === 400 &&
+      error.response?.data?.error
+    ) {
+      const errorText = error.response.data.error.toLowerCase()
+      if (errorText.includes('already exists') || errorText.includes('market already')) {
+        errorMessage.value = 'A market with this name already exists'
+      } else {
+        errorMessage.value = error.response.data.error
+      }
+    } else {
+      errorMessage.value = 'An error occurred. Please try again.'
     }
+  }
 }
 </script>
 
 <template>
-    <div class="container" :style="{ visibility: newOpen ? 'visible' : 'hidden' }">
-        <div class="background" @click="$emit('newClose')" :style="{ opacity: newOpen ? '100%' : '0%' }" data-testid="new-market-overlay-background">
+  <div class="container" :style="{ visibility: newOpen ? 'visible' : 'hidden' }">
+    <div
+      class="background"
+      @click="$emit('newClose')"
+      :style="{ opacity: newOpen ? '100%' : '0%' }"
+      data-testid="new-market-overlay-background"
+    ></div>
+    <template v-if="!next">
+      <ElementFileDrop
+        :isOpen="newOpen"
+        @file-uploaded="handleFileUploaded"
+        @source-data-uploaded="handleSourceDataUploaded"
+      ></ElementFileDrop>
+    </template>
+    <template v-else>
+      <div class="window">
+        <h2>Create new market</h2>
+        <div class="org-select-container">
+          <label class="org-select-label">Organization</label>
+          <ElementOrgSelect v-model="selectedOrgId" />
         </div>
-        <template v-if="!next">
-            <ElementFileDrop :isOpen="newOpen" @file-uploaded="handleFileUploaded" @source-data-uploaded="handleSourceDataUploaded"></ElementFileDrop>
-        </template>
-        <template v-else>
-            <div class="window">
-                <h2>
-                    Create new market
-                </h2>
-                <div class="org-select-container">
-                    <label class="org-select-label">Organization</label>
-                    <ElementOrgSelect v-model="selectedOrgId" />
-                </div>
-                <div class="input-wrapper">
-                    <div style="width: 100%; height: 30px; display: grid; grid-template-columns: 1fr 3fr 1fr;">
-                        <div></div>
-                        <div class="text-input-container">
-                            <input type="text" v-model="marketName" @keydown.enter="handleSubmit" @input="errorMessage = ''"
-                                style="all: unset; font-size: 14px; width: 100%; text-align: center;" placeholder="Market name" data-testid="new-market-name-input" />
-                        </div>
-                        <div style="padding-left: 10px">
-                            <button @click="handleSubmit" :disabled="!selectedOrgId"
-                                style="all: unset; height: 100%; width: 100%; cursor: pointer;"
-                                :style="{ opacity: selectedOrgId ? '75%' : '30%', cursor: selectedOrgId ? 'pointer' : 'not-allowed' }" data-testid="new-market-submit-button">Submit</button>
-                        </div>
-                    </div>
-                    <p v-show="errorMessage" class="error-message">{{ errorMessage }}</p>
-                </div>
+        <div class="input-wrapper">
+          <div style="width: 100%; height: 30px; display: grid; grid-template-columns: 1fr 3fr 1fr">
+            <div></div>
+            <div class="text-input-container">
+              <input
+                type="text"
+                v-model="marketName"
+                @keydown.enter="handleSubmit"
+                @input="errorMessage = ''"
+                style="all: unset; font-size: 14px; width: 100%; text-align: center"
+                placeholder="Market name"
+                data-testid="new-market-name-input"
+              />
             </div>
-        </template>
-    </div>
+            <div style="padding-left: 10px">
+              <button
+                @click="handleSubmit"
+                :disabled="!selectedOrgId"
+                style="all: unset; height: 100%; width: 100%; cursor: pointer"
+                :style="{
+                  opacity: selectedOrgId ? '75%' : '30%',
+                  cursor: selectedOrgId ? 'pointer' : 'not-allowed',
+                }"
+                data-testid="new-market-submit-button"
+              >
+                Submit
+              </button>
+            </div>
+          </div>
+          <p v-show="errorMessage" class="error-message">{{ errorMessage }}</p>
+        </div>
+      </div>
+    </template>
+  </div>
 </template>
 
 <style scoped>
 h3 {
-    display: inline;
+  display: inline;
 }
 
 .container {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
 }
 
 .background {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.5);
-    opacity: 0%;
-    transition: opacity 0.15s ease-in-out, visibility 0.15s ease-in-out;
-    z-index: 0;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0%;
+  transition:
+    opacity 0.15s ease-in-out,
+    visibility 0.15s ease-in-out;
+  z-index: 0;
 }
 
 .window {
-    position: relative;
-    width: 25%;
-    min-height: 140px;
-    padding: 25px;
-    gap: 10px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    background: white;
-    border-radius: 8px;
-    z-index: 1;
+  position: relative;
+  width: 25%;
+  min-height: 140px;
+  padding: 25px;
+  gap: 10px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background: white;
+  border-radius: 8px;
+  z-index: 1;
 }
 
 .org-select-container {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 4px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
 }
 
 .org-select-label {
-    font-size: 12px;
-    font-weight: 600;
-    color: #666;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
 }
 
 .input-wrapper {
-    width: 100%;
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  width: 100%;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .text-input-container {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    flex-direction: row;
-    box-shadow: inset 0px 0px 4px 2px rgba(0, 0, 0, 0.25);
-    border-radius: 8px;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  box-shadow: inset 0px 0px 4px 2px rgba(0, 0, 0, 0.25);
+  border-radius: 8px;
 }
 
 .error-message {
-    position: absolute;
-    top: 35px;
-    left: 50%;
-    transform: translateX(-50%);
-    color: #d32f2f;
-    font-size: 13px;
-    text-align: center;
-    white-space: nowrap;
-    pointer-events: none;
+  position: absolute;
+  top: 35px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: #d32f2f;
+  font-size: 13px;
+  text-align: center;
+  white-space: nowrap;
+  pointer-events: none;
 }
 </style>


### PR DESCRIPTION
## Intent

Fix flaky E2E spec new-market-org.spec.ts:28 that times out at waitForNameInput() during full-suite runs. Root cause: CSS z-index stacking bug — .window and .file-container had z-index:1 on position:static (inert), so the semi-transparent overlay background (position:fixed, z-index:0) painted on top. The file-drop button click could land on the background instead, preventing the file dialog from opening. Fix: position:relative on all 4 overlay .window rules and .file-container to activate z-index. Also added CSV data verification via localStorage. Review step already approved and added fixes for sibling overlays. Base is dev, never main.

## What Changed

- Added `position: relative` to `.window` in all four overlay views (NewMarketOverlay, ManageMarketOverlay, ManageOrgOverlay, LoadMarketOverlay) and to `.file-container` in ElementFileDrop.vue to activate existing `z-index` rules that were inert on `position: static`, fixing a CSS stacking bug where the semi-transparent overlay background painted on top and intercepted click events on file-drop buttons, causing flaky E2E timeouts
- Hardened `new-market-org.spec.ts` with localStorage-based CSV parse verification to catch silent upload failures and applied Prettier formatting across all changed files

## Risk Assessment

✅ Low: The CSS fix adds position: relative with no offsets - zero layout impact, only activates existing z-index values. The E2E test addition is a defensive assertion. Both changes are minimal, well-bounded, and consistent with existing codebase patterns.

## Testing

Ran the targeted flaky test new-market-org.spec.ts (2 tests, ~3s) plus regression tests on market-pipeline, floorplan, and access-control specs (8 additional tests). All 10 tests passed. The CSS fix (position: relative activating z-index:1 on 4 overlay .window rules and .file-container) ensures the file-drop button click lands on the button rather than the semi-transparent background. The new CSV localStorage verification assertions pass. Screenshots from the test run confirm the NewMarketOverlay renders correctly with the org dropdown, submit blocking, and zero-org fallback states all visible.

- Evidence: Submit blocked when no org selected (local file: <code>/tmp/no-mistakes-evidence/01KXH4VC5VP592C6VB8C6GK9TR/01-submit-blocked-no-org.png</code>)
- Evidence: Org selected - submit enabled (local file: <code>/tmp/no-mistakes-evidence/01KXH4VC5VP592C6VB8C6GK9TR/02-org-selected-submit-enabled.png</code>)
- Evidence: Zero-org fallback hint (local file: <code>/tmp/no-mistakes-evidence/01KXH4VC5VP592C6VB8C6GK9TR/03-zero-org-fallback.png</code>)
- Evidence: Test run video recording (local file: <code>/tmp/no-mistakes-evidence/01KXH4VC5VP592C6VB8C6GK9TR/video.webm</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx playwright test new-market-org.spec.ts` - both tests pass (org picker gating + zero-org fallback)</code>
- <code>`npx playwright test market-pipeline.spec.ts` - 3 tests pass (exercises NewMarketOverlay file-drop and org-select)</code>
- <code>`npx playwright test floorplan.spec.ts` - 1 test passes (exercises NewMarketOverlay)</code>
- <code>`npx playwright test access-control.spec.ts` - 4 tests pass (exercises ManageOrgOverlay)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
