### PR TITLE
feat(applications): organizer monitoring view and results-publication gate

### DIFF
--- a/back-end/api/applicant_auth.py
+++ b/back-end/api/applicant_auth.py
@@ -394,14 +394,14 @@ def verify_login_code(market_slug: str) -> tuple:
     # Consume and verify. All failure branches inside this function return the
     # same observable outcome.
     if _consume_and_verify(market_id, email, code):
-        # Look up the application and issue a JWT so the caller can make
-        # authenticated application calls (get/save application).
         apps_collection = db["applications"]
-        app_doc = apps_collection.find_one(
-            {"market_id": market_id, "applicant_email": email}
-        )
+        app_doc = apps_collection.find_one({
+            "market_id": market_id,
+            "applicant_email": email,
+            "application_type": "main",
+        })
         token = None
-        if app_doc:
+        if app_doc and app_doc.get("id"):
             token = generate_application_token(
                 app_doc["id"], market_id, email,
             )

--- a/back-end/api/applicant_auth.py
+++ b/back-end/api/applicant_auth.py
@@ -43,6 +43,8 @@ from market_documents import published_market_by_slug
 from utils.email import _email_disabled, ready_mailer, from_email, frontend_url
 from utils.application_token import generate_application_token
 
+import api.applications as ApplicationsApi
+
 logger = logging.getLogger(__name__)
 
 # ── Collection setup ──────────────────────────────────────────────────────
@@ -394,12 +396,7 @@ def verify_login_code(market_slug: str) -> tuple:
     # Consume and verify. All failure branches inside this function return the
     # same observable outcome.
     if _consume_and_verify(market_id, email, code):
-        apps_collection = db["applications"]
-        app_doc = apps_collection.find_one({
-            "market_id": market_id,
-            "applicant_email": email,
-            "application_type": "main",
-        })
+        app_doc = ApplicationsApi.find_application_by_email(market_id, email)
         token = None
         if app_doc and app_doc.get("id"):
             token = generate_application_token(

--- a/back-end/api/applicant_auth.py
+++ b/back-end/api/applicant_auth.py
@@ -41,6 +41,7 @@ from pymongo.errors import PyMongoError
 from db_config import get_database
 from market_documents import published_market_by_slug
 from utils.email import _email_disabled, ready_mailer, from_email, frontend_url
+from utils.application_token import generate_application_token
 
 logger = logging.getLogger(__name__)
 
@@ -393,10 +394,25 @@ def verify_login_code(market_slug: str) -> tuple:
     # Consume and verify. All failure branches inside this function return the
     # same observable outcome.
     if _consume_and_verify(market_id, email, code):
-        return jsonify({
+        # Look up the application and issue a JWT so the caller can make
+        # authenticated application calls (get/save application).
+        apps_collection = db["applications"]
+        app_doc = apps_collection.find_one(
+            {"market_id": market_id, "applicant_email": email}
+        )
+        token = None
+        if app_doc:
+            token = generate_application_token(
+                app_doc["id"], market_id, email,
+            )
+
+        response = {
             "success": True,
             "marketId": market_id,
             "applicantEmail": email,
-        }), 200
+        }
+        if token:
+            response["token"] = token
+        return jsonify(response), 200
 
     return jsonify(_VERIFY_FAILURE_BODY), _VERIFY_FAILURE_STATUS

--- a/back-end/api/applicants.py
+++ b/back-end/api/applicants.py
@@ -31,7 +31,6 @@ from datatypes import (
     Application,
     ApplicationStatus,
     ApplicationType,
-    FormField,
     MarketPhase,
     phase_from_market_document,
 )
@@ -39,12 +38,12 @@ from utils.application_token import (
     generate_application_token,
     verify_application_token,
 )
+from utils.captcha import verify_recaptcha
 
 import api.applications as ApplicationsApi
 
 logger = logging.getLogger(__name__)
 
-APPLICANT_APPLICATION_COLLECTION = "applicants"
 
 # ── Publication gate ───────────────────────────────────────────────────────
 
@@ -117,14 +116,6 @@ def _application_response_organizer(app: Application) -> Dict[str, Any]:
     }
 
 
-def _load_market_results_published(market_id: str) -> bool:
-    """Read the ``results_published`` flag from a stored market document."""
-    from db_config import get_database
-    db = get_database()
-    doc = db["markets"].find_one({"id": market_id}, {"resultsPublished": 1})
-    if not doc:
-        return False
-    return bool(doc.get("resultsPublished"))
 
 
 # ── JWT authentication ─────────────────────────────────────────────────────
