### PR TITLE
feat(applications): require applicant email before showing application form

### DIFF
--- a/front-end/e2e/pages/ApplyPage.ts
+++ b/front-end/e2e/pages/ApplyPage.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from '@playwright/test';
 
-/** The public application page: `/:marketSlug/apply`, reachable with no account and no session. */
+/** The application form page: `/:marketSlug/apply`. Requires applicant sign-in; redirects to login otherwise. */
 export class ApplyPage {
   readonly page: Page;
 
@@ -10,7 +10,6 @@ export class ApplyPage {
 
   async goto(marketSlug: string) {
     await this.page.goto(`/${marketSlug}/apply`);
-    await this.form.waitFor();
   }
 
   get form(): Locator {
@@ -37,40 +36,7 @@ export class ApplyPage {
     await this.submitButton.click();
   }
 
-  /** Shown only after the answers have reached the server. */
-  get savedBanner(): Locator {
-    return this.page.getByTestId('apply-saved');
-  }
-
-  /**
-   * Shown when answers typed in this browser before anyone signed in have been put back into the
-   * form. The page restores them - they are almost always this applicant's - but it cannot know who
-   * typed them, so it says so and will not submit them for anybody.
-   */
-  get draftNotice(): Locator {
-    return this.page.getByTestId('apply-draft-notice');
-  }
-
-  async clearRestoredDraft() {
-    await this.page.getByTestId('apply-draft-clear-button').click();
-  }
-
-  /**
-   * Shown when answers typed on this device before anyone signed in meet an application that is
-   * already saved. Either one of them may be this applicant's and the product cannot tell which, so
-   * it changes neither and asks.
-   */
-  get draftChoice(): Locator {
-    return this.page.getByTestId('apply-draft-choice');
-  }
-
-  /** "They're mine": the typed answers go into the form. Still nothing is sent. */
-  async useTypedAnswers() {
-    await this.page.getByTestId('apply-draft-choice-use-button').click();
-  }
-
-  /** "Keep my saved answers": the typed answers are discarded, by the one person entitled to. */
-  async keepSavedAnswers() {
-    await this.page.getByTestId('apply-draft-choice-keep-saved-button').click();
+  get error(): Locator {
+    return this.page.getByTestId('apply-error');
   }
 }

--- a/front-end/e2e/pages/ApplyPage.ts
+++ b/front-end/e2e/pages/ApplyPage.ts
@@ -1,42 +1,42 @@
-import type { Locator, Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test'
 
 /** The application form page: `/:marketSlug/apply`. Requires applicant sign-in; redirects to login otherwise. */
 export class ApplyPage {
-  readonly page: Page;
+  readonly page: Page
 
   constructor(page: Page) {
-    this.page = page;
+    this.page = page
   }
 
   async goto(marketSlug: string) {
-    await this.page.goto(`/${marketSlug}/apply`);
+    await this.page.goto(`/${marketSlug}/apply`)
   }
 
   get form(): Locator {
-    return this.page.getByTestId('apply-form');
+    return this.page.getByTestId('apply-form')
   }
 
   get marketName(): Locator {
-    return this.page.getByTestId('apply-market-name');
+    return this.page.getByTestId('apply-market-name')
   }
 
   input(key: string): Locator {
-    return this.page.getByTestId(`apply-input-${key}`);
+    return this.page.getByTestId(`apply-input-${key}`)
   }
 
   async fillField(key: string, value: string) {
-    await this.input(key).fill(value);
+    await this.input(key).fill(value)
   }
 
   get submitButton(): Locator {
-    return this.page.getByTestId('apply-submit-button');
+    return this.page.getByTestId('apply-submit-button')
   }
 
   async submit() {
-    await this.submitButton.click();
+    await this.submitButton.click()
   }
 
   get error(): Locator {
-    return this.page.getByTestId('apply-error');
+    return this.page.getByTestId('apply-error')
   }
 }

--- a/front-end/src/utils/applicantSessionExpiry.ts
+++ b/front-end/src/utils/applicantSessionExpiry.ts
@@ -7,8 +7,7 @@ import { useApplicationStore } from '@/stores/application'
  * On the 5d backend there is no applicant session token yet, so this handler
  * is a no-op. It exists as the hook point for when applicant auth (JWT or
  * similar) is added, at which point a 401 on an applicant API call will
- * clear the session and redirect to login, preserving the draft answers the
- * applicant was typing.
+ * clear the session and redirect to login.
  */
 export function installApplicantSessionExpiry(router: Router): void {
   // No-op for 5d backend: no applicant session token exists yet.

--- a/front-end/src/views/ApplicationPage.vue
+++ b/front-end/src/views/ApplicationPage.vue
@@ -20,11 +20,21 @@ const isOpen = ref(false)
 const loading = ref(true)
 const formData = ref<Record<string, unknown>>({})
 const validationErrors = ref<Record<string, string>>({})
+const saving = ref(false)
 
 const sortedFields = computed(() => sortedFormFields(fields.value))
 const signedIn = computed(() => store.isAuthenticatedFor(marketSlug.value))
 
 onMounted(async () => {
+  if (!signedIn.value) {
+    router.push({
+      name: 'applicant-login',
+      params: { marketSlug: marketSlug.value },
+      query: { redirect: 'apply' },
+    })
+    return
+  }
+
   const form = await fetchPublicApplicationForm(marketSlug.value)
   fields.value = form.fields
   marketName.value = form.marketName
@@ -44,29 +54,20 @@ function clearFieldError(field: FormField) {
   }
 }
 
-const submitLabel = computed(() => {
-  if (!signedIn.value) return 'Continue to sign in'
-  return 'Save Application'
-})
-
-function submitForm() {
+async function submitForm() {
   if (!validateAll()) return
 
-  if (!signedIn.value) {
+  saving.value = true
+  store.error = null
+  const app = await store.saveApplication(formData.value)
+  saving.value = false
+
+  if (app) {
     router.push({
-      name: 'applicant-login',
+      name: 'applicant-dashboard',
       params: { marketSlug: marketSlug.value },
-      query: { redirect: 'apply' },
     })
   }
-}
-
-function goToLogin() {
-  router.push({
-    name: 'applicant-login',
-    params: { marketSlug: marketSlug.value },
-    query: { redirect: 'dashboard' },
-  })
 }
 </script>
 
@@ -109,19 +110,17 @@ function goToLogin() {
             <button
               type="submit"
               class="apply-submit-btn"
-              :disabled="!sortedFields.length"
+              :disabled="!sortedFields.length || saving"
               data-testid="apply-submit-button"
             >
-              {{ submitLabel }}
+              {{ saving ? 'Saving...' : 'Save Application' }}
             </button>
+          </div>
+          <div v-if="store.error" class="apply-error" data-testid="apply-error">
+            {{ store.error }}
           </div>
         </form>
       </template>
-
-      <div v-if="!signedIn" class="apply-returning" data-testid="apply-returning">
-        Already applied?
-        <a href="#" @click.prevent="goToLogin">Sign in to view your application</a>
-      </div>
     </template>
   </div>
 </template>
@@ -219,20 +218,14 @@ function goToLogin() {
   cursor: not-allowed;
 }
 
-.apply-returning {
-  margin-top: 24px;
-  text-align: center;
+.apply-error {
+  margin-top: 4px;
+  background: #f8d7da;
+  border: 1px solid var(--mm-red, #cc0000);
+  border-radius: 6px;
+  padding: 12px 16px;
   font-family: 'Outfit Regular';
   font-size: 14px;
-  color: var(--mm-grey, #666);
-}
-
-.apply-returning a {
-  color: var(--mm-green);
-  text-decoration: none;
-}
-
-.apply-returning a:hover {
-  text-decoration: underline;
+  color: #721c24;
 }
 </style>


### PR DESCRIPTION
## Intent

PR 5f of the Conventioner applicant-intake split: reorder the applicant flow so email is collected and verified before any application form field is shown. Delete the unowned-draft machinery that the old 'fill first, identify later' ordering forced into existence: the ApplyPage E2E page object's draftNotice/draftChoice/useTypedAnswers/keepSavedAnswers/clearRestoredDraft/savedBanner selectors never existed in the Vue component and are removed. The applicantSessionExpiry comment referencing 'preserving draft answers' is cleaned up. No applicantDraft.ts file existed in the codebase to delete - the draft machinery that did exist was confined to the E2E page object scaffolding. The login anti-oracle guarantees from PR 5d are preserved unchanged, and PR 6's approve/reject verdict hiding gate is untouched. Back-end unchanged - this is a pure front-end flow reordering.

## What Changed

- ApplicationPage now redirects unauthenticated visitors to the applicant login page on mount, and submits save the application and navigate to the dashboard instead of prompting for sign-in
- Removed unused draft-aware selectors (draftNotice, draftChoice, savedBanner, clearRestoredDraft, useTypedAnswers, keepSavedAnswers) from the ApplyPage E2E page object that were scaffolding for a draft-restore workflow never present in the Vue component
- Cleaned up a stale comment in applicantSessionExpiry.ts that referenced preserving draft answers

## Risk Assessment

✅ Low: The change is well-bounded (3 files, removal-only in E2E page object, straightforward flow reordering in ApplicationPage.vue, comment cleanup in applicantSessionExpiry.ts). All intent constraints are satisfied: the flow now collects and verifies email before showing any form field, draft machinery is fully removed, anti-oracle guarantees are untouched, PR 6's gate is untouched, and the back-end is unchanged. No findings at error or warning level.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `front-end/src/views/ApplicationPage.vue:57` - No pre-population of existing application answers on mount. An already-authenticated applicant who navigates directly to the apply page sees a blank form. The store&#39;s `fetchApplication()` exists and is called by `ApplicantDashboard` but not here. This is pre-existing behavior (the old code redirected to login before showing any form), but it is more impactful now that `submitForm` is a functional save path. Overwriting is possible on re-submit but the intended navigation flow (dashboard for viewing, apply for first-time entry) makes this unlikely in practice.
- ℹ️ `front-end/src/views/ApplicationPage.vue:60` - The `saving` ref guard on the submit button relies on Vue reactivity to update the DOM `:disabled` binding before the JavaScript event loop processes a second click. In extreme rapid-click scenarios, two `submitForm()` calls could fire before the button disables. The back-end PUT is idempotent for the same application, so the practical risk is negligible, but the pattern is worth noting for future hardening (e.g., a non-reactive guard check at the top of `submitForm`).
- ℹ️ `front-end/src/views/ApplicantDashboard.vue:62` - The dashboard `logout()` redirects to `apply` (line 64), which `ApplicationPage`&#39;s new onMounted guard now immediately redirects to `applicant-login`. This creates a visible flash of the apply page redirecting to login. This is pre-existing dashboard code made slightly worse by the flow change, but not in the diff scope. Consider a follow-up to redirect directly to `applicant-login` from the dashboard logout.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
