### PR TITLE
refactor(markets): route last inline organization fetch through _load_organization_context

### DIFF
--- a/back-end/api/markets.py
+++ b/back-end/api/markets.py
@@ -699,10 +699,8 @@ def get_assigned_market(market_id: str, requesting_user: Optional[str] = None) -
             assigned_market_dict = assigned_market.model_dump()
 
             assigned_market_dict = convert_keys_to_camel_case(assigned_market_dict)
-            if market_dict.get('organization_id'):
-                org = OrgsApi.get_organization(market_dict['organization_id'])
-                if org:
-                    assigned_market_dict['organizationName'] = org.get('name')
+            if context.organization_dict:
+                assigned_market_dict['organizationName'] = context.organization_dict.get('name')
             return assigned_market_dict, 200
 
         except Exception as validation_error:

--- a/back-end/tests/test_load_organization.py
+++ b/back-end/tests/test_load_organization.py
@@ -1,0 +1,168 @@
+"""Every organization load in the markets API goes through one helper.
+
+``_load_organization_context`` is the single "fetch org, drop ``_id``, parse, tolerate
+failure" path. The inline copies it replaced swallowed a parse failure silently; the
+helper logs a warning instead, so a market whose organization no longer parses is
+servable *and* visible in the logs. These tests pin both halves of that contract, at
+the helper and at the call sites that used to inline it.
+"""
+from types import SimpleNamespace
+
+import api.markets as MarketsApi
+from datatypes import Organization
+
+ORG_ID = "org-123"
+
+
+def _organization_doc(**overrides):
+    doc = {
+        "_id": "mongo-org-id",
+        "id": ORG_ID,
+        "name": "Test Org",
+        "owner": "user-9",
+        "admins": [],
+        "members": ["user-1"],
+        "markets": ["market-123"],
+    }
+    doc.update(overrides)
+    return doc
+
+
+def _unparseable_organization_doc():
+    """Fails ``Organization`` validation: the owner may not also be an admin."""
+    return _organization_doc(owner="user-9", admins=["user-9"])
+
+
+def _market_doc():
+    return {
+        "_id": "mongo-market-id",
+        "id": "market-123",
+        "name": "Test Market",
+        "creationDate": "2026-01-01T00:00:00Z",
+        "roles": {"user-1": "owner"},
+        "modificationList": [],
+        "assignmentObject": {
+            "assignmentDate": "",
+            "vendorAssignments": [],
+            "assignmentStatistics": None,
+        },
+        "organizationId": ORG_ID,
+    }
+
+
+class TestLoadOrganizationContext:
+    def test_returns_model_and_document_on_success(self, monkeypatch):
+        monkeypatch.setattr(MarketsApi.OrgsApi, "get_organization", lambda _oid: _organization_doc())
+
+        organization, org_dict = MarketsApi._load_organization_context(ORG_ID)
+
+        assert isinstance(organization, Organization)
+        assert organization.id == ORG_ID
+        assert org_dict["name"] == "Test Org"
+        assert "_id" not in org_dict
+
+    def test_missing_organization_returns_nothing_without_warning(self, monkeypatch, caplog):
+        monkeypatch.setattr(MarketsApi.OrgsApi, "get_organization", lambda _oid: None)
+
+        with caplog.at_level("WARNING"):
+            organization, org_dict = MarketsApi._load_organization_context(ORG_ID)
+
+        assert organization is None
+        assert org_dict is None
+        assert caplog.text == ""
+
+    def test_parse_failure_logs_a_warning_and_still_returns_the_document(self, monkeypatch, caplog):
+        monkeypatch.setattr(
+            MarketsApi.OrgsApi, "get_organization", lambda _oid: _unparseable_organization_doc()
+        )
+
+        with caplog.at_level("WARNING"):
+            organization, org_dict = MarketsApi._load_organization_context(ORG_ID)
+
+        assert organization is None
+        assert org_dict["name"] == "Test Org"
+        assert ORG_ID in caplog.text
+        assert "Failed to parse organization" in caplog.text
+
+
+class TestCallSitesAdoptTheHelpersFailurePath:
+    """The sites that inlined this block used to swallow a parse failure silently."""
+
+    def test_market_context_logs_the_org_parse_failure_and_still_serves_the_market(
+        self, monkeypatch, caplog
+    ):
+        monkeypatch.setattr(MarketsApi.markets_collection, "find_one", lambda _q: _market_doc())
+        monkeypatch.setattr(
+            MarketsApi.OrgsApi, "get_organization", lambda _oid: _unparseable_organization_doc()
+        )
+
+        with caplog.at_level("WARNING"):
+            context = MarketsApi.load_market_context("market-123")
+
+        assert context.market is not None
+        assert context.organization is None
+        assert context.organization_dict["name"] == "Test Org"
+        assert ORG_ID in caplog.text
+
+    def test_load_market_for_logs_the_org_parse_failure(self, monkeypatch, caplog):
+        monkeypatch.setattr(MarketsApi.markets_collection, "find_one", lambda _q: _market_doc())
+        monkeypatch.setattr(
+            MarketsApi.OrgsApi, "get_organization", lambda _oid: _unparseable_organization_doc()
+        )
+        monkeypatch.setattr(
+            MarketsApi.PermissionsApi, "user_has_permission", lambda *_a, **_k: True
+        )
+
+        with caplog.at_level("WARNING"):
+            market = MarketsApi._load_market_for(
+                "market-123", "owner@test.com", MarketsApi.MarketRole.VIEWER, "view"
+            )
+
+        assert market.id == "market-123"
+        assert ORG_ID in caplog.text
+        assert "Failed to parse organization" in caplog.text
+
+
+class TestGetAssignedMarketOrganizationName:
+    """The last inlined fetch: it re-read the organization the context already loaded."""
+
+    def _run(self, monkeypatch, org_doc):
+        fetches = []
+
+        def _get_organization(org_id):
+            fetches.append(org_id)
+            return org_doc
+
+        monkeypatch.setattr(MarketsApi.markets_collection, "find_one", lambda _q: _market_doc())
+        monkeypatch.setattr(MarketsApi.OrgsApi, "get_organization", _get_organization)
+        monkeypatch.setattr(
+            MarketsApi.SourceDataApi,
+            "get_source_data",
+            lambda _mid: ({"headers": [], "data": []}, 200),
+        )
+        monkeypatch.setattr(
+            MarketsApi,
+            "assign_market",
+            lambda _market, _source_data: SimpleNamespace(model_dump=lambda: {}),
+        )
+
+        result, status = MarketsApi.get_assigned_market("market-123")
+        return result, status, fetches
+
+    def test_attaches_organization_name_from_the_single_context_load(self, monkeypatch):
+        result, status, fetches = self._run(monkeypatch, _organization_doc())
+
+        assert status == 200
+        assert result["organizationName"] == "Test Org"
+        assert fetches == [ORG_ID]
+
+    def test_still_attaches_the_name_when_the_organization_fails_to_parse(
+        self, monkeypatch, caplog
+    ):
+        with caplog.at_level("WARNING"):
+            result, status, fetches = self._run(monkeypatch, _unparseable_organization_doc())
+
+        assert status == 200
+        assert result["organizationName"] == "Test Org"
+        assert fetches == [ORG_ID]
+        assert "Failed to parse organization" in caplog.text