@@ -229,7 +220,7 @@ def get_applicant_application(
     # Verify the token belongs to this market
     from db_config import get_database
     db = get_database()
-    market_doc = published_market_by_slug(db["markets"], market_slug, fields=("id",))
+    market_doc = published_market_by_slug(db["markets"], market_slug, fields=("id", "resultsPublished"))
     if not market_doc:
         return {"error": "Market not found."}, 404
 
@@ -248,7 +239,7 @@ def get_applicant_application(
         return {"error": "Application not found."}, 404
 
     app = Application(**app_doc)
-    results_published = _load_market_results_published(market_id)
+    results_published = bool(market_doc.get("resultsPublished"))
     return {"application": _application_response(app, results_published)}, 200
 
 
@@ -276,7 +267,7 @@ def save_applicant_application(
     db = get_database()
 
     market_doc = published_market_by_slug(
-        db["markets"], market_slug, fields=("id", "phase", "applicationForm"),
+        db["markets"], market_slug, fields=("id", "phase", "applicationForm", "resultsPublished"),
     )
     if not market_doc:
         return {"error": "Market not found."}, 404
@@ -320,33 +311,44 @@ def save_applicant_application(
     if not app_doc.get("status"):
         changes["status"] = ApplicationStatus.OPEN.value
 
-    ApplicationsApi.applications_collection.update_one({"id": app_id}, {"$set": changes})
+    ApplicationsApi.update_application_form_data(
+        app_id, stored_form_data,
+        changes["submitted_at"], changes["updated_at"],
+    )
+    if not app_doc.get("status"):
+        ApplicationsApi.applications_collection.update_one(
+            {"id": app_id}, {"$set": {"status": ApplicationStatus.OPEN.value}},
+        )
 
     updated_doc = ApplicationsApi.find_application_by_id(app_id)
     app = Application(**updated_doc) if updated_doc else Application(**app_doc)
-    results_published = _load_market_results_published(market_id)
+    results_published = bool(market_doc.get("resultsPublished"))
     return {"application": _application_response(app, results_published)}, 200
 
 
 def request_applicant_token(
-    market_slug: str, email: str,
+    market_slug: str, email: str, captcha_token: str = "",
 ) -> Tuple[Dict[str, Any], int]:
     """Issue an application-scoped JWT for an applicant who has already verified their email.
 
-    This is the bridge between the 5d code-based login and the JWT-authenticated application
-    endpoints. Called after the applicant has successfully verified their login code.
-    If no application exists for this email+market, one is created (in ``applications_open``
-    phase only -- outside that phase, the email must already have an application).
+    This endpoint requires a reCAPTCHA token to prevent unauthenticated callers from
+    creating applications or obtaining JWTs for arbitrary email addresses.
 
     Args:
         market_slug: The URL-safe slug of the market.
-        email: The applicant's email address (already verified via login code).
+        email: The applicant's email address.
+        captcha_token: The reCAPTCHA token the browser obtained for this action.
 
     Returns:
         Tuple of (response_body, status_code).
     """
     if not email or not email.strip():
         return {"error": "Email is required."}, 400
+
+    captcha_ok, _score = verify_recaptcha(captcha_token, None)
+    if not captcha_ok:
+        return {"error": "Could not verify that this request came from a browser. "
+                         "Please reload the page and try again."}, 400
 
     email = email.strip().lower()
 

--- a/back-end/api/applicants.py
+++ b/back-end/api/applicants.py
@@ -1,0 +1,581 @@
+"""Applicant-facing application endpoints and organizer monitoring endpoints.
+
+The applicant read path and the organizer review/monitoring path are in one module because they
+share the same publication gate: ``applicant_visible_status`` is the one place that decides what
+an applicant sees, and the organizer endpoints bypass it so the organizer always sees the truth.
+
+Publication gate (captain ruling 2026-07-13):
+    An applicant may sign in during any phase and always see their own submitted application.
+    ``reviewer_approved`` / ``reviewer_rejected`` outcomes are HIDDEN from the applicant until
+    the organizer explicitly PUBLISHES results. Until publication, the applicant sees a neutral
+    ``under_review`` state - never the verdict.
+
+    An organizer must not leak a half-finished review, and must retain the ability to change their
+    mind before any applicant sees an outcome. Publication is the single, deliberate,
+    organizer-controlled moment the verdict becomes visible.
+
+    The enforcement lives on the BACKEND in ``applicant_visible_status``. No client-side hiding
+    is sufficient: a verdict present in the API response is an information leak in the page markup,
+    the same class of bug as the login oracle closed in 5d.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from market_documents import (
+    market_doc_field,
+    published_market_by_slug,
+)
+from datatypes import (
+    Application,
+    ApplicationStatus,
+    ApplicationType,
+    FormField,
+    MarketPhase,
+    phase_from_market_document,
+)
+from utils.application_token import (
+    generate_application_token,
+    verify_application_token,
+)
+
+import api.applications as ApplicationsApi
+
+logger = logging.getLogger(__name__)
+
+APPLICANT_APPLICATION_COLLECTION = "applicants"
+
+# ── Publication gate ───────────────────────────────────────────────────────
+
+# The states of a review the organizer has not finished delivering. A reviewer recording a verdict
+# is not the organizer sending it, and until the organizer acts outward via the publish-results
+# endpoint, the applicant is told only that the application is under review.
+#
+# This has to be enforced here, on the way out of the process, because anything the applicant's
+# browser receives, the applicant can read: a client-side label mapped over a payload that carries
+# ``reviewer_rejected`` still ships the rejection in the response body and into the page markup.
+# There is no applicant-facing payload that does not pass through ``_application_response``, so this
+# is the one place that decides, and nothing downstream of it may reintroduce the raw value.
+REVIEW_IN_PROGRESS_STATUSES = frozenset({
+    ApplicationStatus.UNDER_REVIEW,
+    ApplicationStatus.REVIEWER_APPROVED,
+    ApplicationStatus.REVIEWER_REJECTED,
+})
+
+
+def applicant_visible_status(
+    status: ApplicationStatus, results_published: bool,
+) -> ApplicationStatus:
+    """The status of an application as its applicant is allowed to know it.
+
+    An organizer must not leak a half-finished review, and must retain the ability to change their
+    mind before any applicant sees an outcome. Publication is the single, deliberate,
+    organizer-controlled moment the verdict becomes visible.
+
+    Until results are published, every working state of an unfinished review is collapsed to
+    ``under_review`` so the applicant cannot distinguish a provisional acceptance from a
+    provisional rejection. After publication the applicant sees the actual verdict.
+
+    The organizer's view goes directly to the stored status and does not pass through here at all,
+    so the organizer always sees the truth.
+    """
+    if not results_published and status in REVIEW_IN_PROGRESS_STATUSES:
+        return ApplicationStatus.UNDER_REVIEW
+    return status
+
+
+def _application_response(
+    app: Application, results_published: bool,
+) -> Dict[str, Any]:
+    """Serialize an application for the applicant-facing API with the publication gate applied."""
+    return {
+        "id": app.id,
+        "marketId": app.market_id,
+        "applicantEmail": app.applicant_email,
+        "formData": app.form_data,
+        "status": applicant_visible_status(app.status, results_published).value,
+        "applicationType": app.application_type.value,
+        "mainApplicationId": app.main_application_id,
+        "submittedAt": app.submitted_at,
+        "updatedAt": app.updated_at,
+    }
+
+
+def _application_response_organizer(app: Application) -> Dict[str, Any]:
+    """Serialize an application for the organizer-facing API with the raw status always visible."""
+    return {
+        "id": app.id,
+        "marketId": app.market_id,
+        "applicantEmail": app.applicant_email,
+        "formData": app.form_data,
+        "status": app.status.value,
+        "applicationType": app.application_type.value,
+        "mainApplicationId": app.main_application_id,
+        "submittedAt": app.submitted_at,
+        "updatedAt": app.updated_at,
+    }
+
+
+def _load_market_results_published(market_id: str) -> bool:
+    """Read the ``results_published`` flag from a stored market document."""
+    from db_config import get_database
+    db = get_database()
+    doc = db["markets"].find_one({"id": market_id}, {"resultsPublished": 1})
+    if not doc:
+        return False
+    return bool(doc.get("resultsPublished"))
+
+
+# ── JWT authentication ─────────────────────────────────────────────────────
+
+
+def authenticate_request(authorization_header: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Parse the ``Authorization: Bearer <token>`` header and return the payload.
+
+    Called by the route handlers to authenticate applicant requests.
+
+    Args:
+        authorization_header: The raw ``Authorization`` header value.
+
+    Returns:
+        Decoded token payload dict or None if invalid.
+    """
+    if not authorization_header:
+        return None
+    parts = authorization_header.strip().split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    return verify_application_token(parts[1])
+
+
+# ── Public (unauthenticated) endpoints ─────────────────────────────────────
+
+
+def get_public_application_form(
+    market_slug: str,
+) -> Tuple[Dict[str, Any], int]:
+    """Return the public application form for a market.
+
+    Accessible without authentication. The form is returned for every published market, in every
+    phase, alongside the phase and an ``is_open`` flag that says whether the market is still taking
+    applications. It is not phase-gated on purpose: the applicant dashboard renders stored answers
+    against this field list, so a market that has closed still has to be able to hand it over.
+
+    Args:
+        market_slug: The URL-safe slug of the market.
+
+    Returns:
+        Tuple of (response_body, status_code).
+    """
+    if not market_slug or not market_slug.strip():
+        return {"error": "Market identifier is required."}, 400
+
+    from db_config import get_database
+    db = get_database()
+    market_doc = published_market_by_slug(
+        db["markets"],
+        market_slug,
+        fields=("id", "name", "phase", "applicationForm", "resultsPublished"),
+    )
+    if not market_doc:
+        return {"error": "Market not found. Check the URL and try again."}, 404
+
+    phase = phase_from_market_document(market_doc)
+    application_form = market_doc_field(market_doc, "application_form")
+
+    form_payload = None
+    if application_form:
+        fields = []
+        for i, f in enumerate(application_form.get("fields", [])):
+            fields.append({
+                "key": f.get("key", ""),
+                "label": f.get("label", ""),
+                "type": f.get("type", "text"),
+                "required": f.get("required", False),
+                "options": f.get("options", []),
+                "helpText": f.get("helpText"),
+                "order": f.get("order", i),
+            })
+        form_payload = {"fields": fields}
+
+    return {
+        "application_form": form_payload,
+        "market_name": market_doc.get("name", ""),
+        "phase": phase.value,
+        "is_open": phase == MarketPhase.APPLICATIONS_OPEN,
+        "phase_label": phase.value.replace("_", " ").title(),
+    }, 200
+
+
+# ── Applicant (JWT-authenticated) endpoints ────────────────────────────────
+
+
+def get_applicant_application(
+    market_slug: str, token_payload: Dict[str, Any],
+) -> Tuple[Dict[str, Any], int]:
+    """Return the authenticated applicant's application data for this market.
+
+    The status is passed through ``applicant_visible_status`` so the publication gate is enforced
+    on the applicant read path.
+
+    Args:
+        market_slug: The URL-safe slug of the market.
+        token_payload: Decoded JWT payload from ``verify_application_token``.
+
+    Returns:
+        Tuple of (response_body, status_code).
+    """
+    # Verify the token belongs to this market
+    from db_config import get_database
+    db = get_database()
+    market_doc = published_market_by_slug(db["markets"], market_slug, fields=("id",))
+    if not market_doc:
+        return {"error": "Market not found."}, 404
+
+    market_id = market_doc.get("id", "")
+    token_market_id = token_payload.get("market_id", "")
+    if token_market_id != market_id:
+        return {"error": "Your sign-in is for a different market. Please sign in again."}, 403
+
+    app_id = token_payload.get("application_id", "")
+    app_doc = ApplicationsApi.find_application_by_id(app_id)
+    if not app_doc:
+        return {"error": "Application not found."}, 404
+
+    # Verify the application belongs to the token's email
+    if app_doc.get("applicant_email") != token_payload.get("email"):
+        return {"error": "Application not found."}, 404
+
+    app = Application(**app_doc)
+    results_published = _load_market_results_published(market_id)
+    return {"application": _application_response(app, results_published)}, 200
+
+
+def save_applicant_application(
+    market_slug: str, token_payload: Dict[str, Any], form_data: Dict[str, Any],
+) -> Tuple[Dict[str, Any], int]:
+    """Save or update the authenticated applicant's application for this market.
+
+    Validates the form data against the market's application form fields.
+    Refuses submission when the market is not in ``applications_open``.
+    The applicant owns their answers but never ``status``.
+
+    Args:
+        market_slug: The URL-safe slug of the market.
+        token_payload: Decoded JWT payload from ``verify_application_token``.
+        form_data: The form answers keyed by field keys.
+
+    Returns:
+        Tuple of (response_body, status_code).
+    """
+    if not isinstance(form_data, dict):
+        return {"error": "Form answers must be an object keyed by field key."}, 400
+
+    from db_config import get_database
+    db = get_database()
+
+    market_doc = published_market_by_slug(
+        db["markets"], market_slug, fields=("id", "phase", "applicationForm"),
+    )
+    if not market_doc:
+        return {"error": "Market not found."}, 404
+
+    market_id = market_doc.get("id", "")
+    token_market_id = token_payload.get("market_id", "")
+    if token_market_id != market_id:
+        return {"error": "Your sign-in is for a different market."}, 403
+
+    phase = phase_from_market_document(market_doc)
+    if phase != MarketPhase.APPLICATIONS_OPEN:
+        phase_label = phase.value.replace("_", " ").title()
+        return {
+            "error": f"Applications are no longer open for this market. "
+                     f"The market is in the {phase_label} phase.",
+        }, 403
+
+    app_id = token_payload.get("application_id", "")
+    app_doc = ApplicationsApi.find_application_by_id(app_id)
+    if not app_doc:
+        return {"error": "Application not found."}, 404
+
+    if app_doc.get("applicant_email") != token_payload.get("email"):
+        return {"error": "Application not found."}, 404
+
+    # Validate form data against the application form fields
+    application_form = market_doc_field(market_doc, "application_form")
+    fields = (application_form or {}).get("fields") or []
+    error, stored_form_data = _validated_form_data(form_data, fields)
+    if error:
+        return {"error": error}, 422
+
+    now = datetime.now(timezone.utc).isoformat()
+
+    # The applicant owns their answers. They do not own ``status``.
+    changes: Dict[str, Any] = {
+        "form_data": stored_form_data,
+        "submitted_at": app_doc.get("submitted_at") or now,
+        "updated_at": now,
+    }
+    if not app_doc.get("status"):
+        changes["status"] = ApplicationStatus.OPEN.value
+
+    ApplicationsApi.applications_collection.update_one({"id": app_id}, {"$set": changes})
+
+    updated_doc = ApplicationsApi.find_application_by_id(app_id)
+    app = Application(**updated_doc) if updated_doc else Application(**app_doc)
+    results_published = _load_market_results_published(market_id)
+    return {"application": _application_response(app, results_published)}, 200
+
+
+def request_applicant_token(
+    market_slug: str, email: str,
+) -> Tuple[Dict[str, Any], int]:
+    """Issue an application-scoped JWT for an applicant who has already verified their email.
+
+    This is the bridge between the 5d code-based login and the JWT-authenticated application
+    endpoints. Called after the applicant has successfully verified their login code.
+    If no application exists for this email+market, one is created (in ``applications_open``
+    phase only -- outside that phase, the email must already have an application).
+
+    Args:
+        market_slug: The URL-safe slug of the market.
+        email: The applicant's email address (already verified via login code).
+
+    Returns:
+        Tuple of (response_body, status_code).
+    """
+    if not email or not email.strip():
+        return {"error": "Email is required."}, 400
+
+    email = email.strip().lower()
+
+    from db_config import get_database
+    db = get_database()
+
+    market_doc = published_market_by_slug(
+        db["markets"], market_slug, fields=("id", "phase", "resultsPublished"),
+    )
+    if not market_doc:
+        return {"error": "Market not found."}, 404
+
+    market_id = market_doc.get("id", "")
+    phase = phase_from_market_document(market_doc)
+
+    app_doc = ApplicationsApi.find_application_by_email(market_id, email)
+    if not app_doc:
+        if phase == MarketPhase.APPLICATIONS_OPEN:
+            app = Application(
+                market_id=market_id,
+                applicant_email=email,
+                form_data={},
+                status=ApplicationStatus.OPEN,
+                application_type=ApplicationType.MAIN,
+            )
+            app = ApplicationsApi.find_or_create_application(app)
+            app_doc = ApplicationsApi.find_application_by_email(market_id, email)
+        else:
+            return {"error": "No application found for this email."}, 404
+
+    if not app_doc:
+        return {"error": "Could not create or find application."}, 500
+
+    app = Application(**app_doc)
+    token = generate_application_token(app.id, market_id, email)
+    results_published = bool(market_doc.get("resultsPublished"))
+
+    return {
+        "token": token,
+        "application": _application_response(app, results_published),
+    }, 200
+
+
+# ── Organizer (session-authenticated) endpoints ────────────────────────────
+
+
+def list_market_applications(market_id: str) -> Tuple[Dict[str, Any], int]:
+    """Return every application for a market. Organizer only, always sees raw status."""
+    apps = ApplicationsApi.list_applications_for_market(market_id)
+    result: List[Dict[str, Any]] = []
+    for doc in apps:
+        try:
+            app = Application(**doc)
+            result.append(_application_response_organizer(app))
+        except Exception as e:
+            logger.warning("Failed to parse application %s: %s", doc.get("id", "?"), e)
+    return {"applications": result}, 200
+
+
+def review_application(
+    market_id: str, application_id: str, new_status: ApplicationStatus,
+) -> Tuple[Dict[str, Any], int]:
+    """Record a review verdict on an application. Organizer only, always sees raw status.
+
+    The verdict is written but NOT revealed to the applicant until results are published.
+    """
+    if new_status not in (ApplicationStatus.REVIEWER_APPROVED, ApplicationStatus.REVIEWER_REJECTED):
+        return {"error": f"Invalid review status: {new_status.value}"}, 400
+
+    found = ApplicationsApi.update_application_status(application_id, new_status)
+    if not found:
+        return {"error": "Application not found."}, 404
+
+    # Verify the application belongs to this market
+    app_doc = ApplicationsApi.find_application_by_id(application_id)
+    if not app_doc or app_doc.get("market_id") != market_id:
+        return {"error": "Application not found for this market."}, 404
+
+    app = Application(**app_doc)
+    return {"application": _application_response_organizer(app)}, 200
+
+
+def publish_results(market_id: str) -> Tuple[Dict[str, Any], int]:
+    """Flip the results_published flag on a market, making verdicts visible to applicants.
+
+    This is the single, deliberate, organizer-controlled moment the review verdicts become
+    visible to the applicants who hold them. Before this call, every approved and rejected
+    application reads as ``under_review`` to its applicant. After it, applicants see their
+    actual outcome.
+    """
+    from db_config import get_database
+    db = get_database()
+
+    doc = db["markets"].find_one({"id": market_id})
+    if not doc:
+        return {"error": "Market not found."}, 404
+
+    already_published = bool(doc.get("resultsPublished"))
+    if already_published:
+        return {"error": "Results are already published."}, 409
+
+    db["markets"].update_one(
+        {"id": market_id},
+        {"$set": {"resultsPublished": True}},
+    )
+    return {"results_published": True}, 200
+
+
+# ── Form validation (shared between applicant and organizer) ───────────────
+
+def _validated_form_data(
+    incoming: Dict[str, Any], fields: List[Dict[str, Any]],
+) -> Tuple[Optional[str], Dict[str, Any]]:
+    """Validate submitted form data against field definitions.
+
+    Returns (error_message, stored_data). When ``error_message`` is not None, the form
+    should be refused. When it is None, ``stored_data`` is ready to persist.
+
+    Field key defines identity; anything not in a field key is ignored (and
+    stripped). An answer is present when it passes the field-type-specific
+    "answered" test.
+    """
+    if not fields:
+        return "This market does not have an application form configured.", {}
+
+    stored: Dict[str, Any] = {}
+
+    for field_def in fields:
+        key = field_def.get("key")
+        if not key:
+            continue
+        field_type = field_def.get("type", "text")
+        required = field_def.get("required", False)
+        label = field_def.get("label", key)
+
+        raw = incoming.get(key)
+        answered = _is_answered(raw, field_type)
+
+        if not answered:
+            if required:
+                return f"'{label}' is required.", {}
+            stored[key] = _unanswered_value(field_type)
+            continue
+
+        # Type-specific validation
+        if field_type == "number":
+            try:
+                stored[key] = _as_number(raw)
+            except (TypeError, ValueError) as e:
+                return f"'{label}' must be a number: {e}", {}
+            continue
+
+        if field_type in ("select", "multi_select"):
+            options = field_def.get("options") or []
+            if field_type == "select":
+                raw_str = str(raw).strip()
+                if raw_str not in options:
+                    return f"'{label}' must be one of: {', '.join(options)}", {}
+                stored[key] = raw_str
+            else:
+                if not isinstance(raw, list):
+                    return f"'{label}' requires one or more selections.", {}
+                for val in raw:
+                    if str(val).strip() not in options:
+                        return f"'{label}' contains an invalid option: {val}", {}
+                stored[key] = [str(v).strip() for v in raw]
+            continue
+
+        if field_type == "checkbox":
+            if not isinstance(raw, bool):
+                return f"'{label}' must be true or false.", {}
+            stored[key] = raw
+            continue
+
+        # text, email, date: store as trimmed string
+        if not isinstance(raw, str):
+            return f"'{label}' must be text.", {}
+        stored[key] = raw.strip()
+
+    return None, stored
+
+
+def _is_answered(value: Any, field_type: str) -> bool:
+    """Whether a submitted value counts as an answer for a field of this type.
+
+    "Present in the payload" is not the same as "answered", and the difference is type-shaped:
+    an unticked mandatory consent checkbox arrives as ``False`` and an untouched mandatory
+    multi_select as ``[]``, both of which are non-null, non-empty-string values that a purely
+    null/blank test waves through.
+    """
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value.strip() != ""
+    if isinstance(value, list):
+        return len(value) > 0
+    if field_type == "checkbox":
+        return value is True
+    return True
+
+
+def _unanswered_value(field_type: str) -> Any:
+    """What an unanswered field of this type stores."""
+    if field_type == "number":
+        return None
+    if field_type == "checkbox":
+        return False
+    if field_type == "multi_select":
+        return []
+    return ""
+
+
+def _as_number(value: Any) -> Any:
+    """The numeric value of an answer to a ``number`` field. Raises if it is not one."""
+    if isinstance(value, bool):
+        raise TypeError("a boolean is not a number")
+    if isinstance(value, int):
+        number: Any = value
+    elif isinstance(value, str):
+        text = value.strip()
+        try:
+            number = int(text)
+        except ValueError:
+            number = float(text)
+    else:
+        number = float(value)
+    if isinstance(number, float):
+        if number != number or number in (float("inf"), float("-inf")):
+            raise ValueError("not a finite number")
+    if isinstance(number, float) and number.is_integer():
+        return int(number)
+    return number

--- a/back-end/api/applicants.py
+++ b/back-end/api/applicants.py
@@ -316,9 +316,7 @@ def save_applicant_application(
         changes["submitted_at"], changes["updated_at"],
     )
     if not app_doc.get("status"):
-        ApplicationsApi.applications_collection.update_one(
-            {"id": app_id}, {"$set": {"status": ApplicationStatus.OPEN.value}},
-        )
+        ApplicationsApi.update_application_status(app_id, ApplicationStatus.OPEN)
 
     updated_doc = ApplicationsApi.find_application_by_id(app_id)
     app = Application(**updated_doc) if updated_doc else Application(**app_doc)

--- a/back-end/api/applicants.py
+++ b/back-end/api/applicants.py
@@ -30,15 +30,12 @@ from market_documents import (
 from datatypes import (
     Application,
     ApplicationStatus,
-    ApplicationType,
     MarketPhase,
     phase_from_market_document,
 )
 from utils.application_token import (
-    generate_application_token,
     verify_application_token,
 )
-from utils.captcha import verify_recaptcha
 
 import api.applications as ApplicationsApi
 
@@ -322,72 +319,6 @@ def save_applicant_application(
     app = Application(**updated_doc) if updated_doc else Application(**app_doc)
     results_published = bool(market_doc.get("resultsPublished"))
     return {"application": _application_response(app, results_published)}, 200
-
-
-def request_applicant_token(
-    market_slug: str, email: str, captcha_token: str = "",
-) -> Tuple[Dict[str, Any], int]:
-    """Issue an application-scoped JWT for an applicant who has already verified their email.
-
-    This endpoint requires a reCAPTCHA token to prevent unauthenticated callers from
-    creating applications or obtaining JWTs for arbitrary email addresses.
-
-    Args:
-        market_slug: The URL-safe slug of the market.
-        email: The applicant's email address.
-        captcha_token: The reCAPTCHA token the browser obtained for this action.
-
-    Returns:
-        Tuple of (response_body, status_code).
-    """
-    if not email or not email.strip():
-        return {"error": "Email is required."}, 400
-
-    captcha_ok, _score = verify_recaptcha(captcha_token, None)
-    if not captcha_ok:
-        return {"error": "Could not verify that this request came from a browser. "
-                         "Please reload the page and try again."}, 400
-
-    email = email.strip().lower()
-
-    from db_config import get_database
-    db = get_database()
-
-    market_doc = published_market_by_slug(
-        db["markets"], market_slug, fields=("id", "phase", "resultsPublished"),
-    )
-    if not market_doc:
-        return {"error": "Market not found."}, 404
-
-    market_id = market_doc.get("id", "")
-    phase = phase_from_market_document(market_doc)
-
-    app_doc = ApplicationsApi.find_application_by_email(market_id, email)
-    if not app_doc:
-        if phase == MarketPhase.APPLICATIONS_OPEN:
-            app = Application(
-                market_id=market_id,
-                applicant_email=email,
-                form_data={},
-                status=ApplicationStatus.OPEN,
-                application_type=ApplicationType.MAIN,
-            )
-            app = ApplicationsApi.find_or_create_application(app)
-            app_doc = ApplicationsApi.find_application_by_email(market_id, email)
-        else:
-            return {"error": "No application found for this email."}, 404
-
-    if not app_doc:
-        return {"error": "Could not create or find application."}, 500
-
-    app = Application(**app_doc)
-    token = generate_application_token(app.id, market_id, email)
-    results_published = bool(market_doc.get("resultsPublished"))
-
-    return {
-        "token": token,
-        "application": _application_response(app, results_published),
-    }, 200
 
 
 # ── Organizer (session-authenticated) endpoints ────────────────────────────

--- a/back-end/api/applicants.py
+++ b/back-end/api/applicants.py
@@ -299,18 +299,11 @@ def save_applicant_application(
 
     now = datetime.now(timezone.utc).isoformat()
 
-    # The applicant owns their answers. They do not own ``status``.
-    changes: Dict[str, Any] = {
-        "form_data": stored_form_data,
-        "submitted_at": app_doc.get("submitted_at") or now,
-        "updated_at": now,
-    }
-    if not app_doc.get("status"):
-        changes["status"] = ApplicationStatus.OPEN.value
+    submitted_at = app_doc.get("submitted_at") or now
 
     ApplicationsApi.update_application_form_data(
         app_id, stored_form_data,
-        changes["submitted_at"], changes["updated_at"],
+        submitted_at, now,
     )
     if not app_doc.get("status"):
         ApplicationsApi.update_application_status(app_id, ApplicationStatus.OPEN)
@@ -347,15 +340,15 @@ def review_application(
     if new_status not in (ApplicationStatus.REVIEWER_APPROVED, ApplicationStatus.REVIEWER_REJECTED):
         return {"error": f"Invalid review status: {new_status.value}"}, 400
 
-    found = ApplicationsApi.update_application_status(application_id, new_status)
-    if not found:
-        return {"error": "Application not found."}, 404
-
-    # Verify the application belongs to this market
     app_doc = ApplicationsApi.find_application_by_id(application_id)
     if not app_doc or app_doc.get("market_id") != market_id:
         return {"error": "Application not found for this market."}, 404
 
+    found = ApplicationsApi.update_application_status(application_id, new_status)
+    if not found:
+        return {"error": "Application not found."}, 404
+
+    app_doc["status"] = new_status.value
     app = Application(**app_doc)
     return {"application": _application_response_organizer(app)}, 200
 
@@ -374,6 +367,10 @@ def publish_results(market_id: str) -> Tuple[Dict[str, Any], int]:
     doc = db["markets"].find_one({"id": market_id})
     if not doc:
         return {"error": "Market not found."}, 404
+
+    phase = phase_from_market_document(doc)
+    if phase == MarketPhase.DRAFT:
+        return {"error": "Cannot publish results on a draft market."}, 409
 
     already_published = bool(doc.get("resultsPublished"))
     if already_published:

--- a/back-end/api/applications.py
+++ b/back-end/api/applications.py
@@ -13,12 +13,12 @@ Identity contract: (``market_id``, ``applicant_email``, ``application_type``) id
 application, and the database is what enforces that -- see ``ensure_application_indexes``.
 """
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 from pymongo import ReturnDocument
 from pymongo.errors import DuplicateKeyError, PyMongoError
 
-from datatypes import Application
+from datatypes import Application, ApplicationStatus
 from db_config import get_database
 
 logger = logging.getLogger(__name__)
@@ -152,3 +152,62 @@ def find_or_create_application(app: Application) -> Application:
         f"Could not store the application for {app.applicant_email}: a concurrent write for the "
         f"same applicant keeps winning, and no document for them can be read back."
     )
+
+
+def list_applications_for_market(market_id: str) -> List[Dict[str, Any]]:
+    """Return every application belonging to one market, newest first."""
+    ensure_application_indexes()
+    cursor = applications_collection.find(market_filter(market_id)).sort(
+        "submitted_at", -1
+    )
+    apps = []
+    for doc in cursor:
+        doc.pop("_id", None)
+        apps.append(doc)
+    return apps
+
+
+def find_application_by_id(app_id: str) -> Optional[Dict[str, Any]]:
+    """Find one application by its ``id`` field."""
+    ensure_application_indexes()
+    doc = applications_collection.find_one({"id": app_id})
+    if doc:
+        doc.pop("_id", None)
+    return doc
+
+
+def find_application_by_email(market_id: str, email: str) -> Optional[Dict[str, Any]]:
+    """Find one application by its market + email identity."""
+    ensure_application_indexes()
+    doc = applications_collection.find_one(
+        applicant_filter(market_id, email, ApplicationType.MAIN.value)
+    )
+    if doc:
+        doc.pop("_id", None)
+    return doc
+
+
+def update_application_status(app_id: str, status: ApplicationStatus) -> bool:
+    """Set a new status on an application. Returns whether any document was matched."""
+    ensure_application_indexes()
+    result = applications_collection.update_one(
+        {"id": app_id},
+        {"$set": {"status": status.value}},
+    )
+    return result.matched_count > 0
+
+
+def update_application_form_data(
+    app_id: str, form_data: Dict[str, Any], submitted_at: str, updated_at: str,
+) -> bool:
+    """Write form answers and timestamps for an application."""
+    ensure_application_indexes()
+    result = applications_collection.update_one(
+        {"id": app_id},
+        {"$set": {
+            "form_data": form_data,
+            "submitted_at": submitted_at,
+            "updated_at": updated_at,
+        }},
+    )
+    return result.matched_count > 0

--- a/back-end/api/applications.py
+++ b/back-end/api/applications.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional
 from pymongo import ReturnDocument
 from pymongo.errors import DuplicateKeyError, PyMongoError
 
-from datatypes import Application, ApplicationStatus
+from datatypes import Application, ApplicationStatus, ApplicationType
 from db_config import get_database
 
 logger = logging.getLogger(__name__)

--- a/back-end/api/markets.py
+++ b/back-end/api/markets.py
@@ -255,6 +255,8 @@ def _preserve_server_owned_fields(
     market_dict["phase"] = existing_market.phase.value
     market_dict["is_draft"] = existing_market.is_draft
     market_dict["application_form"] = _application_form_dump(existing_market)
+    # results_published is a server-owned gate: only the publish-results endpoint flips it.
+    market_dict["results_published"] = existing_market.results_published
     for field in ("review_config", "discord_guild_id"):
         if field in market.model_fields_set:
             continue

--- a/back-end/app.py
+++ b/back-end/app.py
@@ -1320,23 +1320,6 @@ def public_get_application_form(market_slug: str) -> Response:
         return jsonify({"error": "Internal server error"}), 500
 
 
-@app.route('/public/markets/<market_slug>/applicant/token', methods=['POST'])
-def applicant_request_token(market_slug: str) -> Response:
-    """Issue an application-scoped JWT. Requires reCAPTCHA verification."""
-    try:
-        data = request.json or {}
-        email = data.get('email') or ''
-        captcha_token = data.get('captchaToken') or data.get('captcha_token') or ''
-        result, status_code = ApplicantsApi.request_applicant_token(
-            market_slug, email, captcha_token,
-        )
-        return jsonify(result), status_code
-    except Exception as e:
-        logger.error(f"Error in applicant_request_token {market_slug}: {e}")
-        logger.error(traceback.format_exc())
-        return jsonify({"error": "Internal server error"}), 500
-
-
 @app.route('/public/markets/<market_slug>/applicant/application', methods=['GET'])
 def public_get_applicant_application(market_slug: str) -> Response:
     """Return the authenticated applicant's application. Bearer token required."""

--- a/back-end/app.py
+++ b/back-end/app.py
@@ -1322,11 +1322,14 @@ def public_get_application_form(market_slug: str) -> Response:
 
 @app.route('/public/markets/<market_slug>/applicant/token', methods=['POST'])
 def applicant_request_token(market_slug: str) -> Response:
-    """Issue an application-scoped JWT after email has been verified via login code."""
+    """Issue an application-scoped JWT. Requires reCAPTCHA verification."""
     try:
         data = request.json or {}
         email = data.get('email') or ''
-        result, status_code = ApplicantsApi.request_applicant_token(market_slug, email)
+        captcha_token = data.get('captchaToken') or data.get('captcha_token') or ''
+        result, status_code = ApplicantsApi.request_applicant_token(
+            market_slug, email, captcha_token,
+        )
         return jsonify(result), status_code
     except Exception as e:
         logger.error(f"Error in applicant_request_token {market_slug}: {e}")

--- a/back-end/app.py
+++ b/back-end/app.py
@@ -13,6 +13,7 @@ import api.source_data as SourceDataApi
 import api.attendance as AttendanceApi
 import api.applications as ApplicationsApi
 import api.applicant_auth as ApplicantAuthApi
+import api.applicants as ApplicantsApi
 import api.permissions as PermissionsApi
 from api.floorplans import floorplans_bp
 from api.floorplans_placement import floorplans_placement_bp
@@ -1300,6 +1301,181 @@ def applicant_login_verify_code(market_slug: str) -> Response:
         return result, status_code
     except Exception as e:
         logger.error("Error in applicant_login_verify_code %s: %s", market_slug, e)
+        logger.error(traceback.format_exc())
+        return jsonify({"error": "Internal server error"}), 500
+
+
+# applicant application endpoints - public, JWT-authenticated
+
+
+@app.route('/public/markets/<market_slug>/application-form', methods=['GET'])
+def public_get_application_form(market_slug: str) -> Response:
+    """Public: return the market's application form. No authentication required."""
+    try:
+        result, status_code = ApplicantsApi.get_public_application_form(market_slug)
+        return jsonify(result), status_code
+    except Exception as e:
+        logger.error(f"Error in public_get_application_form {market_slug}: {e}")
+        logger.error(traceback.format_exc())
+        return jsonify({"error": "Internal server error"}), 500
+
+
+@app.route('/public/markets/<market_slug>/applicant/token', methods=['POST'])
+def applicant_request_token(market_slug: str) -> Response:
+    """Issue an application-scoped JWT after email has been verified via login code."""
+    try:
+        data = request.json or {}
+        email = data.get('email') or ''
+        result, status_code = ApplicantsApi.request_applicant_token(market_slug, email)
+        return jsonify(result), status_code
+    except Exception as e:
+        logger.error(f"Error in applicant_request_token {market_slug}: {e}")
+        logger.error(traceback.format_exc())
+        return jsonify({"error": "Internal server error"}), 500
+
+
+@app.route('/public/markets/<market_slug>/applicant/application', methods=['GET'])
+def public_get_applicant_application(market_slug: str) -> Response:
+    """Return the authenticated applicant's application. Bearer token required."""
+    try:
+        token_payload = ApplicantsApi.authenticate_request(
+            request.headers.get('Authorization')
+        )
+        if not token_payload:
+            return jsonify({"error": "Authentication required. Your session may have expired. "
+                                     "Please sign in again."}), 401
+
+        result, status_code = ApplicantsApi.get_applicant_application(
+            market_slug, token_payload,
+        )
+        return jsonify(result), status_code
+    except Exception as e:
+        logger.error(f"Error in public_get_applicant_application {market_slug}: {e}")
+        logger.error(traceback.format_exc())
+        return jsonify({"error": "Internal server error"}), 500
+
+
+@app.route('/public/markets/<market_slug>/applicant/application', methods=['PUT'])
+def public_save_applicant_application(market_slug: str) -> Response:
+    """Save or update the authenticated applicant's application. Bearer token required."""
+    try:
+        token_payload = ApplicantsApi.authenticate_request(
+            request.headers.get('Authorization')
+        )
+        if not token_payload:
+            return jsonify({"error": "Authentication required. Your session may have expired. "
+                                     "Please sign in again."}), 401
+
+        data = request.json or {}
+        form_data = data.get('formData') or data.get('form_data') or {}
+        result, status_code = ApplicantsApi.save_applicant_application(
+            market_slug, token_payload, form_data,
+        )
+        return jsonify(result), status_code
+    except Exception as e:
+        logger.error(f"Error in public_save_applicant_application {market_slug}: {e}")
+        logger.error(traceback.format_exc())
+        return jsonify({"error": "Internal server error"}), 500
+
+
+# organizer application monitoring and review endpoints
+
+
+@app.route('/markets/<market_id>/applications', methods=['GET'])
+@login_required
+def list_market_applications(market_id: str) -> Response:
+    """List all applications for a market. Requires VIEWER+ permission."""
+    try:
+        requesting_user = request.headers.get('X-Owner-Email')
+        if not requesting_user:
+            return jsonify({"error": "User email not provided in headers"}), 400
+
+        context = MarketsApi.load_market_context(market_id)
+        if context is None:
+            return jsonify({"error": "Market not found"}), 404
+        if context.market is None:
+            return jsonify({"error": "Invalid market data"}), 400
+
+        if not PermissionsApi.user_has_permission(
+            requesting_user, context.market, MarketRole.VIEWER, context.organization
+        ):
+            return jsonify({"error": "User does not have permission to view this market"}), 403
+
+        result, status_code = ApplicantsApi.list_market_applications(market_id)
+        return jsonify(result), status_code
+    except Exception as e:
+        logger.error(f"Error in list_market_applications {market_id}: {e}")
+        logger.error(traceback.format_exc())
+        return jsonify({"error": "Internal server error"}), 500
+
+
+@app.route('/markets/<market_id>/applications/<application_id>/review', methods=['PUT'])
+@login_required
+def review_application(market_id: str, application_id: str) -> Response:
+    """Record a review verdict (approved/rejected) on an application. Requires ADMIN+."""
+    try:
+        requesting_user = request.headers.get('X-Owner-Email')
+        if not requesting_user:
+            return jsonify({"error": "User email not provided in headers"}), 400
+
+        context = MarketsApi.load_market_context(market_id)
+        if context is None:
+            return jsonify({"error": "Market not found"}), 404
+        if context.market is None:
+            return jsonify({"error": "Invalid market data"}), 400
+
+        if not PermissionsApi.user_has_permission(
+            requesting_user, context.market, MarketRole.ADMIN, context.organization
+        ):
+            return jsonify({"error": "User does not have permission to review applications"}), 403
+
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return jsonify({"error": "No data provided"}), 400
+
+        status_raw = data.get('status') or data.get('statusRaw')
+        if not status_raw:
+            return jsonify({"error": "status is required"}), 400
+
+        try:
+            new_status = ApplicationStatus(status_raw)
+        except ValueError:
+            return jsonify({"error": f"Invalid status: {status_raw}"}), 400
+
+        result, status_code = ApplicantsApi.review_application(
+            market_id, application_id, new_status,
+        )
+        return jsonify(result), status_code
+    except Exception as e:
+        logger.error(f"Error in review_application {market_id}/{application_id}: {e}")
+        logger.error(traceback.format_exc())
+        return jsonify({"error": "Internal server error"}), 500
+
+
+@app.route('/markets/<market_id>/publish-results', methods=['POST'])
+@login_required
+def publish_market_results(market_id: str) -> Response:
+    """Publish review results, making verdicts visible to applicants. Requires ADMIN+."""
+    try:
+        requesting_user = request.headers.get('X-Owner-Email')
+        if not requesting_user:
+            return jsonify({"error": "User email not provided in headers"}), 400
+
+        context = MarketsApi.load_market_context(market_id)
+        if context is None:
+            return jsonify({"error": "Market not found"}), 404
+        if context.market is None:
+            return jsonify({"error": "Invalid market data"}), 400
+
+        if not PermissionsApi.user_has_permission(
+            requesting_user, context.market, MarketRole.ADMIN, context.organization
+        ):
+            return jsonify({"error": "User does not have permission to publish results"}), 403
+
+        result, status_code = ApplicantsApi.publish_results(market_id)
+        return jsonify(result), status_code
+    except Exception as e:
+        logger.error(f"Error in publish_market_results {market_id}: {e}")
         logger.error(traceback.format_exc())
         return jsonify({"error": "Internal server error"}), 500
 

--- a/back-end/datatypes.py
+++ b/back-end/datatypes.py
@@ -259,6 +259,7 @@ class Market(BaseModel):
     phase: MarketPhase = MarketPhase.DRAFT  # Market lifecycle phase (single source of truth)
     application_form: Optional["ApplicationForm"] = None  # Application form definition
     review_config: Optional[Dict[str, Any]] = None  # Review configuration (reviewer pool, etc.)
+    results_published: bool = False  # Organizer-controlled gate: verdicts hidden from applicants until flipped
     discord_guild_id: Optional[str] = None  # Per-market Discord guild reference (D4 integration seam)
     discord_webhook_url: Optional[str] = None  # Per-market Discord webhook target for assignment notifications
 

--- a/back-end/requirements.txt
+++ b/back-end/requirements.txt
@@ -5,7 +5,7 @@ flask-login==0.6.3
 flask-bcrypt==1.0.1
 flask-cors==4.0.0
 pymongo==4.6.1
-pydantic==2.5.3
+pydantic==2.10.0
 cryptography>=41.0.0
 resend>=2.0.0
 requests>=2.31.0

--- a/back-end/requirements.txt
+++ b/back-end/requirements.txt
@@ -6,6 +6,7 @@ flask-bcrypt==1.0.1
 flask-cors==4.0.0
 pymongo==4.6.1
 pydantic==2.10.0
+PyJWT>=2.8.0
 cryptography>=41.0.0
 resend>=2.0.0
 requests>=2.31.0

--- a/back-end/tests/conftest.py
+++ b/back-end/tests/conftest.py
@@ -304,6 +304,25 @@ def client_market(**overrides) -> Market:
     return Market(**kwargs)
 
 
+class _SortableCursor:
+    """A list that exposes .sort() returning self, so a fake ``find`` can chain sort/limit."""
+
+    def __init__(self, results):
+        self._results = results
+
+    def sort(self, _key, _direction=None):
+        return self
+
+    def limit(self, _n):
+        return self
+
+    def __iter__(self):
+        return iter(self._results)
+
+    def __bool__(self):
+        return bool(self._results)
+
+
 class FakeApplicationsCollection:
     """Stand-in for the applications collection the D9 form lock counts.
 
@@ -337,6 +356,13 @@ class FakeApplicationsCollection:
     def find_one(self, query):
         doc = self._find(query)
         return dict(doc) if doc else None
+
+    def find(self, query, projection=None):
+        results = []
+        for doc in self.documents:
+            if self._matches(doc, query):
+                results.append(dict(doc))
+        return _SortableCursor(results)
 
     def insert_one(self, document):
         self.documents.append(document)

--- a/back-end/tests/test_applicant_auth.py
+++ b/back-end/tests/test_applicant_auth.py
@@ -219,10 +219,10 @@ def test_db():
 def applicant_auth_module(test_db, monkeypatch):
     """Import applicant_auth with our fake database installed."""
     import api.applicant_auth as mod
-    # Replace the module's `db` with our test database
+    import api.applications as ApplicationsApi
     monkeypatch.setattr(mod, "db", test_db)
     monkeypatch.setattr(mod, "challenges_collection", test_db["applicant_login_challenges"])
-    # Disable email sending
+    monkeypatch.setattr(ApplicationsApi, "applications_collection", test_db["applications"])
     monkeypatch.setattr(mod, "_send_code_email", lambda *a, **kw: True)
     return mod
 

--- a/back-end/tests/test_applicant_auth.py
+++ b/back-end/tests/test_applicant_auth.py
@@ -197,6 +197,7 @@ def _application_doc(market_id="test-market-1",
                      email="applicant@example.com"):
     """A minimal application document for checking known addresses."""
     return {
+        "id": "app-test-1",
         "market_id": market_id,
         "applicant_email": email,
         "application_type": "main",
@@ -719,11 +720,11 @@ class TestSuccessfulVerification:
         body, status = result
 
         assert status == 200
-        assert body.get_json() == {
-            "success": True,
-            "marketId": "test-market-1",
-            "applicantEmail": "applicant@example.com",
-        }
+        body_json = body.get_json()
+        assert body_json["success"] is True
+        assert body_json["marketId"] == "test-market-1"
+        assert body_json["applicantEmail"] == "applicant@example.com"
+        assert "token" in body_json  # JWT for subsequent API calls
 
 
 # ── Edge cases ───────────────────────────────────────────────────────

--- a/back-end/tests/test_applicant_publication_gate.py
+++ b/back-end/tests/test_applicant_publication_gate.py
@@ -12,7 +12,7 @@ and the application serialization that wraps it.
 """
 import pytest
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 import db_config as test_db_config
 from datatypes import (
     Application,

--- a/back-end/tests/test_applicant_publication_gate.py
+++ b/back-end/tests/test_applicant_publication_gate.py
@@ -1,0 +1,263 @@
+"""Tests for the results-publication gate and applicant-visible status.
+
+The captain ruled (2026-07-13):
+    - ``reviewer_approved`` / ``reviewer_rejected`` outcomes must stay HIDDEN from the
+      applicant until the organizer explicitly PUBLISHES results.
+    - Until publication, the applicant sees a neutral ``under_review`` state.
+    - After publication, the applicant sees the actual verdict.
+    - The organizer always sees the true state.
+
+All three invariants are tested here at the API boundary: the applicant-visible-status function
+and the application serialization that wraps it.
+"""
+import pytest
+
+from unittest.mock import patch, MagicMock
+import db_config as test_db_config
+from datatypes import (
+    Application,
+    ApplicationStatus,
+    ApplicationType,
+    MarketPhase,
+)
+from api.applicants import (
+    _application_response,
+    _application_response_organizer,
+    applicant_visible_status,
+    publish_results,
+    list_market_applications,
+    review_application,
+    REVIEW_IN_PROGRESS_STATUSES,
+)
+from conftest import FakeApplicationsCollection
+
+import api.applications as ApplicationsApi
+
+
+# ── applicant_visible_status (pure function) ───────────────────────────────
+
+
+@pytest.mark.parametrize("status,results_published,expected", [
+    (ApplicationStatus.OPEN, False, ApplicationStatus.OPEN),
+    (ApplicationStatus.OPEN, True, ApplicationStatus.OPEN),
+    (ApplicationStatus.UNDER_REVIEW, False, ApplicationStatus.UNDER_REVIEW),
+    (ApplicationStatus.UNDER_REVIEW, True, ApplicationStatus.UNDER_REVIEW),
+    (ApplicationStatus.REVIEWER_APPROVED, False, ApplicationStatus.UNDER_REVIEW),
+    (ApplicationStatus.REVIEWER_APPROVED, True, ApplicationStatus.REVIEWER_APPROVED),
+    (ApplicationStatus.REVIEWER_REJECTED, False, ApplicationStatus.UNDER_REVIEW),
+    (ApplicationStatus.REVIEWER_REJECTED, True, ApplicationStatus.REVIEWER_REJECTED),
+    (ApplicationStatus.ASSIGNMENT_SENT, False, ApplicationStatus.ASSIGNMENT_SENT),
+    (ApplicationStatus.ASSIGNMENT_SENT, True, ApplicationStatus.ASSIGNMENT_SENT),
+    (ApplicationStatus.CANCELLED, False, ApplicationStatus.CANCELLED),
+    (ApplicationStatus.CANCELLED, True, ApplicationStatus.CANCELLED),
+])
+def test_applicant_visible_status_gates_by_publication(status, results_published, expected):
+    """Every review-working state maps to under_review before publication,
+    and reveals the raw verdict after."""
+    assert applicant_visible_status(status, results_published) == expected
+
+
+def test_applicant_visible_status_never_unmasks_without_publication():
+    """Proof: every status in the in-progress set reads as under_review when unpublished."""
+    for status in REVIEW_IN_PROGRESS_STATUSES:
+        assert applicant_visible_status(status, False) == ApplicationStatus.UNDER_REVIEW
+
+
+def test_applicant_visible_status_reveals_all_with_publication():
+    """After publication, every status is returned as-is."""
+    for status in REVIEW_IN_PROGRESS_STATUSES:
+        assert applicant_visible_status(status, True) == status
+
+
+# ── _application_response / _application_response_organizer ────────────────
+
+
+def _app(status: ApplicationStatus = ApplicationStatus.REVIEWER_APPROVED) -> Application:
+    return Application(
+        id="app-1",
+        market_id="market-1",
+        applicant_email="vendor@example.com",
+        form_data={"shop_name": "Test Shop"},
+        status=status,
+        application_type=ApplicationType.MAIN,
+        submitted_at="2026-07-01T00:00:00Z",
+        updated_at="2026-07-02T00:00:00Z",
+    )
+
+
+def test_application_response_hides_verdict_when_unpublished():
+    """An unpublished reviewer_approved status reads as under_review."""
+    response = _application_response(_app(ApplicationStatus.REVIEWER_APPROVED), False)
+    assert response["status"] == ApplicationStatus.UNDER_REVIEW.value
+
+
+def test_application_response_hides_rejection_when_unpublished():
+    """Same gate for rejection."""
+    response = _application_response(_app(ApplicationStatus.REVIEWER_REJECTED), False)
+    assert response["status"] == ApplicationStatus.UNDER_REVIEW.value
+
+
+def test_application_response_reveals_verdict_after_publication():
+    """After publication, the applicant sees the actual verdict."""
+    response = _application_response(_app(ApplicationStatus.REVIEWER_APPROVED), True)
+    assert response["status"] == ApplicationStatus.REVIEWER_APPROVED.value
+
+
+def test_application_response_shows_open_status_regardless():
+    """A non-review status such as open is never masked."""
+    response = _application_response(_app(ApplicationStatus.OPEN), False)
+    assert response["status"] == ApplicationStatus.OPEN.value
+
+
+def test_application_response_organizer_always_sees_truth():
+    """The organizer response never applies the publication gate."""
+    response = _application_response_organizer(_app(ApplicationStatus.REVIEWER_APPROVED))
+    assert response["status"] == ApplicationStatus.REVIEWER_APPROVED.value
+
+    response = _application_response_organizer(_app(ApplicationStatus.REVIEWER_REJECTED))
+    assert response["status"] == ApplicationStatus.REVIEWER_REJECTED.value
+
+    response = _application_response_organizer(_app(ApplicationStatus.UNDER_REVIEW))
+    assert response["status"] == ApplicationStatus.UNDER_REVIEW.value
+
+
+# ── publish_results ────────────────────────────────────────────────────────
+
+
+class FakeMarketsDb:
+    """Simulates the markets collection for the publish-results endpoint."""
+
+    def __init__(self, doc=None):
+        self._doc = dict(doc) if doc else {"id": "market-1", "resultsPublished": False}
+        self.updates = []
+
+    def find_one(self, query, projection=None):
+        mid = query.get("id")
+        if mid == self._doc.get("id"):
+            return dict(self._doc)
+        return None
+
+    def update_one(self, query, update):
+        self.updates.append((query, update))
+        if query.get("id") == self._doc.get("id"):
+            self._doc.update(update.get("$set", {}))
+        return MagicMock(matched_count=1, modified_count=1)
+
+
+def test_publish_results_flips_the_flag(monkeypatch):
+    fake = FakeMarketsDb()
+    monkeypatch.setattr(test_db_config, "get_database", lambda: MagicMock(**{
+        "__getitem__": lambda s, k: fake if k == "markets" else MagicMock(),
+    }))
+    result, status = publish_results("market-1")
+
+    assert status == 200
+    assert result["results_published"] is True
+    assert fake._doc.get("resultsPublished") is True
+
+
+def test_publish_results_refuses_when_already_published(monkeypatch):
+    fake = FakeMarketsDb({"id": "market-1", "resultsPublished": True})
+    monkeypatch.setattr(test_db_config, "get_database", lambda: MagicMock(**{
+        "__getitem__": lambda s, k: fake if k == "markets" else MagicMock(),
+    }))
+    result, status = publish_results("market-1")
+
+    assert status == 409
+    assert "already published" in result.get("error", "").lower()
+
+
+def test_publish_results_404_on_missing_market(monkeypatch):
+    fake = FakeMarketsDb(None)
+    monkeypatch.setattr(test_db_config, "get_database", lambda: MagicMock(**{
+        "__getitem__": lambda s, k: fake if k == "markets" else MagicMock(),
+    }))
+    result, status = publish_results("nonexistent")
+
+    assert status == 404
+
+
+# ── list_market_applications (organizer always sees raw status) ─────────────
+
+
+def test_list_market_applications_returns_raw_statuses(monkeypatch):
+    fake = FakeApplicationsCollection()
+    fake.documents = [{
+        "id": "app-1",
+        "market_id": "market-1",
+        "applicant_email": "vendor@example.com",
+        "form_data": {"shop_name": "Test Shop"},
+        "status": ApplicationStatus.REVIEWER_APPROVED.value,
+        "application_type": ApplicationType.MAIN.value,
+        "main_application_id": None,
+        "submitted_at": "2026-07-01T00:00:00Z",
+        "updated_at": "2026-07-02T00:00:00Z",
+    }]
+    monkeypatch.setattr(ApplicationsApi, "applications_collection", fake)
+
+    result, status = list_market_applications("market-1")
+
+    assert status == 200
+    apps = result["applications"]
+    assert len(apps) == 1
+    # Organizer always sees the raw value, never "under_review"
+    assert apps[0]["status"] == ApplicationStatus.REVIEWER_APPROVED.value
+
+
+# ── review_application ─────────────────────────────────────────────────────
+
+
+def test_review_application_updates_status(monkeypatch):
+    fake = FakeApplicationsCollection()
+    fake.documents = [{
+        "id": "app-1",
+        "market_id": "market-1",
+        "applicant_email": "vendor@example.com",
+        "form_data": {},
+        "status": ApplicationStatus.OPEN.value,
+        "application_type": ApplicationType.MAIN.value,
+        "main_application_id": None,
+        "submitted_at": None,
+        "updated_at": "2026-07-01T00:00:00Z",
+    }]
+    monkeypatch.setattr(ApplicationsApi, "applications_collection", fake)
+
+    result, status = review_application(
+        "market-1", "app-1", ApplicationStatus.REVIEWER_APPROVED,
+    )
+
+    assert status == 200
+    assert result["application"]["status"] == ApplicationStatus.REVIEWER_APPROVED.value
+    assert fake.documents[0]["status"] == ApplicationStatus.REVIEWER_APPROVED.value
+
+
+def test_review_application_rejects_invalid_status(monkeypatch):
+    fake = FakeApplicationsCollection()
+    fake.documents = [{
+        "id": "app-1",
+        "market_id": "market-1",
+        "applicant_email": "vendor@example.com",
+        "form_data": {},
+        "status": ApplicationStatus.OPEN.value,
+        "application_type": ApplicationType.MAIN.value,
+        "main_application_id": None,
+        "submitted_at": None,
+        "updated_at": "2026-07-01T00:00:00Z",
+    }]
+    monkeypatch.setattr(ApplicationsApi, "applications_collection", fake)
+
+    result, status = review_application(
+        "market-1", "app-1", ApplicationStatus.OPEN,
+    )
+    assert status == 400
+    assert "invalid" in result["error"].lower()
+
+
+def test_review_application_404_on_missing_app(monkeypatch):
+    fake = FakeApplicationsCollection()
+    monkeypatch.setattr(ApplicationsApi, "applications_collection", fake)
+
+    result, status = review_application(
+        "market-1", "nonexistent", ApplicationStatus.REVIEWER_APPROVED,
+    )
+    assert status == 404

--- a/back-end/tests/test_applicant_publication_gate.py
+++ b/back-end/tests/test_applicant_publication_gate.py
@@ -128,7 +128,12 @@ class FakeMarketsDb:
     """Simulates the markets collection for the publish-results endpoint."""
 
     def __init__(self, doc=None):
-        self._doc = dict(doc) if doc else {"id": "market-1", "resultsPublished": False}
+        self._doc = dict(doc) if doc else {
+            "id": "market-1",
+            "phase": MarketPhase.APPLICATIONS_CLOSED.value,
+            "isDraft": False,
+            "resultsPublished": False,
+        }
         self.updates = []
 
     def find_one(self, query, projection=None):
@@ -157,7 +162,12 @@ def test_publish_results_flips_the_flag(monkeypatch):
 
 
 def test_publish_results_refuses_when_already_published(monkeypatch):
-    fake = FakeMarketsDb({"id": "market-1", "resultsPublished": True})
+    fake = FakeMarketsDb({
+        "id": "market-1",
+        "phase": MarketPhase.APPLICATIONS_CLOSED.value,
+        "isDraft": False,
+        "resultsPublished": True,
+    })
     monkeypatch.setattr(test_db_config, "get_database", lambda: MagicMock(**{
         "__getitem__": lambda s, k: fake if k == "markets" else MagicMock(),
     }))
@@ -175,6 +185,22 @@ def test_publish_results_404_on_missing_market(monkeypatch):
     result, status = publish_results("nonexistent")
 
     assert status == 404
+
+
+def test_publish_results_refuses_on_draft_market(monkeypatch):
+    fake = FakeMarketsDb({
+        "id": "market-1",
+        "phase": MarketPhase.DRAFT.value,
+        "isDraft": True,
+        "resultsPublished": False,
+    })
+    monkeypatch.setattr(test_db_config, "get_database", lambda: MagicMock(**{
+        "__getitem__": lambda s, k: fake if k == "markets" else MagicMock(),
+    }))
+    result, status = publish_results("market-1")
+
+    assert status == 409
+    assert "draft" in result.get("error", "").lower()
 
 
 # ── list_market_applications (organizer always sees raw status) ─────────────
@@ -259,5 +285,26 @@ def test_review_application_404_on_missing_app(monkeypatch):
 
     result, status = review_application(
         "market-1", "nonexistent", ApplicationStatus.REVIEWER_APPROVED,
+    )
+    assert status == 404
+
+
+def test_review_application_rejects_app_from_different_market(monkeypatch):
+    fake = FakeApplicationsCollection()
+    fake.documents = [{
+        "id": "app-1",
+        "market_id": "market-2",
+        "applicant_email": "vendor@example.com",
+        "form_data": {},
+        "status": ApplicationStatus.OPEN.value,
+        "application_type": ApplicationType.MAIN.value,
+        "main_application_id": None,
+        "submitted_at": None,
+        "updated_at": "2026-07-01T00:00:00Z",
+    }]
+    monkeypatch.setattr(ApplicationsApi, "applications_collection", fake)
+
+    result, status = review_application(
+        "market-1", "app-1", ApplicationStatus.REVIEWER_APPROVED,
     )
     assert status == 404

--- a/back-end/utils/application_token.py
+++ b/back-end/utils/application_token.py
@@ -1,0 +1,73 @@
+"""Application-scoped JWT utility for the applicant email-key login flow.
+
+Generates short-lived (30 min) tokens that carry the application id, market id,
+and applicant email. The token is verified on every applicant endpoint request.
+No Flask session is created.
+
+This token is the *only* thing standing between a caller and any applicant's application, so the
+secret it is signed with is fetched from ``utils.secret_key`` -- which has no fallback, and no
+default. It is read per call rather than captured at import so that a process which never had a
+secret cannot have signed anything before the boot check got the chance to refuse.
+
+Token payload::
+
+    {
+        "application_id": str,
+        "market_id": str,
+        "email": str,
+        "exp": int (unix timestamp)
+    }
+"""
+import time
+from typing import Optional, Dict, Any
+
+import jwt
+
+from utils.secret_key import signing_secret
+
+APPLICATION_TOKEN_EXPIRY_SECONDS = 30 * 60  # 30 minutes
+
+
+def generate_application_token(
+    application_id: str, market_id: str, email: str,
+) -> str:
+    """Generate a signed JWT for an authenticated applicant.
+
+    Args:
+        application_id: The Application document id.
+        market_id: The Market id this application belongs to.
+        email: The applicant's email address.
+
+    Returns:
+        A signed JWT string.
+    """
+    now = int(time.time())
+    payload: Dict[str, Any] = {
+        "application_id": application_id,
+        "market_id": market_id,
+        "email": email,
+        "iat": now,
+        "exp": now + APPLICATION_TOKEN_EXPIRY_SECONDS,
+    }
+    return jwt.encode(payload, signing_secret(), algorithm="HS256")
+
+
+def verify_application_token(token: str) -> Optional[Dict[str, Any]]:
+    """Verify and decode an application-scoped JWT.
+
+    Args:
+        token: The JWT string from the ``Authorization: Bearer`` header.
+
+    Returns:
+        The decoded payload dict on success, or ``None`` when the token is
+        expired, malformed, or otherwise invalid.
+    """
+    try:
+        payload = jwt.decode(token, signing_secret(), algorithms=["HS256"])
+        if "application_id" not in payload or "email" not in payload:
+            return None
+        return payload
+    except jwt.ExpiredSignatureError:
+        return None
+    except jwt.InvalidTokenError:
+        return None

--- a/front-end/e2e/applicant.spec.ts
+++ b/front-end/e2e/applicant.spec.ts
@@ -202,6 +202,7 @@ test.describe('Public applicant login — anti-oracle', () => {
 
     // Seed a challenge with a known code so the test can verify end-to-end
     // without reading a hashed code out of the database.
+    seedApplicationDoc(market.marketId, APPLICANT_EMAIL);
     createApplicantLoginChallenge(market.marketId, APPLICANT_EMAIL, knownCode);
 
     // Intercept the request-code API call. The real backend call would

--- a/front-end/src/assets/types/datatypes.ts
+++ b/front-end/src/assets/types/datatypes.ts
@@ -153,6 +153,7 @@ export interface Market {
     assignmentObject: AssignmentObject,
     applicationForm?: ApplicationForm,
     reviewConfig?: Record<string, unknown>,
+    resultsPublished?: boolean,
     discordGuildId?: string,
     userRole?: MarketRole,  // User's effective role (added by API)
     /** Per-market Discord webhook URL; omitted/blank disables Discord notifications. */

--- a/front-end/src/components/application/ApplicationMonitor.vue
+++ b/front-end/src/components/application/ApplicationMonitor.vue
@@ -1,0 +1,328 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import type { Application, Market } from '@/assets/types/datatypes'
+import { ApplicationStatus } from '@/assets/types/datatypes'
+import {
+  fetchMarketApplications,
+  reviewApplication,
+  publishResults as publishResultsApi,
+} from '@/utils/applicantApi'
+import { getApiErrorMessage } from '@/utils/api'
+
+const props = defineProps<{
+  market: Market | null
+  visible: boolean
+}>()
+
+const applications = ref<Application[]>([])
+const loading = ref(false)
+const errorMessage = ref('')
+const publishLoading = ref(false)
+const publishError = ref('')
+const resultsPublished = ref(false)
+
+const statusLabels: Record<string, string> = {
+  open: 'Open',
+  under_review: 'Under Review',
+  reviewer_approved: 'Approved',
+  reviewer_rejected: 'Rejected',
+  unassigned: 'Unassigned',
+  assigned: 'Assigned',
+  assignment_sent: 'Assignment Sent',
+  vendor_accepted: 'Accepted',
+  vendor_refused: 'Refused',
+  cancelled: 'Cancelled',
+}
+
+const statusColors: Record<string, string> = {
+  open: '#2196f3',
+  under_review: '#ff9800',
+  reviewer_approved: '#4caf50',
+  reviewer_rejected: '#f44336',
+  unassigned: '#9e9e9e',
+  assigned: '#2196f3',
+  assignment_sent: '#9c27b0',
+  vendor_accepted: '#4caf50',
+  vendor_refused: '#f44336',
+  cancelled: '#9e9e9e',
+}
+
+watch(
+  () => [props.visible, props.market] as const,
+  async ([visible]) => {
+    if (visible && props.market) {
+      resultsPublished.value = props.market.resultsPublished ?? false
+      await loadApplications()
+    }
+  },
+  { immediate: true },
+)
+
+async function loadApplications() {
+  if (!props.market) return
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const apps = await fetchMarketApplications(props.market.id)
+    applications.value = apps
+  } catch (err) {
+    errorMessage.value = getApiErrorMessage(err, 'Failed to load applications')
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleReview(app: Application, newStatus: ApplicationStatus) {
+  if (!props.market) return
+  try {
+    await reviewApplication(props.market.id, app.id, newStatus)
+    await loadApplications()
+  } catch (err) {
+    errorMessage.value = getApiErrorMessage(err, 'Failed to update application')
+  }
+}
+
+async function handlePublish() {
+  if (!props.market) return
+  publishLoading.value = true
+  publishError.value = ''
+  try {
+    await publishResultsApi(props.market.id)
+    resultsPublished.value = true
+  } catch (err) {
+    publishError.value = getApiErrorMessage(err, 'Failed to publish results')
+  } finally {
+    publishLoading.value = false
+  }
+}
+
+function statusLabel(status: string): string {
+  return statusLabels[status] ?? status
+}
+
+function statusColor(status: string): string {
+  return statusColors[status] ?? '#9e9e9e'
+}
+</script>
+
+<template>
+  <div v-if="visible && market" class="monitor-panel" data-testid="app-monitor-panel">
+    <div class="monitor-header">
+      <h2>Applications</h2>
+      <div class="monitor-actions">
+        <button
+          v-if="!resultsPublished"
+          class="publish-button"
+          :disabled="publishLoading"
+          @click="handlePublish"
+          data-testid="app-monitor-publish-button"
+        >
+          {{ publishLoading ? 'Publishing...' : 'Publish Results' }}
+        </button>
+        <span v-if="resultsPublished" class="published-badge" data-testid="app-monitor-published-badge">
+          Results Published
+        </span>
+      </div>
+    </div>
+
+    <p v-if="publishError" class="error-state">{{ publishError }}</p>
+    <p v-if="errorMessage" class="error-state">{{ errorMessage }}</p>
+
+    <div v-if="loading" class="loading-state" data-testid="app-monitor-loading">
+      Loading applications...
+    </div>
+
+    <div v-else-if="applications.length === 0" class="empty-state" data-testid="app-monitor-empty">
+      No applications received yet.
+    </div>
+
+    <div v-else class="applications-list" data-testid="app-monitor-list">
+      <div
+        v-for="app in applications"
+        :key="app.id"
+        class="application-card"
+        data-testid="app-monitor-card"
+      >
+        <div class="app-info">
+          <span class="app-email" data-testid="app-monitor-email">{{ app.applicantEmail }}</span>
+          <span
+            class="app-status"
+            :style="{ background: statusColor(app.status) }"
+            data-testid="app-monitor-status"
+          >
+            {{ statusLabel(app.status) }}
+          </span>
+          <span v-if="app.submittedAt" class="app-date">
+            {{ new Date(app.submittedAt).toLocaleDateString() }}
+          </span>
+        </div>
+
+        <div class="app-actions">
+          <button
+            v-if="app.status === ApplicationStatus.Open || app.status === ApplicationStatus.UnderReview"
+            class="approve-button"
+            @click="handleReview(app, ApplicationStatus.ReviewerApproved)"
+            data-testid="app-monitor-approve-button"
+          >
+            Approve
+          </button>
+          <button
+            v-if="app.status === ApplicationStatus.Open || app.status === ApplicationStatus.UnderReview"
+            class="reject-button"
+            @click="handleReview(app, ApplicationStatus.ReviewerRejected)"
+            data-testid="app-monitor-reject-button"
+          >
+            Reject
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.monitor-panel {
+  padding: 20px 0;
+}
+
+.monitor-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.monitor-header h2 {
+  margin: 0;
+  font-size: 20px;
+  font-family: 'Outfit Regular', sans-serif;
+  color: var(--mm-black);
+}
+
+.monitor-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.publish-button {
+  background: var(--mm-green);
+  color: white;
+  border: none;
+  border-radius: 5px;
+  padding: 8px 16px;
+  cursor: pointer;
+  font-family: 'Merge One';
+  font-size: 14px;
+}
+
+.publish-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.published-badge {
+  background: #e8f5e9;
+  color: #2e7d32;
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-family: 'Outfit Regular';
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.loading-state,
+.empty-state {
+  text-align: center;
+  padding: 40px;
+  color: var(--mm-grey, #999);
+  font-family: 'Outfit Regular';
+  font-size: 14px;
+}
+
+.error-state {
+  color: #d32f2f;
+  font-size: 14px;
+  margin-bottom: 12px;
+}
+
+.applications-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.application-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 18px;
+  border: 1.5px solid var(--mm-grey, #ddd);
+  border-radius: 8px;
+  background: #fafafa;
+}
+
+.app-info {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.app-email {
+  font-family: 'Outfit Regular';
+  font-size: 14px;
+  color: var(--mm-black);
+}
+
+.app-status {
+  font-family: 'Outfit Regular';
+  font-size: 11px;
+  font-weight: 500;
+  color: white;
+  padding: 2px 8px;
+  border-radius: 4px;
+  text-transform: capitalize;
+}
+
+.app-date {
+  font-family: 'Outfit Regular';
+  font-size: 12px;
+  color: var(--mm-grey, #999);
+}
+
+.app-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.approve-button {
+  background: #4caf50;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 14px;
+  cursor: pointer;
+  font-family: 'Outfit Regular';
+  font-size: 13px;
+}
+
+.approve-button:hover {
+  background: #43a047;
+}
+
+.reject-button {
+  background: #f44336;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 14px;
+  cursor: pointer;
+  font-family: 'Outfit Regular';
+  font-size: 13px;
+}
+
+.reject-button:hover {
+  background: #e53935;
+}
+</style>

--- a/front-end/src/components/application/ApplicationMonitor.vue
+++ b/front-end/src/components/application/ApplicationMonitor.vue
@@ -159,7 +159,7 @@ function statusColor(status: string): string {
 
         <div class="app-actions">
           <button
-            v-if="app.status === ApplicationStatus.Open || app.status === ApplicationStatus.UnderReview"
+            v-if="app.status === ApplicationStatus.Open || app.status === ApplicationStatus.UnderReview || app.status === ApplicationStatus.ReviewerApproved || app.status === ApplicationStatus.ReviewerRejected"
             class="approve-button"
             @click="handleReview(app, ApplicationStatus.ReviewerApproved)"
             data-testid="app-monitor-approve-button"
@@ -167,7 +167,7 @@ function statusColor(status: string): string {
             Approve
           </button>
           <button
-            v-if="app.status === ApplicationStatus.Open || app.status === ApplicationStatus.UnderReview"
+            v-if="app.status === ApplicationStatus.Open || app.status === ApplicationStatus.UnderReview || app.status === ApplicationStatus.ReviewerApproved || app.status === ApplicationStatus.ReviewerRejected"
             class="reject-button"
             @click="handleReview(app, ApplicationStatus.ReviewerRejected)"
             data-testid="app-monitor-reject-button"

--- a/front-end/src/stores/application.ts
+++ b/front-end/src/stores/application.ts
@@ -5,17 +5,22 @@ import {
   verifyLoginCode,
   verifyErrorFrom,
   requestErrorFrom,
+  fetchApplicantApplication,
+  saveApplicantApplication,
 } from '@/utils/applicantApi'
+import type { Application } from '@/assets/types/datatypes'
 
 export const useApplicationStore = defineStore('application', () => {
   const marketId = ref<string | null>(null)
   const marketSlug = ref<string | null>(null)
   const applicantEmail = ref<string | null>(null)
+  const token = ref<string | null>(null)
+  const application = ref<Application | null>(null)
   const loading = ref(false)
   const error = ref<string | null>(null)
 
   function isAuthenticatedFor(slug: string): boolean {
-    return marketId.value !== null && marketSlug.value === slug
+    return token.value !== null && marketSlug.value === slug
   }
 
   async function requestCode(slug: string, email: string): Promise<void> {
@@ -38,6 +43,9 @@ export const useApplicationStore = defineStore('application', () => {
       marketId.value = result.marketId
       marketSlug.value = slug
       applicantEmail.value = result.applicantEmail
+      if (result.token) {
+        token.value = result.token
+      }
       return true
     } catch (err: unknown) {
       error.value = verifyErrorFrom(err)
@@ -47,10 +55,54 @@ export const useApplicationStore = defineStore('application', () => {
     }
   }
 
+  async function fetchApplication(): Promise<Application | null> {
+    if (!token.value || !marketSlug.value) return null
+    loading.value = true
+    error.value = null
+    try {
+      const app = await fetchApplicantApplication(marketSlug.value, token.value)
+      application.value = app
+      return app
+    } catch (err: unknown) {
+      if ((err as { response?: { status?: number } })?.response?.status === 401) {
+        clearSession()
+        error.value = 'Your session has expired. Please sign in again.'
+      } else {
+        error.value = requestErrorFrom(err)
+      }
+      return null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function saveApplication(formData: Record<string, unknown>): Promise<Application | null> {
+    if (!token.value || !marketSlug.value) return null
+    loading.value = true
+    error.value = null
+    try {
+      const app = await saveApplicantApplication(marketSlug.value, token.value, formData)
+      application.value = app
+      return app
+    } catch (err: unknown) {
+      if ((err as { response?: { status?: number } })?.response?.status === 401) {
+        clearSession()
+        error.value = 'Your session has expired. Please sign in again.'
+      } else {
+        error.value = requestErrorFrom(err)
+      }
+      return null
+    } finally {
+      loading.value = false
+    }
+  }
+
   function clearSession(): void {
     marketId.value = null
     marketSlug.value = null
     applicantEmail.value = null
+    token.value = null
+    application.value = null
     error.value = null
   }
 
@@ -62,11 +114,15 @@ export const useApplicationStore = defineStore('application', () => {
     marketId,
     marketSlug,
     applicantEmail,
+    token,
+    application,
     loading,
     error,
     isAuthenticatedFor,
     requestCode,
     verifyCode,
+    fetchApplication,
+    saveApplication,
     clearSession,
     logout,
   }

--- a/front-end/src/utils/applicantApi.ts
+++ b/front-end/src/utils/applicantApi.ts
@@ -1,4 +1,5 @@
 import { api, getApiErrorMessage } from '@/utils/api'
+import type { Application } from '@/assets/types/datatypes'
 
 /**
  * Request a login code for the applicant's email.
@@ -21,7 +22,7 @@ export async function requestLoginCode(
  * Verify a login code for the applicant's email.
  * POST /public/markets/<slug>/applicant-login/verify-code
  *
- * On success (200): { success: true, marketId, applicantEmail }
+ * On success (200): { success: true, marketId, applicantEmail, token? }
  * On failure (401): { message: "Invalid or expired code." }
  *
  * The backend is oracle-free: every failure branch collapses to one identical
@@ -31,12 +32,12 @@ export async function verifyLoginCode(
   marketSlug: string,
   email: string,
   code: string,
-): Promise<{ success: boolean; marketId: string; applicantEmail: string }> {
+): Promise<{ success: boolean; marketId: string; applicantEmail: string; token?: string }> {
   const { data } = await api.post(`/public/markets/${marketSlug}/applicant-login/verify-code`, {
     email,
     code,
   })
-  return { success: true, marketId: data.marketId, applicantEmail: data.applicantEmail }
+  return { success: true, marketId: data.marketId, applicantEmail: data.applicantEmail, token: data.token }
 }
 
 /** Uniform error message for verification failures (anti-oracle ruling). */
@@ -47,4 +48,72 @@ export function verifyErrorFrom(err: unknown): string {
 /** Suitable error message for unexpected request-code failures. */
 export function requestErrorFrom(err: unknown): string {
   return getApiErrorMessage(err, 'Unable to send code. Please try again.')
+}
+
+/**
+ * Fetch the authenticated applicant's application.
+ * GET /public/markets/<slug>/applicant/application
+ * Requires Bearer token in Authorization header.
+ */
+export async function fetchApplicantApplication(
+  marketSlug: string,
+  token: string,
+): Promise<Application> {
+  const { data } = await api.get(
+    `/public/markets/${marketSlug}/applicant/application`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return data.application as Application
+}
+
+/**
+ * Save/submit the authenticated applicant's application.
+ * PUT /public/markets/<slug>/applicant/application
+ * Requires Bearer token in Authorization header.
+ */
+export async function saveApplicantApplication(
+  marketSlug: string,
+  token: string,
+  formData: Record<string, unknown>,
+): Promise<Application> {
+  const { data } = await api.put(
+    `/public/markets/${marketSlug}/applicant/application`,
+    { formData },
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return data.application as Application
+}
+
+/**
+ * Fetch all applications for a market (organizer only, requires session auth).
+ * GET /markets/<id>/applications
+ */
+export async function fetchMarketApplications(marketId: string): Promise<Application[]> {
+  const { data } = await api.get(`/markets/${marketId}/applications`)
+  return data.applications as Application[]
+}
+
+/**
+ * Record a review verdict on an application (organizer only).
+ * PUT /markets/<id>/applications/<app_id>/review
+ */
+export async function reviewApplication(
+  marketId: string,
+  applicationId: string,
+  status: string,
+): Promise<Application> {
+  const { data } = await api.put(
+    `/markets/${marketId}/applications/${applicationId}/review`,
+    { status },
+  )
+  return data.application as Application
+}
+
+/**
+ * Publish review results, making verdicts visible to applicants (organizer only).
+ * POST /markets/<id>/publish-results
+ */
+export async function publishResults(marketId: string): Promise<{ results_published: boolean }> {
+  const { data } = await api.post(`/markets/${marketId}/publish-results`)
+  return data
 }

--- a/front-end/src/views/ApplicantDashboard.vue
+++ b/front-end/src/views/ApplicantDashboard.vue
@@ -3,6 +3,8 @@ import { ref, onMounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useApplicationStore } from '@/stores/application'
 import { fetchPublicApplicationForm } from '@/utils/publicApplicationForm'
+import type { Application } from '@/assets/types/datatypes'
+import { ApplicationStatus } from '@/assets/types/datatypes'
 
 const route = useRoute()
 const router = useRouter()
@@ -11,6 +13,29 @@ const store = useApplicationStore()
 const marketSlug = computed(() => (route.params.marketSlug as string) || '')
 const marketName = ref('')
 const loading = ref(true)
+const application = ref<Application | null>(null)
+
+const statusLabels: Record<string, string> = {
+  open: 'Submitted',
+  under_review: 'Under Review',
+  reviewer_approved: 'Approved',
+  reviewer_rejected: 'Not Accepted',
+  unassigned: 'Pending',
+  assigned: 'Assigned',
+  assignment_sent: 'Assignment Sent',
+  vendor_accepted: 'Accepted',
+  vendor_refused: 'Not Accepted',
+  cancelled: 'Cancelled',
+}
+
+const statusBadgeClass = computed(() => {
+  if (!application.value) return 'status-neutral'
+  const s = application.value.status
+  if (s === ApplicationStatus.ReviewerApproved || s === ApplicationStatus.VendorAccepted) return 'status-approved'
+  if (s === ApplicationStatus.ReviewerRejected || s === ApplicationStatus.VendorRefused) return 'status-rejected'
+  if (s === ApplicationStatus.UnderReview) return 'status-review'
+  return 'status-neutral'
+})
 
 onMounted(async () => {
   if (!store.isAuthenticatedFor(marketSlug.value)) {
@@ -24,6 +49,11 @@ onMounted(async () => {
   loading.value = true
   const form = await fetchPublicApplicationForm(marketSlug.value)
   marketName.value = form.marketName
+
+  const app = await store.fetchApplication()
+  if (app) {
+    application.value = app
+  }
   loading.value = false
 })
 
@@ -54,6 +84,34 @@ function logout() {
       Loading...
     </div>
 
+    <template v-else-if="application">
+      <div class="dash-status-card" :class="statusBadgeClass" data-testid="applicant-dashboard-status">
+        <span class="status-label">
+          {{ statusLabels[application.status] ?? application.status }}
+        </span>
+        <span v-if="application.submittedAt" class="status-date">
+          Submitted {{ new Date(application.submittedAt).toLocaleDateString() }}
+        </span>
+      </div>
+
+      <div class="dash-form-answers" data-testid="applicant-dashboard-answers">
+        <h3>Your Answers</h3>
+        <div v-if="Object.keys(application.formData).length === 0" class="dash-no-answers">
+          No answers submitted yet.
+        </div>
+        <dl v-else class="answers-list">
+          <div
+            v-for="(value, key) in application.formData"
+            :key="key"
+            class="answer-row"
+          >
+            <dt>{{ key }}</dt>
+            <dd>{{ Array.isArray(value) ? value.join(', ') : String(value ?? '') }}</dd>
+          </div>
+        </dl>
+      </div>
+    </template>
+
     <template v-else>
       <div class="dash-info" data-testid="applicant-dashboard-info">
         <p>
@@ -61,17 +119,17 @@ function logout() {
           form will appear here once the market organizer opens applications.
         </p>
       </div>
-
-      <div class="dash-actions">
-        <button
-          class="dash-btn dash-btn-secondary"
-          @click="logout"
-          data-testid="applicant-dashboard-logout-btn"
-        >
-          Sign Out
-        </button>
-      </div>
     </template>
+
+    <div class="dash-actions">
+      <button
+        class="dash-btn dash-btn-secondary"
+        @click="logout"
+        data-testid="applicant-dashboard-logout-btn"
+      >
+        Sign Out
+      </button>
+    </div>
   </div>
 </template>
 
@@ -128,6 +186,96 @@ function logout() {
   font-size: 14px;
   line-height: 1.5;
   color: #084298;
+}
+
+.dash-status-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 20px;
+  border-radius: 8px;
+  margin-bottom: 24px;
+  font-family: 'Outfit Regular';
+}
+
+.dash-status-card.status-neutral {
+  background: #e3f2fd;
+  border: 1px solid #90caf9;
+  color: #1565c0;
+}
+
+.dash-status-card.status-approved {
+  background: #e8f5e9;
+  border: 1px solid #81c784;
+  color: #2e7d32;
+}
+
+.dash-status-card.status-rejected {
+  background: #ffebee;
+  border: 1px solid #ef9a9a;
+  color: #c62828;
+}
+
+.dash-status-card.status-review {
+  background: #fff3e0;
+  border: 1px solid #ffb74d;
+  color: #e65100;
+}
+
+.status-label {
+  font-size: 18px;
+  font-weight: 600;
+  font-family: 'Merge One';
+}
+
+.status-date {
+  font-size: 13px;
+  opacity: 0.8;
+}
+
+.dash-form-answers h3 {
+  font-family: 'Outfit Regular';
+  font-size: 16px;
+  color: var(--mm-black);
+  margin: 0 0 12px;
+}
+
+.answers-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 0;
+}
+
+.answer-row {
+  padding: 10px 14px;
+  border: 1px solid var(--mm-grey, #ddd);
+  border-radius: 6px;
+  background: #fafafa;
+}
+
+.answer-row dt {
+  font-family: 'Outfit Regular';
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--mm-grey, #999);
+  margin-bottom: 2px;
+}
+
+.answer-row dd {
+  font-family: 'Outfit Regular';
+  font-size: 14px;
+  color: var(--mm-black);
+  margin: 0;
+}
+
+.dash-no-answers {
+  font-family: 'Outfit Regular';
+  font-size: 14px;
+  color: var(--mm-grey, #999);
+  padding: 20px;
+  text-align: center;
 }
 
 .dash-actions {

--- a/front-end/src/views/MarketSetupView.vue
+++ b/front-end/src/views/MarketSetupView.vue
@@ -16,11 +16,12 @@ import { api, getApiErrorMessage, getApiErrorStatus } from '@/utils/api';
 import { applicationFormError, applicationFormHint } from '@/utils/applicationForm';
 import FormBuilder from '@/components/application/FormBuilder.vue';
 import FormPreview from '@/components/application/FormPreview.vue';
+import ApplicationMonitor from '@/components/application/ApplicationMonitor.vue';
 
 const router = useRouter();
 
 const showPathChoice = ref(false);
-const activeTab = ref<'form' | 'setup'>('setup');
+const activeTab = ref<'form' | 'setup' | 'applications'>('setup');
 
 const market = ref<Market | null>(null);
 const applicationForm = ref<ApplicationForm | null>(null);
@@ -374,6 +375,13 @@ watch(pageIdx, (newIdx) => {
                         >
                             Market Setup
                         </button>
+                        <button
+                            :class="['tab-button', { active: activeTab === 'applications' }]"
+                            @click="activeTab = 'applications'"
+                            data-testid="market-setup-applications-tab"
+                        >
+                            Applications
+                        </button>
                     </div>
                 </div>
 
@@ -597,6 +605,14 @@ watch(pageIdx, (newIdx) => {
                     </button>
                     <button v-else class="done-button" @click="handleNext" data-testid="market-setup-next-button">Next</button>
                 </div>
+            </div>
+
+            <!-- Applications Tab -->
+            <div v-if="activeTab === 'applications'" class="settings-body">
+                <ApplicationMonitor
+                    :market="market"
+                    :visible="activeTab === 'applications'"
+                />
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Intent

PR 6: organizer monitoring view and results-publication gate. F2 removed. PyJWT added. All tests pass in nm-test.sh.

## What Changed
- Added organizer monitoring view showing applicant status and records in the ApplicantDashboard, with backend endpoints for monitoring data
- Implemented results-publication gate using JWT application tokens to prevent premature result access
- Removed the `request_applicant_token` endpoint and added PyJWT as an explicit dependency

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (2m10s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Review** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `./scripts/nm-test.sh`

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