### PR DESCRIPTION
## Intent

Refactor back-end/api/markets.py so every 'load an organization' call site routes through the existing _load_organization/_load_organization_context helper, collapsing the duplicated inline 'fetch org, pop _id, parse, tolerate failure' blocks and unifying their parse-failure handling. IMPORTANT scoping discovery the PR description must state: most of the dedupe had ALREADY landed in PR #24 (commit a4ef3cc3), which collapsed the ~10 inline blocks into _load_organization_context/load_market_context. This PR therefore covers only the residual inline site in get_assigned_market - which re-fetched the organization document the context load had already fetched just to attach organizationName; it now reads context.organization_dict (same success-path behavior, one fewer DB read) - plus new tests pinning the unified warning contract. The unified failure logging is a DELIBERATE behavior change, not an accident: previously-silent inline sites now log a warning through the helper when an organization document fails validation, while the market stays servable. New back-end/tests/test_load_organization.py pins the helper contract (model+doc on success, warning+doc on parse failure, silence when the org is absent) and proves the call sites (load_market_context, _load_market_for, get_assigned_market) surface the warning and keep serving; get_assigned_market is also pinned to fetch the org exactly once and to still attach organizationName when the org fails to parse (preserving the old inline block's behavior, which never parsed at all). Deliberately NOT routed through the helper: _SummaryLookups.organization() - it memoizes raw org dicts across a market list purely for name decoration and never parses an Organization model, so the helper's parse-and-warn contract does not apply; and permissions.py's inline parses, which are out of this task's markets.py-only scope. Backend-only change; PR base is dev per the branch model. Full backend suite green (498 passed).

## What Changed

- `get_assigned_market` now reads `context.organization_dict` for `organizationName` instead of re-fetching the organization document, eliminating one redundant DB read
- Unified parse-failure handling: inline sites that previously failed silently when an organization document failed validation now log a warning through the helper, while the market remains servable
- Added `tests/test_load_organization.py` pinning the helper contract and call-site behavior (168 lines)

## Risk Assessment

✅ Low: The functional change is a 4-line dedupe that reuses an already-fetched org document with identical success-path behavior (verified against the helper and route guards), plus new tests pinning the contract; the only divergence found is confined to an unreachable internal code path.

## Testing

The baseline `./scripts/nm-test.sh` already passed; I re-ran the full backend pytest suite (498 passed) and focused on the new tests/test_load_organization.py (7 passed), which directly demonstrate the intended behavior: get_assigned_market now reads context.organization_dict so the organization is fetched exactly once (one fewer DB read) while still attaching organizationName even when the org document fails to parse, and the unified helper logs a warning on parse failure while keeping the market servable. This is a backend-only, API/logic change with no user-visible UI surface, so no visual artifact applies; the evidence is the captured pytest transcript showing the single-fetch and warning contract assertions passing.

<details>
<summary>Evidence: get_assigned_market single-fetch + name-on-parse-failure tests pass</summary>

<code>TestGetAssignedMarketOrganizationName::test_attaches_organization_name_from_the_single_context_load PASSED&#10;TestGetAssignedMarketOrganizationName::test_still_attaches_the_name_when_the_organization_fails_to_parse PASSED&#10;2 passed</code>

```text
============================= test session starts ==============================
platform linux -- Python 3.13.12, pytest-9.0.3, pluggy-1.5.0 -- /home/danielc/miniconda3/bin/python3
cachedir: .pytest_cache
rootdir: /home/danielc/.no-mistakes/worktrees/480af703ce12/01KXJRSZ0J9ZY9KB17XBKAAGN1/back-end
configfile: pytest.ini
plugins: mock-3.15.1, cov-7.1.0, anyio-4.10.0
collecting ... collected 2 items

tests/test_load_organization.py::TestGetAssignedMarketOrganizationName::test_attaches_organization_name_from_the_single_context_load PASSED
tests/test_load_organization.py::TestGetAssignedMarketOrganizationName::test_still_attaches_the_name_when_the_organization_fails_to_parse PASSED

============================== 2 passed in 0.02s ===============================
```
</details>
<details>
<summary>Evidence: Full backend suite green (498 passed)</summary>

```text
== 498 passed, 6 warnings in 0.37s ===
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `back-end/api/markets.py:702` - Narrow behavior divergence: `context.organization_dict` is None whenever `load_market_context` bails on a market whose raw document fails validation (markets.py:411), while the old inline block fetched the org independently. A stored market that fails the first parse but succeeds at the second `market_from_document(context.document, market_dict)` call (line 697, thanks to the in-function `assignment_object` reset and `assignment_options` backfill) would previously get `organizationName` attached and now will not. This path is unreachable via the HTTP route (app.py:1120 requires a requesting user, and `context.market is None` then 400s at markets.py:654), so it only affects hypothetical in-process callers with `requesting_user=None`, of which there are none in production code.
- ℹ️ `back-end/tests/test_load_organization.py:71` - `assert caplog.text == &#34;&#34;` pins that the missing-org path logs nothing, but it will fail if any unrelated logger emits a WARNING inside the with-block in the future. Since `get_organization` is monkeypatched and the helper does no other I/O, this is acceptable today; a scoped assertion (e.g. filtering records by the markets logger) would be more robust.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./scripts/nm-test.sh`
- <code>`python3 -m pytest tests/test_load_organization.py` (7 passed) - pins helper contract (model+doc on success, warning+doc on parse failure, silence when org absent) and call-site behavior (load_market_context, _load_market_for, get_assigned_market)</code>
- <code>`python3 -m pytest tests/test_load_organization.py::TestGetAssignedMarketOrganizationName` - proves get_assigned_market fetches the org exactly once (`fetches == [ORG_ID]`, one fewer DB read) and still attaches organizationName when the org fails to parse</code>
- <code>`python3 -m pytest tests/` - full backend suite, 498 passed, matching the intent&#39;s stated baseline</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
