### PR TITLE
feat(applications): essential form fields with plan-derived offering and freeze-on-first-answer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,6 +329,27 @@ This file is the project's committed home for project-intrinsic agent knowledge:
   no site key and no hatch, and `npm run build` throws. Both templates ship the shape that works as
   it stands; `docs/STARTUP.md` names both copies.
 
+## Essential Form Fields (Conventioner sharp edge)
+
+- `back-end/essential_fields.py` is the single owner of the essential-questions contract:
+  the reserved `essential_*` answer keys in `Application.form_data`, the offering derivation
+  (dates from `setupObject.marketDates`, sections from `setupObject.sections`, table types from
+  the LAST floorplan's `tableTypes`), applicant answer validation, and the freeze.
+  `front-end/src/utils/essentialFields.ts` is its front-end mirror and must stay in step.
+- The offering follows the market plan live until the first applicant save, which snapshots it
+  onto `applicationForm.essentialOptions` (camelCase, server-owned like `publishedAt`; a client
+  payload can never write it). After that, no market-plan edit reaches the form - do not add a
+  refresh path. The form save writes `essentialOptions: null`, so the freeze filter matches
+  null-or-missing, not `$exists`.
+- Custom form-field keys may not use the `essential_` prefix (validated in
+  `_normalized_application_form` and mirrored in `front-end/src/utils/applicationForm.ts`).
+- `docs/schema.d.ts` is generated from `datatypes:MarketSchemaContract`; after changing a
+  contract model, run `python generate_market_schema.py --output ../docs/schema.d.ts` from
+  `back-end/` (pinned by `tests/test_generate_market_schema.py`).
+- Local stack for E2E: export `DISABLE_EMAIL=true` when bringing the stack up (`nm-test.sh`
+  does this; a bare `th-compose.sh up` does not), otherwise `auth.spec.ts`'s password-reset
+  test hits a 500 from the unconfigured mailer.
+
 ## No-mistakes Gate
 
 - `.no-mistakes.yaml` at the repo root configures the no-mistakes CI gate.

--- a/back-end/api/applicants.py
+++ b/back-end/api/applicants.py
@@ -255,8 +255,9 @@ def save_applicant_application(
     The applicant owns their answers but never ``status``.
 
     The first successful save freezes the essential offering onto the market's stored form
-    (``freeze_essential_options``), so later market-plan edits can never move a question an
-    applicant has already answered.
+    (``freeze_and_effective_essential_options``), atomically and before the answers are
+    persisted, so later market-plan edits can never move a question an applicant has already
+    answered and no answer is ever recorded against an unfrozen offering.
 
     Args:
         market_slug: The URL-safe slug of the market.
@@ -316,6 +317,19 @@ def save_applicant_application(
     )
     if essential_error:
         return {"error": essential_error}, 422
+
+    # Freeze BEFORE persisting, so no answer is ever recorded against an unfrozen offering.
+    # A concurrent first save may have frozen a different offering; when the governing one
+    # differs from what we validated against, re-validate against it.
+    frozen_options = EssentialFields.freeze_and_effective_essential_options(
+        db["markets"], market_id, essential_options,
+    )
+    if frozen_options != essential_options:
+        essential_error, essential_answers = EssentialFields.validated_essential_answers(
+            form_data, frozen_options,
+        )
+        if essential_error:
+            return {"error": essential_error}, 422
     stored_form_data.update(essential_answers)
 
     now = datetime.now(timezone.utc).isoformat()
@@ -328,9 +342,6 @@ def save_applicant_application(
     )
     if not app_doc.get("status"):
         ApplicationsApi.update_application_status(app_id, ApplicationStatus.OPEN)
-
-    # A recorded answer freezes the offering it was validated against; a no-op once frozen.
-    EssentialFields.freeze_essential_options(db["markets"], market_id, essential_options)
 
     updated_doc = ApplicationsApi.find_application_by_id(app_id)
     app = Application(**updated_doc) if updated_doc else Application(**app_doc)

--- a/back-end/api/applicants.py
+++ b/back-end/api/applicants.py
@@ -38,6 +38,7 @@ from utils.application_token import (
 )
 
 import api.applications as ApplicationsApi
+import essential_fields as EssentialFields
 
 logger = logging.getLogger(__name__)
 
@@ -164,7 +165,7 @@ def get_public_application_form(
     market_doc = published_market_by_slug(
         db["markets"],
         market_slug,
-        fields=("id", "name", "phase", "applicationForm", "resultsPublished"),
+        fields=("id", "name", "phase", "applicationForm", "resultsPublished", "setupObject"),
     )
     if not market_doc:
         return {"error": "Market not found. Check the URL and try again."}, 404
@@ -187,8 +188,11 @@ def get_public_application_form(
             })
         form_payload = {"fields": fields}
 
+    essential_options = EssentialFields.effective_essential_options(market_doc)
+
     return {
         "application_form": form_payload,
+        "essential_options": EssentialFields.essential_options_payload(essential_options),
         "market_name": market_doc.get("name", ""),
         "phase": phase.value,
         "is_open": phase == MarketPhase.APPLICATIONS_OPEN,
@@ -245,9 +249,14 @@ def save_applicant_application(
 ) -> Tuple[Dict[str, Any], int]:
     """Save or update the authenticated applicant's application for this market.
 
-    Validates the form data against the market's application form fields.
-    Refuses submission when the market is not in ``applications_open``.
+    Validates the form data against the market's application form fields, and the essential
+    answers against what the essential questions offer (``essential_fields``). Refuses
+    submission when the market is not in ``applications_open``.
     The applicant owns their answers but never ``status``.
+
+    The first successful save freezes the essential offering onto the market's stored form
+    (``freeze_essential_options``), so later market-plan edits can never move a question an
+    applicant has already answered.
 
     Args:
         market_slug: The URL-safe slug of the market.
@@ -264,7 +273,9 @@ def save_applicant_application(
     db = get_database()
 
     market_doc = published_market_by_slug(
-        db["markets"], market_slug, fields=("id", "phase", "applicationForm", "resultsPublished"),
+        db["markets"],
+        market_slug,
+        fields=("id", "phase", "applicationForm", "resultsPublished", "setupObject"),
     )
     if not market_doc:
         return {"error": "Market not found."}, 404
@@ -297,6 +308,16 @@ def save_applicant_application(
     if error:
         return {"error": error}, 422
 
+    # Validate the essential answers against what the questions offered. The essential answers
+    # are merged last so no custom answer can ever shadow one.
+    essential_options = EssentialFields.effective_essential_options(market_doc)
+    essential_error, essential_answers = EssentialFields.validated_essential_answers(
+        form_data, essential_options,
+    )
+    if essential_error:
+        return {"error": essential_error}, 422
+    stored_form_data.update(essential_answers)
+
     now = datetime.now(timezone.utc).isoformat()
 
     submitted_at = app_doc.get("submitted_at") or now
@@ -307,6 +328,9 @@ def save_applicant_application(
     )
     if not app_doc.get("status"):
         ApplicationsApi.update_application_status(app_id, ApplicationStatus.OPEN)
+
+    # A recorded answer freezes the offering it was validated against; a no-op once frozen.
+    EssentialFields.freeze_essential_options(db["markets"], market_id, essential_options)
 
     updated_doc = ApplicationsApi.find_application_by_id(app_id)
     app = Application(**updated_doc) if updated_doc else Application(**app_doc)

--- a/back-end/api/markets.py
+++ b/back-end/api/markets.py
@@ -1223,17 +1223,8 @@ def get_application_form(market_id: str, requesting_user: str) -> dict:
     return {
         "application_form": convert_keys_to_camel_case(form_dict) if form_dict else None,
         "essential_options": EssentialFields.essential_options_payload(
-            _effective_essential_options(market)
+            EssentialFields.effective_essential_options_for_market(market)
         ),
         "editable": lock_reason is None,
         "lock_reason": lock_reason,
     }
-
-
-def _effective_essential_options(market: Market) -> EssentialFormOptions:
-    """The essential offering for a parsed market: frozen snapshot first, live plan otherwise."""
-    form = market.application_form
-    if form is not None and form.essential_options is not None:
-        return form.essential_options
-    setup = market.setup_object.model_dump() if market.setup_object else None
-    return EssentialFields.essential_options_from_setup(setup)

--- a/back-end/api/markets.py
+++ b/back-end/api/markets.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 from bson import ObjectId
 from datatypes import (
     ApplicationForm,
+    EssentialFormOptions,
     FormField,
     Market,
     MarketPhase,
@@ -18,6 +19,7 @@ from datatypes import (
 from assignment.assignment import assign_market
 from assignment.utils import convert_keys_to_snake_case, convert_keys_to_camel_case, snake_to_camel
 import api.applications as ApplicationsApi
+import essential_fields as EssentialFields
 from market_documents import (
     market_doc_field,
     market_doc_filter,
@@ -160,7 +162,9 @@ def _normalized_select_options(field: FormField, key: str) -> List[str]:
 
 
 def _normalized_application_form(
-    application_form: ApplicationForm, published_at: Optional[str] = None
+    application_form: ApplicationForm,
+    published_at: Optional[str] = None,
+    essential_options: Optional[EssentialFormOptions] = None,
 ) -> ApplicationForm:
     """Validate a form and return it exactly as it will be persisted.
 
@@ -173,6 +177,9 @@ def _normalized_application_form(
 
     ``published_at`` is lock-bearing lifecycle state (D9). It is taken from the server's stored
     form and any value in the payload is discarded, so a client can never forge it.
+    ``essential_options`` is the frozen offering of the essential questions and is server-owned
+    for the same reason: it is stamped by the first recorded applicant answer
+    (``essential_fields.freeze_essential_options``) and any value in a payload is discarded.
     """
     if not application_form.fields:
         raise ValueError("Application form must include at least one field")
@@ -189,6 +196,12 @@ def _normalized_application_form(
             raise ValueError(
                 f"Invalid field key '{key}'. Keys may only contain lowercase letters, "
                 "numbers, and underscores."
+            )
+        if key.startswith(EssentialFields.ESSENTIAL_KEY_PREFIX):
+            raise ValueError(
+                f"Field key '{key}' uses the reserved "
+                f"'{EssentialFields.ESSENTIAL_KEY_PREFIX}' prefix. Those keys belong to the "
+                "essential questions every form already asks."
             )
         if key in seen_keys:
             raise ValueError(f"Duplicate field key '{key}'. Field keys must be unique.")
@@ -217,7 +230,11 @@ def _normalized_application_form(
             "order": index,
         }))
 
-    return application_form.model_copy(update={"fields": fields, "published_at": published_at})
+    return application_form.model_copy(update={
+        "fields": fields,
+        "published_at": published_at,
+        "essential_options": essential_options,
+    })
 
 
 def _application_form_dump(market: Market) -> Optional[Dict[str, Any]]:
@@ -1175,6 +1192,7 @@ def save_application_form(market_id: str, application_form_data: dict, requestin
     application_form = _normalized_application_form(
         application_form,
         published_at=stored_form.published_at if stored_form else None,
+        essential_options=stored_form.essential_options if stored_form else None,
     )
 
     form_dict = convert_keys_to_camel_case(application_form.model_dump())
@@ -1192,6 +1210,10 @@ def get_application_form(market_id: str, requesting_user: str) -> dict:
     Requires VIEWER+ permission. ``application_form`` is camelCase, matching the
     front-end contract and the persisted market document. ``editable``/``lock_reason``
     let the builder render read-only before an organizer invests work in a locked form.
+
+    ``essential_options`` is what the essential questions currently offer: the frozen
+    snapshot once one exists, otherwise the market plan as it stands. The builder renders
+    the always-present essential questions from it.
     """
     market = _load_market_for(market_id, requesting_user, MarketRole.VIEWER, "view")
 
@@ -1200,6 +1222,18 @@ def get_application_form(market_id: str, requesting_user: str) -> dict:
 
     return {
         "application_form": convert_keys_to_camel_case(form_dict) if form_dict else None,
+        "essential_options": EssentialFields.essential_options_payload(
+            _effective_essential_options(market)
+        ),
         "editable": lock_reason is None,
         "lock_reason": lock_reason,
     }
+
+
+def _effective_essential_options(market: Market) -> EssentialFormOptions:
+    """The essential offering for a parsed market: frozen snapshot first, live plan otherwise."""
+    form = market.application_form
+    if form is not None and form.essential_options is not None:
+        return form.essential_options
+    setup = market.setup_object.model_dump() if market.setup_object else None
+    return EssentialFields.essential_options_from_setup(setup)

--- a/back-end/datatypes.py
+++ b/back-end/datatypes.py
@@ -363,9 +363,32 @@ class FormField(BaseModel):
     order: int = 0                 # display order
 
 
+class EssentialFormOptions(BaseModel):
+    """What the essential form questions offer, derived from the market plan.
+
+    The essential questions (available dates, max dates, section preference, table type
+    preference) are present in every application form; the only thing an organizer customises
+    is what they offer, and that offering is the market plan itself: ``dates`` come from
+    ``SetupObject.market_dates``, ``sections`` from ``SetupObject.sections``, and
+    ``table_types`` from the market's floorplan table types. See ``essential_fields.py``,
+    the single owner of that derivation.
+
+    A value of this type stored on ``ApplicationForm.essential_options`` is a *frozen*
+    offering: it is written by the server the first time an applicant's answers are recorded
+    against it (the same principle as the D9 lock - an applicant can never have answered a
+    question that moved), and never refreshed afterwards.
+    """
+    dates: List[str] = []
+    sections: List[str] = []
+    table_types: List[str] = []
+
+
 class ApplicationForm(BaseModel):
     fields: List[FormField]
     published_at: Optional[str] = None  # locks form when applications exist (D9)
+    # Server-owned frozen offering of the essential questions; None until the first
+    # applicant answer freezes it. Never writable by a client (see _normalized_application_form).
+    essential_options: Optional[EssentialFormOptions] = None
 
 
 class Application(BaseModel):
@@ -607,9 +630,14 @@ class FormFieldContract(FormField, ContractModel):
     """Camel-cased contract view of an application form field."""
 
 
+class EssentialFormOptionsContract(EssentialFormOptions, ContractModel):
+    """Camel-cased contract view of the essential questions' offering."""
+
+
 class ApplicationFormContract(ContractModel):
     fields: List[FormFieldContract]
     published_at: Optional[str] = None
+    essential_options: Optional[EssentialFormOptionsContract] = None
 
 
 class MarketSchemaContract(ContractModel):

--- a/back-end/datatypes.py
+++ b/back-end/datatypes.py
@@ -354,7 +354,7 @@ class ApplicationType(str, Enum):
 
 
 class FormField(BaseModel):
-    key: str                       # machine name (e.g., "business_name")
+    key: str                       # machine name (e.g., "business_name"); must not use the reserved "essential_" prefix
     label: str                     # human label (e.g., "Business Name")
     type: str                      # "text", "number", "select", "multi_select", "checkbox", "date", "email", "file"
     required: bool = False

--- a/back-end/essential_fields.py
+++ b/back-end/essential_fields.py
@@ -141,10 +141,11 @@ def freeze_essential_options(
 ) -> None:
     """Persist the offering the first recorded answer was validated against.
 
-    Written once: the ``$exists: False`` filter makes every later call a no-op, so the first
-    applicant save is the freeze point and concurrent saves cannot fight over it. The form must
-    already be an object on the document - a dot-path ``$set`` onto a market with no form would
-    conjure a fieldless one.
+    Written once: the filter matches only while no snapshot is stored - ``None`` in a Mongo
+    filter matches both a missing key and the explicit ``null`` the form save writes - so the
+    first applicant save is the freeze point and concurrent saves cannot fight over it. The
+    form must already be an object on the document - a dot-path ``$set`` onto a market with no
+    form would conjure a fieldless one.
     """
     form_key = market_doc_key("application_form")
     snapshot_key = f"{form_key}.{snake_to_camel('essential_options')}"
@@ -152,7 +153,7 @@ def freeze_essential_options(
         {
             "id": market_id,
             form_key: {"$type": "object"},
-            snapshot_key: {"$exists": False},
+            snapshot_key: None,
         },
         {"$set": {snapshot_key: essential_options_payload(options)}},
     )

--- a/back-end/essential_fields.py
+++ b/back-end/essential_fields.py
@@ -1,0 +1,297 @@
+"""The essential application-form questions: the answers the assignment solver reads directly.
+
+Every application form asks these, whatever else the organizer builds. If the assignment
+algorithm reads it, it is essential - that test is mechanical, and five fields pass it:
+
+  - email                    -- the applicant's identity; captured at sign-in, not asked here
+  - essential_available_dates -- which market dates the applicant CAN attend (capability)
+  - essential_max_dates       -- at most how many dates they WANT (appetite; not capability)
+  - essential_section_ranking -- section preference, best first
+  - essential_table_type_ranking -- table type preference, best first
+
+This module is the single owner of that contract: the reserved answer keys, the derivation of
+what the questions offer, the validation of an applicant's answers, and the freeze that stops
+the offering from moving under recorded answers.
+
+The offering is never an independent list: it is the market plan itself. Dates come from
+``SetupObject.market_dates``, sections from ``SetupObject.sections``, and table types from the
+market's floorplan (the latest saved one - ``floorplans_save`` overwrites ``sections`` and
+``locations`` from the latest floorplan too, so its table types are the current plan's).
+
+Freeze semantics (the D9 principle extended to the offering): while no applicant has recorded
+an answer, the offering follows the market plan live - an organizer edits their plan and the
+form follows. The moment the first answer is stored, the offering it was validated against is
+persisted onto ``applicationForm.essentialOptions`` (camelCase, like the whole market document)
+and every later read serves that snapshot, so an applicant can never have answered a question
+that moved. There is deliberately no way to refresh it afterwards.
+"""
+from typing import Any, Dict, List, Optional, Tuple
+
+from assignment.utils import (
+    convert_keys_to_camel_case,
+    convert_keys_to_snake_case,
+    snake_to_camel,
+)
+from datatypes import EssentialFormOptions
+from market_documents import market_doc_field, market_doc_key
+
+# Custom builder fields may never use this prefix: the essential answers live beside the custom
+# answers in ``Application.form_data``, and a custom field that shadowed one would corrupt what
+# the solver reads.
+ESSENTIAL_KEY_PREFIX = "essential_"
+
+AVAILABLE_DATES_KEY = "essential_available_dates"
+MAX_DATES_KEY = "essential_max_dates"
+SECTION_RANKING_KEY = "essential_section_ranking"
+TABLE_TYPE_RANKING_KEY = "essential_table_type_ranking"
+
+# The labels the applicant sees, shared with error messages so a validation failure names the
+# question exactly as the form asked it.
+AVAILABLE_DATES_LABEL = "Available dates"
+MAX_DATES_LABEL = "Number of dates you want"
+SECTION_RANKING_LABEL = "Section preference"
+TABLE_TYPE_RANKING_LABEL = "Table type preference"
+
+
+def _unique_names(values: Any) -> List[str]:
+    """Trimmed, non-blank, order-preserving unique strings."""
+    seen: List[str] = []
+    if not isinstance(values, list):
+        return seen
+    for value in values:
+        text = str(value or "").strip()
+        if text and text not in seen:
+            seen.append(text)
+    return seen
+
+
+def essential_options_from_setup(setup: Optional[Dict[str, Any]]) -> EssentialFormOptions:
+    """The essential questions' offering, read from the market plan.
+
+    ``setup`` is a snake_case dict of ``SetupObject`` (a ``model_dump()``, or a stored
+    ``setupObject`` converted through ``convert_keys_to_snake_case``). A market with no plan
+    yet offers nothing - the applicant form omits questions whose offering is empty.
+    """
+    if not isinstance(setup, dict):
+        return EssentialFormOptions()
+
+    dates = _unique_names([
+        md.get("date")
+        for md in setup.get("market_dates") or []
+        if isinstance(md, dict)
+    ])
+    sections = _unique_names([
+        section.get("name")
+        for section in setup.get("sections") or []
+        if isinstance(section, dict)
+    ])
+
+    floorplans = [fp for fp in setup.get("floorplans") or [] if isinstance(fp, dict)]
+    table_types: List[str] = []
+    if floorplans:
+        # The latest floorplan is the current plan: floorplans_save overwrites sections and
+        # locations from it, so its table types are what the plan actually offers.
+        table_types = _unique_names([
+            table_type.get("name")
+            for table_type in floorplans[-1].get("table_types") or []
+            if isinstance(table_type, dict)
+        ])
+
+    return EssentialFormOptions(dates=dates, sections=sections, table_types=table_types)
+
+
+def effective_essential_options(market_doc: Dict[str, Any]) -> EssentialFormOptions:
+    """What the essential questions offer for this market, frozen or live.
+
+    A stored snapshot (``applicationForm.essentialOptions``) wins: it is what an applicant's
+    recorded answers were validated against, and it never moves. Absent one, the offering is
+    the market plan as it stands.
+
+    Callers hand in the raw stored (camelCase) market document; the projection must include
+    ``applicationForm`` and ``setupObject``.
+    """
+    form_doc = market_doc_field(market_doc, "application_form")
+    if isinstance(form_doc, dict):
+        snapshot = form_doc.get(snake_to_camel("essential_options"))
+        if isinstance(snapshot, dict):
+            return essential_options_from_snapshot(snapshot)
+
+    setup_doc = market_doc_field(market_doc, "setup_object")
+    setup = convert_keys_to_snake_case(setup_doc) if isinstance(setup_doc, dict) else None
+    return essential_options_from_setup(setup)
+
+
+def essential_options_from_snapshot(snapshot: Dict[str, Any]) -> EssentialFormOptions:
+    """Parse a stored (camelCase) ``essentialOptions`` snapshot."""
+    data = convert_keys_to_snake_case(snapshot)
+    return EssentialFormOptions(
+        dates=_unique_names(data.get("dates")),
+        sections=_unique_names(data.get("sections")),
+        table_types=_unique_names(data.get("table_types")),
+    )
+
+
+def essential_options_payload(options: EssentialFormOptions) -> Dict[str, Any]:
+    """The camelCase wire/persisted shape of an offering."""
+    return convert_keys_to_camel_case(options.model_dump())
+
+
+def freeze_essential_options(
+    markets_collection: Any, market_id: str, options: EssentialFormOptions,
+) -> None:
+    """Persist the offering the first recorded answer was validated against.
+
+    Written once: the ``$exists: False`` filter makes every later call a no-op, so the first
+    applicant save is the freeze point and concurrent saves cannot fight over it. The form must
+    already be an object on the document - a dot-path ``$set`` onto a market with no form would
+    conjure a fieldless one.
+    """
+    form_key = market_doc_key("application_form")
+    snapshot_key = f"{form_key}.{snake_to_camel('essential_options')}"
+    markets_collection.update_one(
+        {
+            "id": market_id,
+            form_key: {"$type": "object"},
+            snapshot_key: {"$exists": False},
+        },
+        {"$set": {snapshot_key: essential_options_payload(options)}},
+    )
+
+
+# -- Applicant answer validation ---------------------------------------------------------------
+
+
+def validated_essential_answers(
+    incoming: Dict[str, Any], options: EssentialFormOptions,
+) -> Tuple[Optional[str], Dict[str, Any]]:
+    """Validate an applicant's essential answers against what the form offered.
+
+    Returns ``(error_message, stored_answers)``; when ``error_message`` is not None the save
+    must be refused. Questions whose offering is empty are not asked, so they are not required
+    and store their empty value.
+
+    STUBBED PRODUCT DECISIONS (deliberately minimal until the product owner rules):
+      - Rankings are TOTAL: an applicant ranks every offered section / table type, and the
+        stored list must be a permutation of the offering. A partial ranking ("only the ones I
+        want") is not accepted yet.
+      - ``max_dates`` is bounded by the number of OFFERED dates only. Its relation to the
+        applicant's own available dates is not validated here; a consumer should treat the
+        effective cap as ``min(max_dates, len(available_dates))``.
+    """
+    stored: Dict[str, Any] = {}
+
+    error = _validate_available_dates(incoming, options, stored)
+    if error:
+        return error, {}
+
+    error = _validate_max_dates(incoming, options, stored)
+    if error:
+        return error, {}
+
+    error = _validate_ranking(
+        incoming, SECTION_RANKING_KEY, SECTION_RANKING_LABEL, options.sections, stored,
+    )
+    if error:
+        return error, {}
+
+    error = _validate_ranking(
+        incoming, TABLE_TYPE_RANKING_KEY, TABLE_TYPE_RANKING_LABEL, options.table_types, stored,
+    )
+    if error:
+        return error, {}
+
+    return None, stored
+
+
+def _validate_available_dates(
+    incoming: Dict[str, Any], options: EssentialFormOptions, stored: Dict[str, Any],
+) -> Optional[str]:
+    if not options.dates:
+        stored[AVAILABLE_DATES_KEY] = []
+        return None
+
+    raw = incoming.get(AVAILABLE_DATES_KEY)
+    if raw is None or raw == []:
+        return f"'{AVAILABLE_DATES_LABEL}' is required. Select at least one date."
+    if not isinstance(raw, list):
+        return f"'{AVAILABLE_DATES_LABEL}' requires one or more of the offered dates."
+
+    chosen = [str(value).strip() for value in raw]
+    for value in chosen:
+        if value not in options.dates:
+            return f"'{AVAILABLE_DATES_LABEL}' contains a date this market does not offer: {value}"
+    if len(set(chosen)) != len(chosen):
+        return f"'{AVAILABLE_DATES_LABEL}' repeats a date."
+
+    # Stored in the market plan's order, so every consumer reads one canonical ordering.
+    stored[AVAILABLE_DATES_KEY] = [date for date in options.dates if date in chosen]
+    return None
+
+
+def _validate_max_dates(
+    incoming: Dict[str, Any], options: EssentialFormOptions, stored: Dict[str, Any],
+) -> Optional[str]:
+    if not options.dates:
+        stored[MAX_DATES_KEY] = None
+        return None
+
+    raw = incoming.get(MAX_DATES_KEY)
+    if raw is None or (isinstance(raw, str) and not raw.strip()):
+        return f"'{MAX_DATES_LABEL}' is required."
+
+    if isinstance(raw, bool):
+        return f"'{MAX_DATES_LABEL}' must be a whole number."
+    if isinstance(raw, int):
+        value = raw
+    elif isinstance(raw, str):
+        try:
+            value = int(raw.strip())
+        except ValueError:
+            return f"'{MAX_DATES_LABEL}' must be a whole number."
+    elif isinstance(raw, float) and raw.is_integer():
+        value = int(raw)
+    else:
+        return f"'{MAX_DATES_LABEL}' must be a whole number."
+
+    if value < 1:
+        return f"'{MAX_DATES_LABEL}' must be at least 1."
+    if value > len(options.dates):
+        return (
+            f"'{MAX_DATES_LABEL}' cannot exceed the {len(options.dates)} date(s) "
+            f"this market offers."
+        )
+
+    stored[MAX_DATES_KEY] = value
+    return None
+
+
+def _validate_ranking(
+    incoming: Dict[str, Any],
+    key: str,
+    label: str,
+    offered: List[str],
+    stored: Dict[str, Any],
+) -> Optional[str]:
+    if not offered:
+        stored[key] = []
+        return None
+
+    raw = incoming.get(key)
+    if raw is None or raw == []:
+        return f"'{label}' is required. Rank every option, best first."
+    if not isinstance(raw, list):
+        return f"'{label}' must be an ordered list of the offered options."
+
+    ranked = [str(value).strip() for value in raw]
+    for value in ranked:
+        if value not in offered:
+            return f"'{label}' contains an option this market does not offer: {value}"
+    if len(set(ranked)) != len(ranked):
+        return f"'{label}' repeats an option."
+    if len(ranked) != len(offered):
+        # Stub: total ranking required (see the module docstring).
+        missing = [value for value in offered if value not in ranked]
+        return f"'{label}' must rank every option. Missing: {', '.join(missing)}"
+
+    stored[key] = ranked
+    return None

--- a/back-end/essential_fields.py
+++ b/back-end/essential_fields.py
@@ -20,10 +20,11 @@ market's floorplan (the latest saved one - ``floorplans_save`` overwrites ``sect
 
 Freeze semantics (the D9 principle extended to the offering): while no applicant has recorded
 an answer, the offering follows the market plan live - an organizer edits their plan and the
-form follows. The moment the first answer is stored, the offering it was validated against is
-persisted onto ``applicationForm.essentialOptions`` (camelCase, like the whole market document)
-and every later read serves that snapshot, so an applicant can never have answered a question
-that moved. There is deliberately no way to refresh it afterwards.
+form follows. The first accepted answer freezes the offering it was validated against onto
+``applicationForm.essentialOptions`` (camelCase, like the whole market document) - written
+atomically before the answer itself is stored, so no answer ever lands against an unfrozen
+offering - and every later read serves that snapshot, so an applicant can never have answered
+a question that moved. There is deliberately no way to refresh it afterwards.
 """
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -32,7 +33,7 @@ from assignment.utils import (
     convert_keys_to_snake_case,
     snake_to_camel,
 )
-from datatypes import EssentialFormOptions
+from datatypes import EssentialFormOptions, Market
 from market_documents import market_doc_field, market_doc_key
 
 # Custom builder fields may never use this prefix: the essential answers live beside the custom
@@ -121,6 +122,19 @@ def effective_essential_options(market_doc: Dict[str, Any]) -> EssentialFormOpti
     return essential_options_from_setup(setup)
 
 
+def effective_essential_options_for_market(market: Market) -> EssentialFormOptions:
+    """``effective_essential_options`` over a parsed ``Market``: same rule, other representation.
+
+    A frozen snapshot on the form wins; absent one, the offering is the market plan as it
+    stands.
+    """
+    form = market.application_form
+    if form is not None and form.essential_options is not None:
+        return form.essential_options
+    setup = market.setup_object.model_dump() if market.setup_object else None
+    return essential_options_from_setup(setup)
+
+
 def essential_options_from_snapshot(snapshot: Dict[str, Any]) -> EssentialFormOptions:
     """Parse a stored (camelCase) ``essentialOptions`` snapshot."""
     data = convert_keys_to_snake_case(snapshot)
@@ -157,6 +171,26 @@ def freeze_essential_options(
         },
         {"$set": {snapshot_key: essential_options_payload(options)}},
     )
+
+
+def freeze_and_effective_essential_options(
+    markets_collection: Any, market_id: str, options: EssentialFormOptions,
+) -> EssentialFormOptions:
+    """Freeze the offering and return the one that actually governs the save.
+
+    Called before an applicant's answers are persisted, so no answer can ever be recorded
+    against an unfrozen offering. The freeze attempt is atomic and first-writer-wins; the
+    re-read serves whichever snapshot won (ours, or a concurrent save's). A caller must
+    re-validate its answers when the returned offering differs from the one it validated
+    against, because that means another save froze a different offering first.
+    """
+    freeze_essential_options(markets_collection, market_id, options)
+    form_key = market_doc_key("application_form")
+    setup_key = market_doc_key("setup_object")
+    market_doc = markets_collection.find_one(
+        {"id": market_id}, {form_key: 1, setup_key: 1},
+    )
+    return effective_essential_options(market_doc or {})
 
 
 # -- Applicant answer validation ---------------------------------------------------------------

--- a/back-end/tests/test_essential_fields.py
+++ b/back-end/tests/test_essential_fields.py
@@ -249,14 +249,16 @@ class FakeFreezeMarketsCollection:
 
 
 class TestFreezeEssentialOptions:
-    def test_the_snapshot_is_written_once_in_camel_case_behind_an_exists_guard(self):
+    def test_the_snapshot_is_written_once_in_camel_case_behind_an_unset_guard(self):
         markets = FakeFreezeMarketsCollection()
 
         EssentialFields.freeze_essential_options(markets, "market-123", OPTIONS)
 
         (filter_, update), = markets.calls
         assert filter_["id"] == "market-123"
-        assert filter_["applicationForm.essentialOptions"] == {"$exists": False}
+        # None matches both a missing key and the explicit null the form save writes;
+        # either way, an existing snapshot is never overwritten.
+        assert filter_["applicationForm.essentialOptions"] is None
         assert filter_["applicationForm"] == {"$type": "object"}
         written = update["$set"]["applicationForm.essentialOptions"]
         assert written == {"dates": DATES, "sections": SECTIONS, "tableTypes": TABLE_TYPES}

--- a/back-end/tests/test_essential_fields.py
+++ b/back-end/tests/test_essential_fields.py
@@ -369,6 +369,39 @@ class TestApplicantSave:
         assert status == 422
         assert "does not offer" in body["error"]
 
+    def test_a_save_losing_the_freeze_race_is_validated_against_the_winning_offering(
+        self, monkeypatch, applications,
+    ):
+        """The freeze is attempted before the answers are persisted; when a concurrent save
+        froze a different offering first, the answers are re-validated against the winner and
+        nothing is stored on failure."""
+        doc = _applicant_market_doc()
+        markets = FakeSlugMarketsCollection(doc)
+        original_update = markets.update_one
+
+        def losing_freeze(filter_, update):
+            doc["applicationForm"]["essentialOptions"] = {
+                "dates": ["2026-08-01"], "sections": ["Main Hall"], "tableTypes": ["Full Table"],
+            }
+            return original_update(filter_, update)
+
+        markets.update_one = losing_freeze
+
+        class _Db(dict):
+            def __getitem__(self, name):
+                return markets
+
+        monkeypatch.setattr(test_db_config, "get_database", lambda *_a, **_kw: _Db())
+        _seed_application(applications)
+
+        body, status = save_applicant_application(
+            "test-market", _token(), {**VALID_ANSWERS, "business_name": "Acme"},
+        )
+
+        assert status == 422
+        assert "does not offer" in body["error"]
+        assert applications.find_one({"id": "app-1"})["form_data"] == {}
+
 
 class TestPublicForm:
     def test_the_public_form_carries_the_essential_offering(self, applicant_db):

--- a/back-end/tests/test_essential_fields.py
+++ b/back-end/tests/test_essential_fields.py
@@ -1,0 +1,392 @@
+"""Tests for the essential form fields: the answers the assignment solver reads directly.
+
+``essential_fields.py`` is the single owner of the contract: the reserved answer keys, the
+derivation of what the essential questions offer (from the market plan, never a second list),
+the validation of an applicant's essential answers, and the freeze that stops the offering from
+moving under recorded answers (the D9 principle extended to the offering).
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from conftest import FakeMarketsCollection, FakeSlugMarketsCollection, stored_market
+
+import api.markets as MarketsApi
+import api.permissions as PermissionsApi
+import db_config as test_db_config
+import essential_fields as EssentialFields
+from api.applicants import get_public_application_form, save_applicant_application
+from datatypes import Application, ApplicationForm, ApplicationStatus, EssentialFormOptions
+
+
+DATES = ["2026-08-01", "2026-08-08", "2026-08-15"]
+SECTIONS = ["Main Hall", "Garden"]
+TABLE_TYPES = ["Full Table", "Half Table"]
+
+OPTIONS = EssentialFormOptions(dates=DATES, sections=SECTIONS, table_types=TABLE_TYPES)
+
+SETUP_SNAKE = {
+    "market_dates": [{"date": date} for date in DATES],
+    "sections": [{"name": name, "count": 4} for name in SECTIONS],
+    "floorplans": [
+        {"table_types": [{"name": "Stale Type"}]},
+        {"table_types": [{"name": name} for name in TABLE_TYPES]},
+    ],
+}
+
+# The same plan as Mongo stores it: camelCase throughout, complete enough for ``Market`` to
+# parse (the organizer endpoint loads the market through ``market_from_document``).
+def _camel_table_type(name: str) -> dict:
+    return {"name": name, "widthMm": 1800.0, "heightMm": 800.0, "maxCapacity": 2}
+
+
+SETUP_CAMEL = {
+    "colNames": [],
+    "colValues": [],
+    "colInclude": [],
+    "enumPriorityOrder": [],
+    "priority": [],
+    "marketDates": [{"date": date} for date in DATES],
+    "tiers": [],
+    "locations": [],
+    "sections": [{"name": name, "count": 4} for name in SECTIONS],
+    "assignmentOptions": {},
+    "floorplans": [
+        {"tableTypes": [_camel_table_type("Stale Type")]},
+        {"tableTypes": [_camel_table_type(name) for name in TABLE_TYPES]},
+    ],
+}
+
+VALID_ANSWERS = {
+    "essential_available_dates": ["2026-08-08", "2026-08-01"],
+    "essential_max_dates": 2,
+    "essential_section_ranking": ["Garden", "Main Hall"],
+    "essential_table_type_ranking": ["Full Table", "Half Table"],
+}
+
+
+class TestEssentialOptionsFromSetup:
+    def test_reads_dates_sections_and_table_types_from_the_plan(self):
+        options = EssentialFields.essential_options_from_setup(SETUP_SNAKE)
+
+        assert options.dates == DATES
+        assert options.sections == SECTIONS
+        assert options.table_types == TABLE_TYPES
+
+    def test_the_latest_floorplan_owns_the_table_types(self):
+        """floorplans_save appends floorplans and overwrites sections from the latest one,
+        so the latest floorplan's table types are the current plan's."""
+        options = EssentialFields.essential_options_from_setup(SETUP_SNAKE)
+
+        assert "Stale Type" not in options.table_types
+
+    def test_a_market_with_no_plan_offers_nothing(self):
+        assert EssentialFields.essential_options_from_setup(None) == EssentialFormOptions()
+
+    def test_blank_and_duplicate_names_are_dropped(self):
+        options = EssentialFields.essential_options_from_setup({
+            "market_dates": [{"date": "2026-08-01"}, {"date": ""}, {"date": "2026-08-01"}],
+            "sections": [{"name": "  Garden  "}, {"name": "Garden"}],
+        })
+
+        assert options.dates == ["2026-08-01"]
+        assert options.sections == ["Garden"]
+
+
+class TestEffectiveEssentialOptions:
+    def test_live_offering_comes_from_the_stored_camel_case_plan(self):
+        doc = stored_market(setupObject=SETUP_CAMEL)
+
+        options = EssentialFields.effective_essential_options(doc)
+
+        assert options == OPTIONS
+
+    def test_a_frozen_snapshot_wins_over_the_live_plan(self):
+        """Once an answer froze the offering, later plan edits must never reach the form."""
+        doc = stored_market(
+            setupObject=SETUP_CAMEL,
+            applicationForm={
+                "fields": [],
+                "essentialOptions": {
+                    "dates": ["2026-01-01"],
+                    "sections": ["Old Hall"],
+                    "tableTypes": ["Old Table"],
+                },
+            },
+        )
+
+        options = EssentialFields.effective_essential_options(doc)
+
+        assert options.dates == ["2026-01-01"]
+        assert options.sections == ["Old Hall"]
+        assert options.table_types == ["Old Table"]
+
+
+class TestValidatedEssentialAnswers:
+    def test_valid_answers_are_stored_under_the_reserved_keys(self):
+        error, stored = EssentialFields.validated_essential_answers(VALID_ANSWERS, OPTIONS)
+
+        assert error is None
+        # Dates are canonicalized to the plan's order.
+        assert stored["essential_available_dates"] == ["2026-08-01", "2026-08-08"]
+        assert stored["essential_max_dates"] == 2
+        assert stored["essential_section_ranking"] == ["Garden", "Main Hall"]
+        assert stored["essential_table_type_ranking"] == ["Full Table", "Half Table"]
+
+    @pytest.mark.parametrize("missing_key,expected", [
+        ("essential_available_dates", "'Available dates' is required"),
+        ("essential_max_dates", "'Number of dates you want' is required"),
+        ("essential_section_ranking", "'Section preference' is required"),
+        ("essential_table_type_ranking", "'Table type preference' is required"),
+    ])
+    def test_every_essential_answer_is_required(self, missing_key, expected):
+        answers = {key: value for key, value in VALID_ANSWERS.items() if key != missing_key}
+
+        error, stored = EssentialFields.validated_essential_answers(answers, OPTIONS)
+
+        assert error is not None and expected in error
+        assert stored == {}
+
+    def test_a_date_the_market_does_not_offer_is_refused(self):
+        answers = {**VALID_ANSWERS, "essential_available_dates": ["2027-01-01"]}
+
+        error, _ = EssentialFields.validated_essential_answers(answers, OPTIONS)
+
+        assert "does not offer" in error
+
+    def test_max_dates_must_be_a_whole_number_of_at_least_one(self):
+        for bad in (0, -1, "abc", 1.5, True):
+            answers = {**VALID_ANSWERS, "essential_max_dates": bad}
+            error, _ = EssentialFields.validated_essential_answers(answers, OPTIONS)
+            assert error is not None, f"{bad!r} should be refused"
+
+    def test_max_dates_cannot_exceed_the_offered_dates(self):
+        answers = {**VALID_ANSWERS, "essential_max_dates": len(DATES) + 1}
+
+        error, _ = EssentialFields.validated_essential_answers(answers, OPTIONS)
+
+        assert "cannot exceed" in error
+
+    def test_max_dates_may_exceed_the_available_dates(self):
+        """STUB (product decision pending): max > len(available) is accepted; consumers treat
+        the effective cap as min(max_dates, len(available_dates))."""
+        answers = {**VALID_ANSWERS, "essential_available_dates": ["2026-08-01"],
+                   "essential_max_dates": 3}
+
+        error, stored = EssentialFields.validated_essential_answers(answers, OPTIONS)
+
+        assert error is None
+        assert stored["essential_max_dates"] == 3
+
+    def test_a_partial_ranking_is_refused(self):
+        """STUB (product decision pending): rankings are total; every offered option must be
+        ranked."""
+        answers = {**VALID_ANSWERS, "essential_section_ranking": ["Garden"]}
+
+        error, _ = EssentialFields.validated_essential_answers(answers, OPTIONS)
+
+        assert "must rank every option" in error
+        assert "Main Hall" in error
+
+    def test_a_ranking_may_not_repeat_or_invent_options(self):
+        repeated = {**VALID_ANSWERS, "essential_section_ranking": ["Garden", "Garden"]}
+        invented = {**VALID_ANSWERS, "essential_table_type_ranking": ["Full Table", "Podium"]}
+
+        assert EssentialFields.validated_essential_answers(repeated, OPTIONS)[0] is not None
+        assert "does not offer" in EssentialFields.validated_essential_answers(invented, OPTIONS)[0]
+
+    def test_questions_with_an_empty_offering_are_not_asked(self):
+        """A plan with no sections or table types yet omits those questions; their answers
+        store empty. Dates likewise."""
+        error, stored = EssentialFields.validated_essential_answers({}, EssentialFormOptions())
+
+        assert error is None
+        assert stored == {
+            "essential_available_dates": [],
+            "essential_max_dates": None,
+            "essential_section_ranking": [],
+            "essential_table_type_ranking": [],
+        }
+
+
+class TestReservedKeyPrefix:
+    def test_the_builder_refuses_custom_fields_in_the_essential_namespace(self, monkeypatch,
+                                                                           applications):
+        monkeypatch.setattr(MarketsApi, "markets_collection",
+                            FakeMarketsCollection(stored_market()))
+        monkeypatch.setattr(PermissionsApi, "user_has_permission", lambda *_a, **_kw: True)
+        form = {"fields": [
+            {"key": "essential_available_dates", "label": "Sneaky", "type": "text"},
+        ]}
+
+        with pytest.raises(ValueError, match="reserved 'essential_' prefix"):
+            MarketsApi.save_application_form("market-123", form, "user-1")
+
+    def test_a_client_cannot_forge_the_frozen_offering(self, monkeypatch, applications):
+        """``essential_options`` is server-owned, like ``published_at``: whatever a payload
+        carries is discarded."""
+        markets = FakeMarketsCollection(stored_market())
+        monkeypatch.setattr(MarketsApi, "markets_collection", markets)
+        monkeypatch.setattr(PermissionsApi, "user_has_permission", lambda *_a, **_kw: True)
+        form = {
+            "fields": [{"key": "business_name", "label": "Business Name", "type": "text"}],
+            "essential_options": {"dates": ["2027-01-01"], "sections": [], "table_types": []},
+        }
+
+        MarketsApi.save_application_form("market-123", form, "user-1")
+
+        written = markets.last_update["$set"]["applicationForm"]
+        assert written["essentialOptions"] is None
+
+
+class FakeFreezeMarketsCollection:
+    def __init__(self):
+        self.calls = []
+
+    def update_one(self, filter_, update):
+        self.calls.append((filter_, update))
+        return SimpleNamespace(matched_count=1, modified_count=1, upserted_id=None)
+
+
+class TestFreezeEssentialOptions:
+    def test_the_snapshot_is_written_once_in_camel_case_behind_an_exists_guard(self):
+        markets = FakeFreezeMarketsCollection()
+
+        EssentialFields.freeze_essential_options(markets, "market-123", OPTIONS)
+
+        (filter_, update), = markets.calls
+        assert filter_["id"] == "market-123"
+        assert filter_["applicationForm.essentialOptions"] == {"$exists": False}
+        assert filter_["applicationForm"] == {"$type": "object"}
+        written = update["$set"]["applicationForm.essentialOptions"]
+        assert written == {"dates": DATES, "sections": SECTIONS, "tableTypes": TABLE_TYPES}
+
+
+def _applicant_market_doc(**overrides):
+    from datatypes import MarketPhase
+
+    return stored_market(
+        phase=MarketPhase.APPLICATIONS_OPEN,
+        setupObject=SETUP_CAMEL,
+        applicationForm={"fields": [
+            {"key": "business_name", "label": "Business Name", "type": "text",
+             "required": True, "options": [], "order": 0},
+        ]},
+        **overrides,
+    )
+
+
+@pytest.fixture
+def applicant_db(monkeypatch):
+    markets = FakeSlugMarketsCollection(_applicant_market_doc())
+
+    class _Db(dict):
+        def __getitem__(self, name):
+            assert name == "markets"
+            return markets
+
+    monkeypatch.setattr(test_db_config, "get_database", lambda *_a, **_kw: _Db())
+    return markets
+
+
+def _token(app_id="app-1", market_id="market-123", email="vendor@example.com"):
+    return {"application_id": app_id, "market_id": market_id, "email": email}
+
+
+def _seed_application(applications):
+    applications.insert_one(Application(
+        id="app-1",
+        market_id="market-123",
+        applicant_email="vendor@example.com",
+        form_data={},
+        status=ApplicationStatus.OPEN,
+    ).model_dump())
+
+
+class TestApplicantSave:
+    def test_a_save_stores_the_essential_answers_beside_the_custom_ones(
+        self, applicant_db, applications,
+    ):
+        _seed_application(applications)
+
+        body, status = save_applicant_application(
+            "test-market", _token(),
+            {**VALID_ANSWERS, "business_name": "Acme"},
+        )
+
+        assert status == 200, body
+        stored = applications.find_one({"id": "app-1"})["form_data"]
+        assert stored["business_name"] == "Acme"
+        assert stored["essential_available_dates"] == ["2026-08-01", "2026-08-08"]
+        assert stored["essential_max_dates"] == 2
+        assert stored["essential_section_ranking"] == ["Garden", "Main Hall"]
+        assert stored["essential_table_type_ranking"] == ["Full Table", "Half Table"]
+
+    def test_a_save_missing_an_essential_answer_is_refused(self, applicant_db, applications):
+        _seed_application(applications)
+
+        body, status = save_applicant_application(
+            "test-market", _token(), {"business_name": "Acme"},
+        )
+
+        assert status == 422
+        assert "Available dates" in body["error"]
+
+    def test_the_first_recorded_answer_freezes_the_offering(self, applicant_db, applications):
+        _seed_application(applications)
+
+        _, status = save_applicant_application(
+            "test-market", _token(), {**VALID_ANSWERS, "business_name": "Acme"},
+        )
+
+        assert status == 200
+        frozen = applicant_db.last_update["$set"]["applicationForm.essentialOptions"]
+        assert frozen == {"dates": DATES, "sections": SECTIONS, "tableTypes": TABLE_TYPES}
+
+    def test_answers_are_validated_against_the_frozen_offering_not_the_live_plan(
+        self, monkeypatch, applications,
+    ):
+        """After the freeze, a plan edit must not admit answers the frozen form never offered."""
+        doc = _applicant_market_doc()
+        doc["applicationForm"]["essentialOptions"] = {
+            "dates": ["2026-08-01"], "sections": ["Main Hall"], "tableTypes": ["Full Table"],
+        }
+        markets = FakeSlugMarketsCollection(doc)
+
+        class _Db(dict):
+            def __getitem__(self, name):
+                return markets
+
+        monkeypatch.setattr(test_db_config, "get_database", lambda *_a, **_kw: _Db())
+        _seed_application(applications)
+
+        body, status = save_applicant_application(
+            "test-market", _token(), {**VALID_ANSWERS, "business_name": "Acme"},
+        )
+
+        assert status == 422
+        assert "does not offer" in body["error"]
+
+
+class TestPublicForm:
+    def test_the_public_form_carries_the_essential_offering(self, applicant_db):
+        body, status = get_public_application_form("test-market")
+
+        assert status == 200
+        assert body["essential_options"] == {
+            "dates": DATES, "sections": SECTIONS, "tableTypes": TABLE_TYPES,
+        }
+
+    def test_the_organizer_form_endpoint_carries_the_effective_offering(
+        self, monkeypatch, applications,
+    ):
+        monkeypatch.setattr(
+            MarketsApi, "markets_collection", FakeMarketsCollection(_applicant_market_doc()),
+        )
+        monkeypatch.setattr(PermissionsApi, "user_has_permission", lambda *_a, **_kw: True)
+
+        result = MarketsApi.get_application_form("market-123", "user-1")
+
+        assert result["essential_options"] == {
+            "dates": DATES, "sections": SECTIONS, "tableTypes": TABLE_TYPES,
+        }

--- a/docs/OBJECT_RELATIONSHIPS.md
+++ b/docs/OBJECT_RELATIONSHIPS.md
@@ -385,10 +385,11 @@ The application form definition for a market.
 **Fields:**
 - `fields: List[FormField]` - Ordered list of form fields. Must contain at least one field.
 - `published_at: Optional[str]` - ISO timestamp for when the form is published. Server-owned: a save always carries over the value on the stored form and discards any value in the payload, so a client cannot forge this lock-bearing state. No write path sets it yet, so it is `None` in practice; publishing lands with the applicant flow.
+- `essential_options: Optional[EssentialFormOptions]` - Frozen offering of the essential questions (dates, sections, table types). Server-owned: written by the back end (`essential_fields.freeze_essential_options`) on the first applicant answer, never writable from a client payload. `None` until frozen.
 
 **Endpoints:**
-- `GET /markets/<market_id>/application-form` - Requires `VIEWER`. Returns `{ application_form, editable, lock_reason }`, where `application_form` is camelCase (or `null` when no form has been saved) and `editable` / `lock_reason` describe the lock so the builder can render read-only before an organizer invests work in a form they cannot save.
-- `PUT /markets/<market_id>/application-form` - Requires `EDITOR`. The only writer of `Market.application_form` on an existing market. Takes the form (camelCase) as the body and returns `{ message, application_form }` with the form exactly as persisted. `404` unknown market, `403` insufficient permission, `400` validation failure, `409` locked.
+- `GET /markets/<market_id>/application-form` - Requires `VIEWER`. Returns `{ application_form, editable, lock_reason }`, where `application_form` is camelCase (or `null` when no form has been saved) and `editable` / `lock_reason` describe the lock so the builder can render read-only before an organizer invests work in a form they cannot save. The response includes `essentialOptions` (the effective offering, live or frozen).
+- `PUT /markets/<market_id>/application-form` - Requires `EDITOR`. The only writer of `Market.application_form` on an existing market. Takes the form (camelCase) as the body and returns `{ message, application_form }` with the form exactly as persisted. `essential_options` in the body is server-owned and discarded; the stored value is carried over from the existing document. `404` unknown market, `403` insufficient permission, `400` validation failure, `409` locked.
 
 **Editability (the D9 lock):**
 
@@ -400,7 +401,7 @@ The second rule is permanent: once an applicant has submitted, the form can neve
 
 **Validation and Normalization:**
 
-Every writer (`POST /markets` with a form on the body, and the `PUT` above) runs the form through one validator, which returns it exactly as it will be persisted, so a stored form can never differ from the form that was checked. It rejects a form with no fields, and per field enforces the [FormField](#formfield) rules below. It also renormalizes `order` to the field's array position, so the builder and the applicant's form can never disagree about display order.
+Every writer (`POST /markets` with a form on the body, and the `PUT` above) runs the form through one validator, which returns it exactly as it will be persisted, so a stored form can never differ from the form that was checked. It rejects a form with no fields, and per field enforces the [FormField](#formfield) rules below. It also renormalizes `order` to the field's array position, so the builder and the applicant's form can never disagree about display order. `essential_options` is server-owned (like `published_at`): any value in the payload is stripped and the stored value is carried over from the existing document.
 
 **Relationships:**
 - **One-to-One with Market**: Embedded in `Market.application_form` (optional; None if no form has been saved)
@@ -423,7 +424,7 @@ A single field in an application form.
 - `order: int` - Display order. Default **0**. Server-owned: renormalized on every write to the field's position in `ApplicationForm.fields`.
 
 **Validation (enforced on every write of `Market.application_form`):**
-- `key` must be non-blank, unique within the form, and match `^[a-z0-9_]+$`. Field keys become document keys inside `Application.form_data`, where a dot or a leading `$` cannot be addressed by Mongo update operators, so the charset is held to the slug form the builder auto-generates from the label.
+- `key` must be non-blank, unique within the form, and match `^[a-z0-9_]+$`. Field keys become document keys inside `Application.form_data`, where a dot or a leading `$` cannot be addressed by Mongo update operators, so the charset is held to the slug form the builder auto-generates from the label. Custom keys may not use the reserved `essential_` prefix (validated in `back-end/api/markets.py:_normalized_application_form` and mirrored in `front-end/src/utils/applicationForm.ts`).
 - `label` must be non-blank.
 - `type` must be one of the accepted types above.
 - `select` / `multi_select` fields must have at least one option, and options are trimmed and must be non-blank and unique - they are the persisted answer values in `Application.form_data`, so a duplicate would be an ambiguous answer. Options are cleared to `[]` on every other field type.
@@ -761,6 +762,7 @@ Market
 │   │   └── TierObject (many:1, optional)
 │   └── AssignmentOptionObject (1:1)
 ├── ApplicationForm (1:1, optional, server-owned: written only via PUT /markets/<id>/application-form)
+│   ├── EssentialFormOptions (1:1, server-owned, frozen: stamped by freeze_essential_options on first applicant answer)
 │   └── FormField[] (1:many)
 ├── ModificationObject[] (1:many, currently unused)
 └── AssignmentObject (1:1)
@@ -909,7 +911,7 @@ SourceData
 - `SectionObject.location` and `tier` are optional (sections can exist independently)
 - `Market.organization_id` is `Optional` in the model but required by `POST /markets`: new markets always belong to an organization, and the optional typing only keeps pre-existing org-less markets readable
 - `Market.theme` and `Organization.theme` are optional
-- `Market.application_form`, `review_config`, and `discord_guild_id` are optional (None by default)
+- `Market.application_form`, `review_config`, and `discord_guild_id` are optional (None by default); within `ApplicationForm`, `essential_options` and `published_at` are optional (None until set by the server)
 - The CSV-derived fields (`SetupObject.col_names` / `col_values` / `col_include` / `enum_priority_order`, `PriorityObject.col_name_idx`, `MarketDateObject.col_name_idx`, and the `AssignmentOptionObject` column indices) are optional and kept for backward compatibility. The assignment algorithm validates them instead of the models. See [SetupObject](#setupobject).
 
 ### 5. Permission Resolution

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -32,15 +32,17 @@ pip install -r requirements-dev.txt
 python -m pytest tests/ -v
 ```
 
-433 tests covering the assignment algorithm, statistics, Discord webhook, attendance,
+526 tests covering the assignment algorithm, statistics, Discord webhook, attendance,
 column mapping, schema generation, role validation, CAPTCHA verification/bypass, the
 Conventioner data model (market phases, `is_draft` computed strictly from `phase`, application
 form/status models, and backward compatibility with existing market documents), the `phase`
 backfill migration, the `applications` collection migration, the server-owned market fields
-preserved across updates, and the application form endpoints (`test_application_form.py`:
+preserved across updates, the application form endpoints (`test_application_form.py`:
 permission checks, field/key/option validation, `order` renormalization, server-owned
-`published_at`, and the D9 lock refusing edits on every write path once an application
-exists or the market leaves `draft`).
+`published_at`/`essential_options`, and the D9 lock refusing edits on every write path once an
+application exists or the market leaves `draft`), and the essential form fields
+(`test_essential_fields.py`: offering derivation, answer validation, freeze-on-first-answer,
+server-owned options stripped from client payloads, and the `essential_` prefix guard).
 
 `test_attendance_api.py` additionally pins the public slug lookup (queried via the
 stored `slug` field for an indexed, O(1) lookup rather than a collection scan), which

--- a/docs/schema.d.ts
+++ b/docs/schema.d.ts
@@ -5,6 +5,11 @@
 
 export interface MarketSchema {
   applicationForm?: {
+    essentialOptions?: {
+      dates?: string[];
+      sections?: string[];
+      tableTypes?: string[];
+    };
     fields: {
       helpText?: string;
       key: string;

--- a/front-end/e2e/essential-fields.spec.ts
+++ b/front-end/e2e/essential-fields.spec.ts
@@ -1,0 +1,420 @@
+import { test, expect, BACKEND_URL, TEST_USER, ApplicationFormPage, ApplyPage } from './fixtures';
+import { ApplicantLoginPage } from './pages/ApplicantLoginPage';
+import { ensureTestOrg, loginViaApi } from './helpers/seeds';
+import {
+  seedApplicantMarket,
+  seedApplicationDoc,
+  createApplicantLoginChallenge,
+  planSetupObject,
+  PLAN_DATES,
+} from './helpers/seedApplicantMarket';
+import type { APIRequestContext, Page } from '@playwright/test';
+
+/**
+ * The essential form fields: the answers the assignment solver reads directly, present in
+ * every application form.
+ *
+ * Three user stories, driven through the real UI:
+ *   1. The organizer customises what the essential questions offer by editing the market plan
+ *      (dates and sections through the setup wizard; table types come from the floorplan), and
+ *      cannot remove the questions themselves.
+ *   2. The applicant states their available dates, at most how many they want, and ranks their
+ *      section and table type preferences.
+ *   3. The offering freezes with the first recorded answer: a later plan edit never reaches
+ *      the form (the D9 principle extended to the offering).
+ */
+
+const APPLICANT_EMAIL = 'applicant-e2e@example.com';
+const KNOWN_CODE = '123456';
+
+/** Create a market via the API with the given plan, and land on the setup view. */
+async function createMarketWithPlan(
+  page: Page,
+  setupObject: Record<string, unknown>,
+): Promise<string> {
+  const ctx = page.request;
+  await loginViaApi(ctx, BACKEND_URL, TEST_USER.email, TEST_USER.password);
+  const orgsRes = await ctx.get(`${BACKEND_URL}/organizations`, {
+    headers: { 'X-Owner-Email': TEST_USER.email },
+  });
+  const orgs = (await orgsRes.json()).organizations as { id: string }[];
+  const orgId = orgs[0]?.id;
+  if (!orgId) throw new Error('No organization found');
+
+  const marketName = `Essential Fields E2E ${Date.now()}`;
+  const createRes = await ctx.post(`${BACKEND_URL}/markets`, {
+    headers: { 'Content-Type': 'application/json', 'X-Owner-Email': TEST_USER.email },
+    data: {
+      name: marketName,
+      creationDate: new Date().toISOString(),
+      organizationId: orgId,
+      roles: { [TEST_USER.email]: 'owner' },
+      modificationList: [],
+      assignmentObject: {},
+      setupObject,
+    },
+  });
+  if (!createRes.ok()) {
+    throw new Error(`Market creation failed: ${createRes.status()} ${await createRes.text()}`);
+  }
+  const { market_id: marketId } = (await createRes.json()) as { market_id: string };
+
+  const marketRes = await ctx.get(`${BACKEND_URL}/markets/${marketId}`, {
+    headers: { 'X-Owner-Email': TEST_USER.email },
+  });
+  const { market } = (await marketRes.json()) as { market: Record<string, unknown> };
+
+  await page.evaluate(
+    ({ m, user }) => {
+      localStorage.setItem('market', JSON.stringify(m));
+      localStorage.setItem('user', JSON.stringify(user));
+      localStorage.setItem('setupPageIdx', '0');
+    },
+    { m: market, user: TEST_USER.email },
+  );
+
+  await page.goto('/market-setup');
+  return marketId;
+}
+
+/**
+ * Sign an applicant in through the real login UI with a seeded known-code challenge, landing
+ * on the apply page. The applicant session lives in memory (deliberately - no persisted
+ * token), so the flow must reach the form the way an applicant does: via the login redirect,
+ * not a fresh page load.
+ */
+async function signInApplicant(page: Page, marketId: string, marketSlug: string): Promise<void> {
+  seedApplicationDoc(marketId, APPLICANT_EMAIL);
+  createApplicantLoginChallenge(marketId, APPLICANT_EMAIL, KNOWN_CODE);
+
+  // The real request-code call would overwrite the seeded known-code challenge, so it is
+  // fulfilled without reaching the back end (same pattern as applicant.spec.ts).
+  await page.route('**/applicant-login/request-code', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ message: "If an account exists for this email, we've sent a code." }),
+    });
+  });
+
+  const login = new ApplicantLoginPage(page);
+  await page.goto(`/${marketSlug}/applicant-login?redirect=apply`);
+  await login.requestCode(APPLICANT_EMAIL);
+  await expect(login.codeInput).toBeVisible({ timeout: 5000 });
+  await login.enterCode(KNOWN_CODE);
+  await page.waitForURL(new RegExp(`/${marketSlug}/apply`), { timeout: 5000 });
+  await page.unroute('**/applicant-login/request-code');
+}
+
+/** An applicant JWT obtained through the real login endpoints, for API-level saves. */
+async function applicantToken(
+  request: APIRequestContext,
+  marketId: string,
+  marketSlug: string,
+): Promise<string> {
+  createApplicantLoginChallenge(marketId, APPLICANT_EMAIL, KNOWN_CODE);
+  const verifyRes = await request.post(
+    `${BACKEND_URL}/public/markets/${marketSlug}/applicant-login/verify-code`,
+    { data: { email: APPLICANT_EMAIL, code: KNOWN_CODE } },
+  );
+  expect(verifyRes.ok()).toBeTruthy();
+  const { token } = (await verifyRes.json()) as { token: string };
+  expect(token).toBeTruthy();
+  return token;
+}
+
+test.describe('Essential form fields', () => {
+  test.beforeAll(async ({ request }) => {
+    await ensureTestOrg(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);
+  });
+
+  /**
+   * Story 1: the essential questions are always in the form and cannot be removed; the
+   * organizer customises what they offer by editing the market plan, and the form follows.
+   */
+  test('the organizer customises the essential offering through the market plan', async ({
+    authenticatedPage: page,
+  }, testInfo) => {
+    const formPage = new ApplicationFormPage(page);
+    // The plan starts with a floorplan (table types) but no dates and no sections yet.
+    await createMarketWithPlan(page, {
+      ...planSetupObject([]),
+      sections: [],
+    });
+
+    // The essential questions are present before the organizer builds anything.
+    await formPage.openFormTab();
+    await expect(formPage.essentialPanel).toBeVisible();
+    await expect(formPage.essentialBadge).toHaveText('Always included');
+    await expect(formPage.essentialItem('email')).toContainText('signs in');
+    // Offering not configured yet: the panel says so instead of showing empty questions.
+    await expect(formPage.essentialDatesEmpty).toBeVisible();
+    await expect(formPage.essentialSectionsEmpty).toBeVisible();
+    // Table types already come from the plan's floorplan.
+    await expect(formPage.essentialTableTypeChips).toHaveCount(2);
+    await expect(formPage.essentialTableTypeChips.nth(0)).toContainText('Full Table');
+    // Purpose-built, not custom fields: the panel offers no remove/reorder/edit controls.
+    await expect(formPage.essentialPanel.locator('button')).toHaveCount(0);
+    await page.screenshot({
+      path: testInfo.outputPath('01-essential-panel-before-plan.png'),
+      fullPage: true,
+    });
+
+    // The organizer adds market dates in the setup wizard...
+    await formPage.openSetupTab();
+    await page.getByTestId('setup-dates-add-button').click();
+    await page.getByTestId('setup-dates-date-input-0').fill('2026-08-01');
+    await page.getByTestId('setup-dates-add-button').click();
+    await page.getByTestId('setup-dates-date-input-1').fill('2026-08-08');
+
+    // ...and sections on the next wizard page (Next also persists the plan).
+    await page.getByTestId('market-setup-next-button').click();
+    await page.getByTestId('setup-section-add-button').click();
+    await page.getByTestId('setup-section-name-input-0').fill('Main Hall');
+    await page.getByTestId('setup-section-count-input-0').fill('4');
+    await page.getByTestId('setup-section-add-button').click();
+    await page.getByTestId('setup-section-name-input-1').fill('Garden');
+    await page.getByTestId('setup-section-count-input-1').fill('2');
+    await page.getByTestId('market-setup-back-button').click();
+
+    // The essential questions now offer exactly what the plan defines.
+    await formPage.openFormTab();
+    await expect(formPage.essentialDateChips).toHaveCount(2);
+    await expect(formPage.essentialDateChips.nth(0)).toContainText('August 1, 2026');
+    await expect(formPage.essentialSectionChips).toHaveCount(2);
+    await expect(formPage.essentialSectionChips.nth(0)).toContainText('Main Hall');
+    await expect(formPage.essentialSectionChips.nth(1)).toContainText('Garden');
+    // The applicant preview shows them exactly as the applicant will get them.
+    await expect(formPage.previewEssential).toBeVisible();
+    await expect(
+      formPage.previewEssential.getByTestId('form-preview-essential-date-2026-08-01'),
+    ).toBeVisible();
+    await page.screenshot({
+      path: testInfo.outputPath('02-essential-panel-offering-from-plan.png'),
+      fullPage: true,
+    });
+
+    // Custom fields may not squat on the essential namespace.
+    await formPage.addField();
+    await formPage.fillLabel(0, 'Business Name');
+    await formPage.keyInput(0).fill('essential_business');
+    await expect(formPage.validationError).toContainText('reserved "essential_" prefix');
+    await formPage.keyInput(0).fill('business_name');
+    await expect(formPage.saveButton).toBeEnabled();
+    await formPage.save();
+    await expect(formPage.saveSuccess).toBeVisible();
+
+    // Everything survives a reload: the offering is derived server-side from the saved plan.
+    await page.reload();
+    await formPage.openFormTab();
+    await expect(formPage.essentialDateChips).toHaveCount(2);
+    await expect(formPage.essentialSectionChips).toHaveCount(2);
+    await expect(formPage.essentialTableTypeChips).toHaveCount(2);
+    await expect(formPage.previewField('business_name')).toBeVisible();
+    await page.screenshot({
+      path: testInfo.outputPath('03-essential-panel-after-reload.png'),
+      fullPage: true,
+    });
+  });
+
+  /**
+   * Story 2: the applicant states available dates, at most how many they want, and ranks
+   * section and table type preferences - and the persisted answers are exactly the shape the
+   * solver will read.
+   */
+  test('the applicant answers the essential questions and the answers persist', async ({
+    page,
+    request,
+  }, testInfo) => {
+    const market = await seedApplicantMarket(
+      request,
+      BACKEND_URL,
+      TEST_USER.email,
+      TEST_USER.password,
+      { setupObject: planSetupObject() },
+    );
+    await signInApplicant(page, market.marketId, market.marketSlug);
+
+    const apply = new ApplyPage(page);
+    await expect(apply.form).toBeVisible();
+
+    // Identity is settled before the form: the email rides along read-only.
+    await expect(apply.essentialEmail).toContainText(APPLICANT_EMAIL);
+
+    // Available dates: capability.
+    await expect(apply.dateCheckbox(PLAN_DATES[0])).toBeVisible();
+    await apply.dateCheckbox('2026-08-01').check();
+    await apply.dateCheckbox('2026-08-08').check();
+
+    // Max dates: appetite - available on two dates, wants at most two.
+    await apply.maxDatesInput.fill('2');
+
+    // Rankings arrive seeded in the plan's order; the applicant reorders with the arrows.
+    await expect(apply.sectionRankName(0)).toHaveText('Main Hall');
+    await apply.sectionRankUp(1).click();
+    await expect(apply.sectionRankName(0)).toHaveText('Garden');
+    await expect(apply.sectionRankName(1)).toHaveText('Main Hall');
+
+    await expect(apply.tableTypeRankName(0)).toHaveText('Full Table');
+    await apply.tableTypeRankDown(0).click();
+    await expect(apply.tableTypeRankName(0)).toHaveText('Half Table');
+
+    await apply.fillField('business_name', 'Vermilion Ceramics');
+    await apply.fillField('product_type', 'Hand-thrown pottery');
+
+    await page.screenshot({
+      path: testInfo.outputPath('04-applicant-essential-fields.png'),
+      fullPage: true,
+    });
+
+    // A first-time applicant is likelier on a phone; the essential block must read there too.
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.screenshot({
+      path: testInfo.outputPath('05-applicant-essential-fields-mobile.png'),
+      fullPage: true,
+    });
+    await page.setViewportSize({ width: 1280, height: 720 });
+
+    await apply.submit();
+    await page.waitForURL(new RegExp(`/${market.marketSlug}/applicant/dashboard`), {
+      timeout: 5000,
+    });
+
+    // The dashboard reads the answers back with the questions' own labels.
+    const answers = page.getByTestId('applicant-dashboard-answers');
+    await expect(
+      answers.getByTestId('applicant-dashboard-answer-essential_available_dates'),
+    ).toContainText('August 1, 2026');
+    await expect(
+      answers.getByTestId('applicant-dashboard-answer-essential_max_dates'),
+    ).toContainText('2');
+    await expect(
+      answers.getByTestId('applicant-dashboard-answer-essential_section_ranking'),
+    ).toContainText('1. Garden');
+    await expect(
+      answers.getByTestId('applicant-dashboard-answer-essential_table_type_ranking'),
+    ).toContainText('1. Half Table');
+    await page.screenshot({
+      path: testInfo.outputPath('06-applicant-dashboard-answers.png'),
+      fullPage: true,
+    });
+
+    // The persisted shape is the contract the solver task consumes - pin it exactly.
+    await loginViaApi(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);
+    const appsRes = await request.get(`${BACKEND_URL}/markets/${market.marketId}/applications`, {
+      headers: { 'X-Owner-Email': TEST_USER.email },
+    });
+    const { applications } = (await appsRes.json()) as {
+      applications: Array<{ applicantEmail: string; formData: Record<string, unknown> }>;
+    };
+    const app = applications.find((a) => a.applicantEmail === APPLICANT_EMAIL);
+    expect(app).toBeTruthy();
+    expect(app!.formData).toEqual({
+      business_name: 'Vermilion Ceramics',
+      product_type: 'Hand-thrown pottery',
+      essential_available_dates: ['2026-08-01', '2026-08-08'],
+      essential_max_dates: 2,
+      essential_section_ranking: ['Garden', 'Main Hall'],
+      essential_table_type_ranking: ['Half Table', 'Full Table'],
+    });
+  });
+
+  /**
+   * Story 3: the first recorded answer freezes the offering. A market plan edit afterwards
+   * never reaches the form - there is no fourth date after applications arrive.
+   */
+  test('the essential offering freezes once an applicant has answered', async ({
+    authenticatedPage: page,
+    request,
+  }, testInfo) => {
+    const market = await seedApplicantMarket(
+      request,
+      BACKEND_URL,
+      TEST_USER.email,
+      TEST_USER.password,
+      { setupObject: planSetupObject() },
+    );
+    seedApplicationDoc(market.marketId, APPLICANT_EMAIL);
+    const token = await applicantToken(request, market.marketId, market.marketSlug);
+
+    // The applicant records answers against the three offered dates.
+    const saveRes = await request.put(
+      `${BACKEND_URL}/public/markets/${market.marketSlug}/applicant/application`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        data: {
+          formData: {
+            business_name: 'Vermilion Ceramics',
+            product_type: 'Pottery',
+            essential_available_dates: ['2026-08-01'],
+            essential_max_dates: 1,
+            essential_section_ranking: ['Main Hall', 'Garden'],
+            essential_table_type_ranking: ['Full Table', 'Half Table'],
+          },
+        },
+      },
+    );
+    expect(saveRes.status()).toBe(200);
+
+    // The organizer now wants a fourth date - the plan accepts it...
+    const marketRes = await request.get(`${BACKEND_URL}/markets/${market.marketId}`, {
+      headers: { 'X-Owner-Email': TEST_USER.email },
+    });
+    const { market: marketDoc } = (await marketRes.json()) as {
+      market: { setupObject: { marketDates: Array<{ date: string }> } } & Record<string, unknown>;
+    };
+    marketDoc.setupObject.marketDates.push({ date: '2026-08-22' });
+    const putRes = await request.put(`${BACKEND_URL}/markets/${market.marketId}`, {
+      headers: { 'X-Owner-Email': TEST_USER.email },
+      data: marketDoc,
+    });
+    expect(putRes.ok()).toBeTruthy();
+
+    // ...but the form's offering is frozen: the public form still offers the original three.
+    const publicForm = await (
+      await request.get(`${BACKEND_URL}/public/markets/${market.marketSlug}/application-form`)
+    ).json();
+    expect(publicForm.essential_options.dates).toEqual(PLAN_DATES);
+
+    // An answer naming the new date is refused - it was never offered.
+    const staleToken = await applicantToken(request, market.marketId, market.marketSlug);
+    const sneakyRes = await request.put(
+      `${BACKEND_URL}/public/markets/${market.marketSlug}/applicant/application`,
+      {
+        headers: { Authorization: `Bearer ${staleToken}` },
+        data: {
+          formData: {
+            business_name: 'Vermilion Ceramics',
+            product_type: 'Pottery',
+            essential_available_dates: ['2026-08-22'],
+            essential_max_dates: 1,
+            essential_section_ranking: ['Main Hall', 'Garden'],
+            essential_table_type_ranking: ['Full Table', 'Half Table'],
+          },
+        },
+      },
+    );
+    expect(sneakyRes.status()).toBe(422);
+    expect((await sneakyRes.json()).error).toContain('does not offer');
+
+    // The builder tells the organizer the same story: locked form, frozen offering - the
+    // panel shows three dates even though the local plan now carries four.
+    await page.evaluate(
+      ({ m, user }) => {
+        localStorage.setItem('market', JSON.stringify(m));
+        localStorage.setItem('user', JSON.stringify(user));
+        localStorage.setItem('setupPageIdx', '0');
+      },
+      { m: marketDoc, user: TEST_USER.email },
+    );
+    await page.goto('/market-setup');
+    const formPage = new ApplicationFormPage(page);
+    await formPage.openFormTab();
+    await expect(formPage.lockBanner).toBeVisible();
+    await expect(formPage.essentialDateChips).toHaveCount(3);
+    await page.screenshot({
+      path: testInfo.outputPath('07-essential-offering-frozen.png'),
+      fullPage: true,
+    });
+  });
+});

--- a/front-end/e2e/helpers/seedApplicantMarket.ts
+++ b/front-end/e2e/helpers/seedApplicantMarket.ts
@@ -42,6 +42,53 @@ export const APPLICATION_FIELDS = [
   },
 ];
 
+/** The dates, sections and table types a seeded market plan offers. */
+export const PLAN_DATES = ['2026-08-01', '2026-08-08', '2026-08-15'];
+export const PLAN_SECTIONS = ['Main Hall', 'Garden'];
+export const PLAN_TABLE_TYPES = ['Full Table', 'Half Table'];
+
+/**
+ * A market plan (camelCase `setupObject`) that offers the essential questions everything they
+ * need: dates, sections, and a floorplan carrying table types - the same three sources the
+ * back end derives the essential offering from.
+ */
+export function planSetupObject(dates: string[] = PLAN_DATES) {
+  return {
+    colNames: [],
+    colValues: [],
+    colInclude: [],
+    enumPriorityOrder: [],
+    priority: [],
+    marketDates: dates.map((date) => ({ date, colNameIdx: null })),
+    tiers: [],
+    locations: [{ name: 'Indoors' }],
+    sections: PLAN_SECTIONS.map((name) => ({
+      name,
+      location: { name: 'Indoors' },
+      tier: null,
+      count: 4,
+    })),
+    assignmentOptions: {
+      maxAssignmentsPerVendor: null,
+      maxHalfTableProportionPerSection: null,
+      emailColNameIdx: null,
+      tableChoiceColNameIdx: null,
+      tableShareEmailColNameIdx: null,
+      maxDaysColNameIdx: null,
+    },
+    floorplans: [
+      {
+        tableTypes: PLAN_TABLE_TYPES.map((name) => ({
+          name,
+          widthMm: 1800,
+          heightMm: 800,
+          maxCapacity: 2,
+        })),
+      },
+    ],
+  };
+}
+
 /**
  * Create a published market in `applications_open` phase with an application
  * form and an Application document for the test applicant.
@@ -58,6 +105,7 @@ export async function seedApplicantMarket(
   baseURL: string,
   email: string,
   password: string,
+  options: { setupObject?: Record<string, unknown> } = {},
 ): Promise<ApplicantMarketSeed> {
   const userId = await loginViaApi(request, baseURL, email, password);
   const orgId = await ensureTestOrgAuthenticated(request, baseURL, email);
@@ -72,6 +120,7 @@ export async function seedApplicantMarket(
       roles: { [userId]: 'owner' },
       modificationList: [],
       assignmentObject: {},
+      ...(options.setupObject ? { setupObject: options.setupObject } : {}),
     },
   });
   if (!createRes.ok()) {
@@ -139,14 +188,18 @@ export function createApplicantLoginChallenge(marketId: string, email: string, c
   const createdAt = new Date().toISOString();
 
   const evalJs = [
-    `db.applicant_login_challenges.insertOne({`,
-    `  market_id: ${JSON.stringify(marketId)},`,
-    `  email: ${JSON.stringify(emailLower)},`,
-    `  code_hash: ${JSON.stringify(codeHash)},`,
-    `  consumed: false,`,
-    `  expires_at: new Date(${expiryTs}),`,
-    `  created_at: ${JSON.stringify(createdAt)}`,
-    `})`,
+    `db.applicant_login_challenges.replaceOne(`,
+    `  { market_id: ${JSON.stringify(marketId)}, email: ${JSON.stringify(emailLower)} },`,
+    `  {`,
+    `    market_id: ${JSON.stringify(marketId)},`,
+    `    email: ${JSON.stringify(emailLower)},`,
+    `    code_hash: ${JSON.stringify(codeHash)},`,
+    `    consumed: false,`,
+    `    expires_at: new Date(${expiryTs}),`,
+    `    created_at: ${JSON.stringify(createdAt)}`,
+    `  },`,
+    `  { upsert: true }`,
+    `)`,
   ].join('\n');
 
   execFileSync(

--- a/front-end/e2e/pages/ApplicationFormPage.ts
+++ b/front-end/e2e/pages/ApplicationFormPage.ts
@@ -28,6 +28,17 @@ export class ApplicationFormPage {
   // Preview
   readonly preview: Locator;
   readonly previewEmpty: Locator;
+  readonly previewEssential: Locator;
+
+  // Essential fields panel (always present in the builder; not removable)
+  readonly essentialPanel: Locator;
+  readonly essentialBadge: Locator;
+  readonly essentialDateChips: Locator;
+  readonly essentialSectionChips: Locator;
+  readonly essentialTableTypeChips: Locator;
+  readonly essentialDatesEmpty: Locator;
+  readonly essentialSectionsEmpty: Locator;
+  readonly essentialTableTypesEmpty: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -48,6 +59,16 @@ export class ApplicationFormPage {
 
     this.preview = page.getByTestId('form-preview');
     this.previewEmpty = page.getByTestId('form-preview-empty');
+    this.previewEssential = page.getByTestId('form-preview-essential');
+
+    this.essentialPanel = page.getByTestId('essential-fields-panel');
+    this.essentialBadge = page.getByTestId('essential-fields-badge');
+    this.essentialDateChips = page.getByTestId('essential-date-chip');
+    this.essentialSectionChips = page.getByTestId('essential-section-chip');
+    this.essentialTableTypeChips = page.getByTestId('essential-table-type-chip');
+    this.essentialDatesEmpty = page.getByTestId('essential-dates-empty');
+    this.essentialSectionsEmpty = page.getByTestId('essential-sections-empty');
+    this.essentialTableTypesEmpty = page.getByTestId('essential-table-types-empty');
   }
 
   async openFormTab(): Promise<void> {
@@ -137,5 +158,10 @@ export class ApplicationFormPage {
   /** A field in the applicant preview, addressed by its (slugged) key. */
   previewField(key: string): Locator {
     return this.page.getByTestId(`form-preview-field-${key}`);
+  }
+
+  /** One of the five essential-question cards in the builder panel. */
+  essentialItem(name: string): Locator {
+    return this.page.getByTestId(`essential-item-${name}`);
   }
 }

--- a/front-end/e2e/pages/ApplyPage.ts
+++ b/front-end/e2e/pages/ApplyPage.ts
@@ -39,4 +39,47 @@ export class ApplyPage {
   get error(): Locator {
     return this.page.getByTestId('apply-error');
   }
+
+  // ── Essential fields ─────────────────────────────────────────────────
+
+  get essentialFields(): Locator {
+    return this.page.getByTestId('apply-essential-fields');
+  }
+
+  get essentialEmail(): Locator {
+    return this.page.getByTestId('apply-essential-email');
+  }
+
+  /** The checkbox for one offered market date (ISO string). */
+  dateCheckbox(date: string): Locator {
+    return this.page.getByTestId(`apply-essential-date-${date}`);
+  }
+
+  get maxDatesInput(): Locator {
+    return this.page.getByTestId('apply-essential-max-dates-input');
+  }
+
+  sectionRankName(index: number): Locator {
+    return this.page.getByTestId(`apply-essential-section-rank-name-${index}`);
+  }
+
+  sectionRankUp(index: number): Locator {
+    return this.page.getByTestId(`apply-essential-section-rank-up-${index}`);
+  }
+
+  sectionRankDown(index: number): Locator {
+    return this.page.getByTestId(`apply-essential-section-rank-down-${index}`);
+  }
+
+  tableTypeRankName(index: number): Locator {
+    return this.page.getByTestId(`apply-essential-table-type-rank-name-${index}`);
+  }
+
+  tableTypeRankUp(index: number): Locator {
+    return this.page.getByTestId(`apply-essential-table-type-rank-up-${index}`);
+  }
+
+  tableTypeRankDown(index: number): Locator {
+    return this.page.getByTestId(`apply-essential-table-type-rank-down-${index}`);
+  }
 }

--- a/front-end/src/assets/types/datatypes.ts
+++ b/front-end/src/assets/types/datatypes.ts
@@ -211,9 +211,22 @@ export interface FormField {
   order: number;
 }
 
+/**
+ * What the essential form questions offer. Derived from the market plan (dates, sections,
+ * floorplan table types); once an applicant records an answer, the back end freezes it onto
+ * the stored form so the questions can never move under recorded answers.
+ */
+export interface EssentialFormOptions {
+  dates: string[];
+  sections: string[];
+  tableTypes: string[];
+}
+
 export interface ApplicationForm {
   fields: FormField[];
   publishedAt?: string;
+  /** Server-owned frozen offering; null/undefined until the first applicant answer. */
+  essentialOptions?: EssentialFormOptions | null;
 }
 
 export interface Application {

--- a/front-end/src/assets/types/datatypes.ts
+++ b/front-end/src/assets/types/datatypes.ts
@@ -201,6 +201,11 @@ export enum ApplicationType {
   Waitlist = 'waitlist',
 }
 
+/**
+ * A single editable field in an application form. Keys with the reserved `essential_`
+ * prefix are rejected by both front-end validation and the back-end API; see
+ * `essential_fields.py` and `front-end/src/utils/applicationForm.ts`.
+ */
 export interface FormField {
   key: string;
   label: string;

--- a/front-end/src/components/application/EssentialApplicationFields.vue
+++ b/front-end/src/components/application/EssentialApplicationFields.vue
@@ -1,0 +1,321 @@
+<script setup lang="ts">
+/**
+ * The essential questions every applicant answers: available dates, how many dates they want,
+ * and ranked section and table type preferences. Their answers are what the assignment solver
+ * reads, so the shape is fixed - the market plan only decides what they offer.
+ *
+ * One component for both applicant surfaces and the organizer's preview (`disabled`), for the
+ * same no-drift reason as ApplicationFormFields: what the organizer previews must be what the
+ * applicant gets.
+ */
+import { computed, watch } from 'vue';
+import type { EssentialFormOptions } from '@/assets/types/datatypes';
+import {
+  AVAILABLE_DATES_KEY,
+  AVAILABLE_DATES_LABEL,
+  MAX_DATES_KEY,
+  MAX_DATES_LABEL,
+  SECTION_RANKING_KEY,
+  SECTION_RANKING_LABEL,
+  TABLE_TYPE_RANKING_KEY,
+  TABLE_TYPE_RANKING_LABEL,
+  formattedEssentialDate,
+} from '@/utils/essentialFields';
+import RankedChoiceInput from './RankedChoiceInput.vue';
+
+const props = withDefaults(
+  defineProps<{
+    options: EssentialFormOptions;
+    modelValue: Record<string, unknown>;
+    errors?: Record<string, string>;
+    prefix?: string;
+    email?: string | null;
+    disabled?: boolean;
+  }>(),
+  { errors: () => ({}), prefix: 'apply', email: null, disabled: false },
+);
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: Record<string, unknown>): void;
+  (e: 'field-change', key: string): void;
+}>();
+
+const selectedDates = computed(() => (props.modelValue[AVAILABLE_DATES_KEY] as string[]) ?? []);
+
+const sectionRanking = computed(
+  () => (props.modelValue[SECTION_RANKING_KEY] as string[]) ?? props.options.sections,
+);
+const tableTypeRanking = computed(
+  () => (props.modelValue[TABLE_TYPE_RANKING_KEY] as string[]) ?? props.options.tableTypes,
+);
+
+/**
+ * A ranking is total, so it always holds every offered option - seed it from the plan's order
+ * the moment the offering is known, and the applicant only ever reorders.
+ */
+watch(
+  () => props.options,
+  (options) => {
+    if (props.disabled) return;
+    const seeded: Record<string, unknown> = {};
+    if (options.sections.length && !props.modelValue[SECTION_RANKING_KEY]) {
+      seeded[SECTION_RANKING_KEY] = [...options.sections];
+    }
+    if (options.tableTypes.length && !props.modelValue[TABLE_TYPE_RANKING_KEY]) {
+      seeded[TABLE_TYPE_RANKING_KEY] = [...options.tableTypes];
+    }
+    if (Object.keys(seeded).length) {
+      emit('update:modelValue', { ...props.modelValue, ...seeded });
+    }
+  },
+  { immediate: true },
+);
+
+function setAnswer(key: string, value: unknown) {
+  emit('update:modelValue', { ...props.modelValue, [key]: value });
+  emit('field-change', key);
+}
+
+function toggleDate(date: string, checked: boolean) {
+  const current = selectedDates.value;
+  setAnswer(AVAILABLE_DATES_KEY, checked ? [...current, date] : current.filter((d) => d !== date));
+}
+
+function onMaxDatesInput(event: Event) {
+  const raw = (event.target as HTMLInputElement).value;
+  setAnswer(MAX_DATES_KEY, raw === '' ? null : Number(raw));
+}
+
+function errorFor(key: string): string {
+  return props.errors[key] || '';
+}
+</script>
+
+<template>
+  <div class="essential-fields" :data-testid="`${prefix}-essential-fields`">
+    <div v-if="email" class="essential-email" :data-testid="`${prefix}-essential-email`">
+      <span class="essential-email-label">Email</span>
+      <span class="essential-email-value">{{ email }}</span>
+      <span class="essential-email-note">You signed in with it; every update goes there.</span>
+    </div>
+
+    <!-- Available dates -->
+    <div
+      v-if="options.dates.length"
+      class="essential-field"
+      :data-testid="`${prefix}-essential-available-dates`"
+    >
+      <span class="essential-label">
+        {{ AVAILABLE_DATES_LABEL }}
+        <span class="essential-required">*</span>
+      </span>
+      <p class="essential-help">Tick every market date you could attend.</p>
+      <div class="essential-dates" :class="{ error: errorFor(AVAILABLE_DATES_KEY) }">
+        <label
+          v-for="date in options.dates"
+          :key="date"
+          class="essential-date-option"
+          :class="{ checked: selectedDates.includes(date) }"
+        >
+          <input
+            type="checkbox"
+            :checked="selectedDates.includes(date)"
+            :disabled="disabled"
+            :data-testid="`${prefix}-essential-date-${date}`"
+            @change="toggleDate(date, ($event.target as HTMLInputElement).checked)"
+          />
+          <span>{{ formattedEssentialDate(date) }}</span>
+        </label>
+      </div>
+      <p
+        v-if="errorFor(AVAILABLE_DATES_KEY)"
+        class="essential-error"
+        :data-testid="`${prefix}-essential-error-available-dates`"
+      >
+        {{ errorFor(AVAILABLE_DATES_KEY) }}
+      </p>
+    </div>
+
+    <!-- Max dates -->
+    <div
+      v-if="options.dates.length"
+      class="essential-field"
+      :data-testid="`${prefix}-essential-max-dates`"
+    >
+      <label class="essential-label" :for="`${prefix}-essential-max-dates-input`">
+        {{ MAX_DATES_LABEL }}
+        <span class="essential-required">*</span>
+      </label>
+      <p class="essential-help">
+        Being available doesn't commit you: you'll be assigned at most this many of the dates you
+        ticked above.
+      </p>
+      <input
+        :id="`${prefix}-essential-max-dates-input`"
+        class="essential-max-input"
+        :class="{ error: errorFor(MAX_DATES_KEY) }"
+        type="number"
+        min="1"
+        :max="options.dates.length"
+        inputmode="numeric"
+        :value="(modelValue[MAX_DATES_KEY] as number | null) ?? ''"
+        :disabled="disabled"
+        :data-testid="`${prefix}-essential-max-dates-input`"
+        @input="onMaxDatesInput"
+      />
+      <p
+        v-if="errorFor(MAX_DATES_KEY)"
+        class="essential-error"
+        :data-testid="`${prefix}-essential-error-max-dates`"
+      >
+        {{ errorFor(MAX_DATES_KEY) }}
+      </p>
+    </div>
+
+    <!-- Section preference -->
+    <div
+      v-if="options.sections.length"
+      class="essential-field"
+      :data-testid="`${prefix}-essential-section-ranking`"
+    >
+      <span class="essential-label">
+        {{ SECTION_RANKING_LABEL }}
+        <span class="essential-required">*</span>
+      </span>
+      <p class="essential-help">Use the arrows to order the sections, first choice on top.</p>
+      <RankedChoiceInput
+        :modelValue="sectionRanking"
+        :testid="`${prefix}-essential-section-rank`"
+        :disabled="disabled"
+        @update:modelValue="(v: string[]) => setAnswer(SECTION_RANKING_KEY, v)"
+      />
+    </div>
+
+    <!-- Table type preference -->
+    <div
+      v-if="options.tableTypes.length"
+      class="essential-field"
+      :data-testid="`${prefix}-essential-table-type-ranking`"
+    >
+      <span class="essential-label">
+        {{ TABLE_TYPE_RANKING_LABEL }}
+        <span class="essential-required">*</span>
+      </span>
+      <p class="essential-help">Use the arrows to order the table types, first choice on top.</p>
+      <RankedChoiceInput
+        :modelValue="tableTypeRanking"
+        :testid="`${prefix}-essential-table-type-rank`"
+        :disabled="disabled"
+        @update:modelValue="(v: string[]) => setAnswer(TABLE_TYPE_RANKING_KEY, v)"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.essential-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.essential-email {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 14px;
+  border: 1px solid var(--mm-grey, #ddd);
+  border-radius: 6px;
+  background: #fafafa;
+}
+
+.essential-email-label {
+  font-family: 'Outfit Regular';
+  font-size: 14px;
+  font-weight: bold;
+  color: var(--mm-black);
+}
+
+.essential-email-value {
+  font-family: 'Outfit Regular';
+  font-size: 14px;
+  color: var(--mm-black);
+}
+
+.essential-email-note {
+  font-family: 'Outfit Regular';
+  font-size: 12px;
+  color: var(--mm-grey, #666);
+}
+
+.essential-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.essential-label {
+  font-family: 'Outfit Regular';
+  font-size: 14px;
+  font-weight: bold;
+  color: var(--mm-black);
+}
+
+.essential-required {
+  color: var(--mm-red, #cc0000);
+}
+
+.essential-help {
+  font-family: 'Outfit Regular';
+  font-size: 12px;
+  color: var(--mm-grey, #666);
+  margin: 0;
+}
+
+.essential-dates {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  border: 1px solid var(--mm-grey, #ddd);
+  border-radius: 5px;
+  background: white;
+}
+
+.essential-dates.error {
+  border-color: var(--mm-red, #cc0000);
+}
+
+.essential-date-option {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  font-family: 'Outfit Regular';
+  font-size: 14px;
+  color: var(--mm-black);
+  cursor: pointer;
+}
+
+.essential-max-input {
+  height: 36px;
+  width: 120px;
+  padding: 4px 10px;
+  font-family: 'Outfit Regular';
+  font-size: 14px;
+  border: 1px solid var(--mm-grey, #b0b0b0);
+  border-radius: 5px;
+  background: white;
+}
+
+.essential-max-input.error {
+  border-color: var(--mm-red, #cc0000);
+}
+
+.essential-error {
+  font-family: 'Outfit Regular';
+  font-size: 12px;
+  color: var(--mm-red, #cc0000);
+  margin: 2px 0 0;
+}
+</style>

--- a/front-end/src/components/application/EssentialApplicationFields.vue
+++ b/front-end/src/components/application/EssentialApplicationFields.vue
@@ -275,8 +275,8 @@ function errorFor(key: string): string {
 .essential-dates {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: 10px;
+  gap: 2px;
+  padding: 6px;
   border: 1px solid var(--mm-grey, #ddd);
   border-radius: 5px;
   background: white;
@@ -290,10 +290,30 @@ function errorFor(key: string): string {
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid transparent;
+  border-radius: 5px;
   font-family: 'Outfit Regular';
   font-size: 14px;
   color: var(--mm-black);
+  cursor: pointer;
+}
+
+.essential-date-option:hover {
+  background: #f4f4f4;
+}
+
+.essential-date-option.checked {
+  background: #eef7ef;
+  border-color: #cfe3d4;
+}
+
+.essential-date-option input[type='checkbox'] {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  accent-color: var(--mm-green);
   cursor: pointer;
 }
 

--- a/front-end/src/components/application/EssentialFieldsPanel.vue
+++ b/front-end/src/components/application/EssentialFieldsPanel.vue
@@ -1,0 +1,262 @@
+<script setup lang="ts">
+/**
+ * The always-present essential questions, as the form builder shows them to the organizer.
+ *
+ * These are purpose-built, not custom fields: an organizer cannot remove or reorder them, and
+ * the only thing they customise is what the questions offer - which is the market plan itself
+ * (dates, sections, and the floorplan's table types). This panel therefore renders the current
+ * offering read-only and points at where each list is edited, instead of offering a second
+ * place to edit it.
+ */
+import type { EssentialFormOptions } from '@/assets/types/datatypes';
+import {
+  AVAILABLE_DATES_LABEL,
+  MAX_DATES_LABEL,
+  SECTION_RANKING_LABEL,
+  TABLE_TYPE_RANKING_LABEL,
+  formattedEssentialDate,
+} from '@/utils/essentialFields';
+
+defineProps<{
+  options: EssentialFormOptions;
+  /** True once the offering is frozen (an application exists); the hints change tense. */
+  locked?: boolean;
+}>();
+</script>
+
+<template>
+  <div class="essential-panel" data-testid="essential-fields-panel">
+    <div class="essential-panel-header">
+      <h3>Essential questions</h3>
+      <span class="essential-badge" data-testid="essential-fields-badge">Always included</span>
+    </div>
+    <p class="essential-panel-note">
+      Every application form asks these - the table assignment reads them directly, so they cannot
+      be removed. What they offer comes from your market plan{{
+        locked ? ' and is frozen with the rest of the form' : ''
+      }}.
+    </p>
+
+    <div class="essential-item" data-testid="essential-item-email">
+      <div class="essential-item-header">
+        <span class="essential-item-label">Email</span>
+        <span class="essential-type-badge">sign-in</span>
+      </div>
+      <p class="essential-item-detail">
+        Collected when the applicant signs in; every notification goes there.
+      </p>
+    </div>
+
+    <div class="essential-item" data-testid="essential-item-available-dates">
+      <div class="essential-item-header">
+        <span class="essential-item-label">{{ AVAILABLE_DATES_LABEL }}</span>
+        <span class="essential-type-badge">pick dates</span>
+      </div>
+      <div v-if="options.dates.length" class="essential-chips">
+        <span
+          v-for="date in options.dates"
+          :key="date"
+          class="essential-chip"
+          data-testid="essential-date-chip"
+        >
+          {{ formattedEssentialDate(date) }}
+        </span>
+      </div>
+      <p v-else class="essential-item-warning" data-testid="essential-dates-empty">
+        No market dates yet - this question is hidden from applicants until you add dates under
+        Market Setup.
+      </p>
+    </div>
+
+    <div class="essential-item" data-testid="essential-item-max-dates">
+      <div class="essential-item-header">
+        <span class="essential-item-label">{{ MAX_DATES_LABEL }}</span>
+        <span class="essential-type-badge">number</span>
+      </div>
+      <p class="essential-item-detail">
+        {{
+          options.dates.length
+            ? `A number from 1 to ${options.dates.length} - how many of their available dates the
+          applicant actually wants.`
+            : 'Asked alongside the dates once your market has them.'
+        }}
+      </p>
+    </div>
+
+    <div class="essential-item" data-testid="essential-item-section-ranking">
+      <div class="essential-item-header">
+        <span class="essential-item-label">{{ SECTION_RANKING_LABEL }}</span>
+        <span class="essential-type-badge">ranking</span>
+      </div>
+      <div v-if="options.sections.length" class="essential-chips">
+        <span
+          v-for="(section, index) in options.sections"
+          :key="section"
+          class="essential-chip"
+          data-testid="essential-section-chip"
+        >
+          <span class="essential-chip-rank">{{ index + 1 }}</span>
+          {{ section }}
+        </span>
+      </div>
+      <p v-else class="essential-item-warning" data-testid="essential-sections-empty">
+        No sections yet - this question is hidden from applicants until your market plan defines
+        sections (Market Setup or the floorplan editor).
+      </p>
+    </div>
+
+    <div class="essential-item" data-testid="essential-item-table-type-ranking">
+      <div class="essential-item-header">
+        <span class="essential-item-label">{{ TABLE_TYPE_RANKING_LABEL }}</span>
+        <span class="essential-type-badge">ranking</span>
+      </div>
+      <div v-if="options.tableTypes.length" class="essential-chips">
+        <span
+          v-for="(tableType, index) in options.tableTypes"
+          :key="tableType"
+          class="essential-chip"
+          data-testid="essential-table-type-chip"
+        >
+          <span class="essential-chip-rank">{{ index + 1 }}</span>
+          {{ tableType }}
+        </span>
+      </div>
+      <p v-else class="essential-item-warning" data-testid="essential-table-types-empty">
+        No table types yet - this question is hidden from applicants until your floorplan defines
+        table types.
+      </p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.essential-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid #cfe3d4;
+  border-radius: 8px;
+  background: #f4faf5;
+}
+
+.essential-panel-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.essential-panel-header h3 {
+  font-family: 'Merge One';
+  font-size: 15px;
+  color: var(--mm-black);
+  margin: 0;
+}
+
+.essential-badge {
+  font-family: 'Outfit Regular';
+  font-size: 11px;
+  background: var(--mm-green);
+  color: white;
+  border-radius: 3px;
+  padding: 2px 8px;
+  white-space: nowrap;
+}
+
+.essential-panel-note {
+  font-family: 'Outfit Regular';
+  font-size: 12px;
+  line-height: 1.4;
+  color: #3c5a44;
+  margin: 0;
+}
+
+.essential-item {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 10px 12px;
+  border: 1px solid #dbe8de;
+  border-radius: 6px;
+  background: white;
+}
+
+.essential-item-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+.essential-item-label {
+  font-family: 'Outfit Regular';
+  font-size: 14px;
+  font-weight: bold;
+  color: var(--mm-black);
+  flex: 1;
+  min-width: 0;
+}
+
+.essential-type-badge {
+  font-family: 'Outfit Regular';
+  font-size: 11px;
+  background: #e8e8e8;
+  color: #555;
+  border-radius: 3px;
+  padding: 1px 6px;
+  white-space: nowrap;
+}
+
+.essential-item-detail {
+  font-family: 'Outfit Regular';
+  font-size: 12px;
+  color: var(--mm-grey, #666);
+  margin: 0;
+}
+
+.essential-chips {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.essential-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: 'Outfit Regular';
+  font-size: 12px;
+  color: var(--mm-black);
+  background: #eef4ef;
+  border: 1px solid #d5e3d8;
+  border-radius: 12px;
+  padding: 2px 10px;
+}
+
+.essential-chip-rank {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--mm-green);
+  color: white;
+  font-size: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.essential-item-warning {
+  font-family: 'Outfit Regular';
+  font-size: 12px;
+  line-height: 1.4;
+  color: #7a5200;
+  background: #fff6e0;
+  border: 1px solid #f0d089;
+  border-radius: 5px;
+  padding: 6px 9px;
+  margin: 0;
+}
+</style>

--- a/front-end/src/components/application/FormPreview.vue
+++ b/front-end/src/components/application/FormPreview.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { type ApplicationForm } from '@/assets/types/datatypes';
+import { type ApplicationForm, type EssentialFormOptions } from '@/assets/types/datatypes';
+import EssentialApplicationFields from './EssentialApplicationFields.vue';
 
 const props = defineProps<{
   applicationForm: ApplicationForm | null;
+  essentialOptions?: EssentialFormOptions | null;
 }>();
 
 const sortedFields = computed(() => {
@@ -12,6 +14,15 @@ const sortedFields = computed(() => {
 });
 
 const hasFields = computed(() => sortedFields.value.length > 0);
+
+/**
+ * The preview renders the same essential component the applicant gets, disabled. Rankings are
+ * seeded here (the disabled component never writes), so the preview shows the plan's order.
+ */
+const essentialPreviewData = computed<Record<string, unknown>>(() => ({
+  essential_section_ranking: props.essentialOptions?.sections ?? [],
+  essential_table_type_ranking: props.essentialOptions?.tableTypes ?? [],
+}));
 </script>
 
 <template>
@@ -19,6 +30,17 @@ const hasFields = computed(() => sortedFields.value.length > 0);
     <div class="preview-banner">
       <span class="preview-badge">PREVIEW</span>
       Applicant view
+    </div>
+
+    <div v-if="essentialOptions" class="preview-essential" data-testid="form-preview-essential">
+      <EssentialApplicationFields
+        :options="essentialOptions"
+        :modelValue="essentialPreviewData"
+        prefix="form-preview"
+        email="applicant@example.com"
+        disabled
+      />
+      <div class="preview-custom-divider">Your questions</div>
     </div>
 
     <div v-if="!hasFields" class="preview-empty" data-testid="form-preview-empty">
@@ -115,6 +137,23 @@ const hasFields = computed(() => sortedFields.value.length > 0);
   padding: 1px 6px;
   font-weight: bold;
   font-size: 10px;
+}
+
+.preview-essential {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.preview-custom-divider {
+  font-family: 'Outfit Regular';
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--mm-grey, #999);
+  border-bottom: 1px solid #e5e5e5;
+  padding-bottom: 4px;
 }
 
 .preview-empty {

--- a/front-end/src/components/application/RankedChoiceInput.vue
+++ b/front-end/src/components/application/RankedChoiceInput.vue
@@ -1,0 +1,154 @@
+<script setup lang="ts">
+/**
+ * An ordered preference list the applicant ranks with explicit up/down controls.
+ *
+ * Buttons rather than drag on purpose: drag-to-reorder is invisible affordance on a phone and
+ * undrivable in tests, while "1 is your first choice" plus arrows is self-explaining. The list
+ * always contains every offered option (rankings are total - see essentialFields.ts), so the
+ * applicant's only job is ordering, never remembering what exists.
+ */
+const props = withDefaults(
+  defineProps<{
+    modelValue: string[];
+    testid: string;
+    disabled?: boolean;
+  }>(),
+  { disabled: false },
+);
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string[]): void;
+}>();
+
+function move(index: number, delta: number) {
+  if (props.disabled) return;
+  const target = index + delta;
+  if (target < 0 || target >= props.modelValue.length) return;
+  const next = [...props.modelValue];
+  const [item] = next.splice(index, 1);
+  next.splice(target, 0, item);
+  emit('update:modelValue', next);
+}
+</script>
+
+<template>
+  <ol class="ranked-list" :data-testid="testid">
+    <li
+      v-for="(option, index) in modelValue"
+      :key="option"
+      class="ranked-item"
+      :data-testid="`${testid}-item-${index}`"
+    >
+      <span class="ranked-position" aria-hidden="true">{{ index + 1 }}</span>
+      <span class="ranked-name" :data-testid="`${testid}-name-${index}`">{{ option }}</span>
+      <span v-if="index === 0" class="ranked-first-badge">1st choice</span>
+      <span v-if="!disabled" class="ranked-controls">
+        <button
+          type="button"
+          class="ranked-btn"
+          :disabled="index === 0"
+          :aria-label="`Move ${option} up to rank ${index}`"
+          :data-testid="`${testid}-up-${index}`"
+          @click="move(index, -1)"
+        >
+          &#9650;
+        </button>
+        <button
+          type="button"
+          class="ranked-btn"
+          :disabled="index === modelValue.length - 1"
+          :aria-label="`Move ${option} down to rank ${index + 2}`"
+          :data-testid="`${testid}-down-${index}`"
+          @click="move(index, 1)"
+        >
+          &#9660;
+        </button>
+      </span>
+    </li>
+  </ol>
+</template>
+
+<style scoped>
+.ranked-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+}
+
+.ranked-item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--mm-grey, #ddd);
+  border-radius: 6px;
+  background: white;
+}
+
+.ranked-position {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--mm-green);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Merge One';
+  font-size: 13px;
+}
+
+.ranked-name {
+  flex: 1;
+  min-width: 0;
+  font-family: 'Outfit Regular';
+  font-size: 14px;
+  color: var(--mm-black);
+  overflow-wrap: anywhere;
+}
+
+.ranked-first-badge {
+  font-family: 'Outfit Regular';
+  font-size: 11px;
+  color: var(--mm-green);
+  border: 1px solid var(--mm-green);
+  border-radius: 10px;
+  padding: 1px 8px;
+  white-space: nowrap;
+}
+
+.ranked-controls {
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+}
+
+.ranked-btn {
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--mm-grey, #ccc);
+  border-radius: 5px;
+  background: white;
+  color: var(--mm-black);
+  font-size: 11px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ranked-btn:hover:not(:disabled) {
+  border-color: var(--mm-green);
+  color: var(--mm-green);
+}
+
+.ranked-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+</style>

--- a/front-end/src/components/application/RankedChoiceInput.vue
+++ b/front-end/src/components/application/RankedChoiceInput.vue
@@ -47,7 +47,7 @@ function move(index: number, delta: number) {
           type="button"
           class="ranked-btn"
           :disabled="index === 0"
-          :aria-label="`Move ${option} up to rank ${index}`"
+          :aria-label="`Move ${option} up to rank ${Math.max(index, 1)}`"
           :data-testid="`${testid}-up-${index}`"
           @click="move(index, -1)"
         >
@@ -57,7 +57,7 @@ function move(index: number, delta: number) {
           type="button"
           class="ranked-btn"
           :disabled="index === modelValue.length - 1"
-          :aria-label="`Move ${option} down to rank ${index + 2}`"
+          :aria-label="`Move ${option} down to rank ${Math.min(index + 2, modelValue.length)}`"
           :data-testid="`${testid}-down-${index}`"
           @click="move(index, 1)"
         >

--- a/front-end/src/utils/applicationForm.ts
+++ b/front-end/src/utils/applicationForm.ts
@@ -1,4 +1,5 @@
 import type { ApplicationForm, FormField } from '@/assets/types/datatypes';
+import { ESSENTIAL_KEY_PREFIX } from '@/utils/essentialFields';
 
 /** The charset the back-end holds field keys to; they become document keys on every answer. */
 export const FIELD_KEY_PATTERN = /^[a-z0-9_]+$/;
@@ -45,6 +46,9 @@ export function applicationFormError(form: ApplicationForm | null): string | nul
     if (!key) return `Field "${field.label}" needs a key.`;
     if (!FIELD_KEY_PATTERN.test(key)) {
       return `Key "${key}" is invalid. Use lowercase letters, numbers, and underscores only.`;
+    }
+    if (key.startsWith(ESSENTIAL_KEY_PREFIX)) {
+      return `Key "${key}" uses the reserved "${ESSENTIAL_KEY_PREFIX}" prefix. Those keys belong to the essential questions every form already asks.`;
     }
     if (seen.has(key)) return `Duplicate field key "${key}". Keys must be unique.`;
     seen.add(key);

--- a/front-end/src/utils/essentialFields.ts
+++ b/front-end/src/utils/essentialFields.ts
@@ -1,0 +1,113 @@
+import type { EssentialFormOptions, SetupObject } from '@/assets/types/datatypes';
+import { getFormattedDate } from '@/utils/utils';
+
+/**
+ * The essential form questions: the answers the assignment solver reads directly, present in
+ * every application form. This mirrors the back-end contract in `back-end/essential_fields.py`,
+ * which is the single owner of it - the reserved keys, labels, offering derivation, and
+ * validation here must say what the back end will say, only sooner.
+ */
+
+/** Custom builder fields may never use this prefix; the keys belong to the essential answers. */
+export const ESSENTIAL_KEY_PREFIX = 'essential_';
+
+export const AVAILABLE_DATES_KEY = 'essential_available_dates';
+export const MAX_DATES_KEY = 'essential_max_dates';
+export const SECTION_RANKING_KEY = 'essential_section_ranking';
+export const TABLE_TYPE_RANKING_KEY = 'essential_table_type_ranking';
+
+export const AVAILABLE_DATES_LABEL = 'Available dates';
+export const MAX_DATES_LABEL = 'Number of dates you want';
+export const SECTION_RANKING_LABEL = 'Section preference';
+export const TABLE_TYPE_RANKING_LABEL = 'Table type preference';
+
+export const EMPTY_ESSENTIAL_OPTIONS: EssentialFormOptions = {
+  dates: [],
+  sections: [],
+  tableTypes: [],
+};
+
+function uniqueNames(values: Array<string | null | undefined>): string[] {
+  const seen: string[] = [];
+  for (const value of values) {
+    const text = (value ?? '').trim();
+    if (text && !seen.includes(text)) seen.push(text);
+  }
+  return seen;
+}
+
+/**
+ * What the essential questions offer, read live from the market plan. The mirror of
+ * `essential_options_from_setup`: dates from the plan's market dates, sections from its
+ * sections, table types from the latest floorplan (the one whose sections the plan carries).
+ */
+export function essentialOptionsFromSetup(
+  setup: SetupObject | null | undefined,
+): EssentialFormOptions {
+  if (!setup) return EMPTY_ESSENTIAL_OPTIONS;
+  const floorplan = setup.floorplans?.length ? setup.floorplans[setup.floorplans.length - 1] : null;
+  return {
+    dates: uniqueNames((setup.marketDates ?? []).map((d) => d.date)),
+    sections: uniqueNames((setup.sections ?? []).map((s) => s.name)),
+    tableTypes: uniqueNames((floorplan?.tableTypes ?? []).map((t) => t.name)),
+  };
+}
+
+/**
+ * A market date as the applicant reads it ("Saturday, August 1, 2026"), falling back to the
+ * raw value. The year is spelled out because a market's dates can span a year boundary and the
+ * stored ISO value is what the solver will read back.
+ */
+export function formattedEssentialDate(date: string): string {
+  const formatted = getFormattedDate(date);
+  if (!formatted) return date;
+  const year = date.slice(0, 4);
+  return /^\d{4}$/.test(year) ? `${formatted}, ${year}` : formatted;
+}
+
+/**
+ * Client-side validation of the essential answers, mirroring the back end's
+ * `validated_essential_answers` so the applicant sees what is wrong before the request leaves.
+ * Questions whose offering is empty are not asked and not validated.
+ *
+ * STUBBED PRODUCT DECISIONS (kept in step with the back end):
+ * - rankings are total - every offered option is ranked;
+ * - max dates is bounded by the offered dates only, not by the applicant's own selection.
+ */
+export function essentialValidationErrors(
+  options: EssentialFormOptions,
+  formData: Record<string, unknown>,
+): Record<string, string> {
+  const errors: Record<string, string> = {};
+
+  if (options.dates.length > 0) {
+    const dates = formData[AVAILABLE_DATES_KEY];
+    if (!Array.isArray(dates) || dates.length === 0) {
+      errors[AVAILABLE_DATES_KEY] =
+        `'${AVAILABLE_DATES_LABEL}' is required. Select at least one date.`;
+    }
+
+    const max = formData[MAX_DATES_KEY];
+    const maxNumber = typeof max === 'string' ? Number(max.trim()) : max;
+    if (max === null || max === undefined || max === '') {
+      errors[MAX_DATES_KEY] = `'${MAX_DATES_LABEL}' is required.`;
+    } else if (typeof maxNumber !== 'number' || !Number.isInteger(maxNumber) || maxNumber < 1) {
+      errors[MAX_DATES_KEY] = `'${MAX_DATES_LABEL}' must be a whole number of at least 1.`;
+    } else if (maxNumber > options.dates.length) {
+      errors[MAX_DATES_KEY] =
+        `'${MAX_DATES_LABEL}' cannot exceed the ${options.dates.length} date(s) this market offers.`;
+    }
+  }
+
+  const rankingError = (key: string, label: string, offered: string[]) => {
+    if (offered.length === 0) return;
+    const ranked = formData[key];
+    if (!Array.isArray(ranked) || ranked.length !== offered.length) {
+      errors[key] = `'${label}' is required. Rank every option, best first.`;
+    }
+  };
+  rankingError(SECTION_RANKING_KEY, SECTION_RANKING_LABEL, options.sections);
+  rankingError(TABLE_TYPE_RANKING_KEY, TABLE_TYPE_RANKING_LABEL, options.tableTypes);
+
+  return errors;
+}

--- a/front-end/src/utils/publicApplicationForm.ts
+++ b/front-end/src/utils/publicApplicationForm.ts
@@ -1,9 +1,11 @@
-import type { FormField } from '@/assets/types/datatypes';
+import type { EssentialFormOptions, FormField } from '@/assets/types/datatypes';
 import { api } from '@/utils/api';
+import { EMPTY_ESSENTIAL_OPTIONS } from '@/utils/essentialFields';
 
 export interface PublicApplicationForm {
   marketName: string;
   fields: FormField[];
+  essentialOptions: EssentialFormOptions;
   phaseLabel: string;
   isOpen: boolean;
 }
@@ -21,9 +23,15 @@ export async function fetchPublicApplicationForm(
   try {
     const { data } = await api.get(`/public/markets/${marketSlug}/application-form`);
     const form = data.application_form || data.applicationForm || {};
+    const essential = data.essential_options || data.essentialOptions || {};
     return {
       marketName: data.market_name || data.marketName || '',
       fields: form.fields ?? [],
+      essentialOptions: {
+        dates: essential.dates ?? [],
+        sections: essential.sections ?? [],
+        tableTypes: essential.tableTypes ?? [],
+      },
       phaseLabel: data.phase_label || data.phaseLabel || '',
       isOpen: data.is_open === true || data.isOpen === true,
     };
@@ -31,6 +39,7 @@ export async function fetchPublicApplicationForm(
     return {
       marketName: '',
       fields: [],
+      essentialOptions: EMPTY_ESSENTIAL_OPTIONS,
       phaseLabel: '',
       isOpen: false,
     };

--- a/front-end/src/views/ApplicantDashboard.vue
+++ b/front-end/src/views/ApplicantDashboard.vue
@@ -3,8 +3,19 @@ import { ref, onMounted, computed } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useApplicationStore } from '@/stores/application';
 import { fetchPublicApplicationForm } from '@/utils/publicApplicationForm';
-import type { Application } from '@/assets/types/datatypes';
+import type { Application, FormField } from '@/assets/types/datatypes';
 import { ApplicationStatus } from '@/assets/types/datatypes';
+import {
+  AVAILABLE_DATES_KEY,
+  AVAILABLE_DATES_LABEL,
+  MAX_DATES_KEY,
+  MAX_DATES_LABEL,
+  SECTION_RANKING_KEY,
+  SECTION_RANKING_LABEL,
+  TABLE_TYPE_RANKING_KEY,
+  TABLE_TYPE_RANKING_LABEL,
+  formattedEssentialDate,
+} from '@/utils/essentialFields';
 
 const route = useRoute();
 const router = useRouter();
@@ -14,6 +25,7 @@ const marketSlug = computed(() => (route.params.marketSlug as string) || '');
 const marketName = ref('');
 const loading = ref(true);
 const application = ref<Application | null>(null);
+const formFields = ref<FormField[]>([]);
 
 const statusLabels: Record<string, string> = {
   open: 'Submitted',
@@ -51,12 +63,78 @@ onMounted(async () => {
   loading.value = true;
   const form = await fetchPublicApplicationForm(marketSlug.value);
   marketName.value = form.marketName;
+  formFields.value = form.fields;
 
   const app = await store.fetchApplication();
   if (app) {
     application.value = app;
   }
   loading.value = false;
+});
+
+interface AnswerRow {
+  key: string;
+  label: string;
+  value: string;
+}
+
+/**
+ * The applicant's answers with the questions' own labels: the essential answers first (they
+ * are asked first), then the organizer's questions in form order, then anything the form no
+ * longer names, so no stored answer is ever silently dropped.
+ */
+const answerRows = computed<AnswerRow[]>(() => {
+  const data = application.value?.formData ?? {};
+  const rows: AnswerRow[] = [];
+  const seen = new Set<string>();
+
+  const push = (key: string, label: string, value: unknown) => {
+    if (value === null || value === undefined || value === '') return;
+    if (Array.isArray(value) && value.length === 0) return;
+    rows.push({
+      key,
+      label,
+      value: Array.isArray(value) ? value.join(', ') : String(value),
+    });
+  };
+
+  const essentialRows: Array<[string, string, (v: unknown) => unknown]> = [
+    [
+      AVAILABLE_DATES_KEY,
+      AVAILABLE_DATES_LABEL,
+      (v) => (Array.isArray(v) ? v.map((d) => formattedEssentialDate(String(d))) : v),
+    ],
+    [MAX_DATES_KEY, MAX_DATES_LABEL, (v) => v],
+    [
+      SECTION_RANKING_KEY,
+      SECTION_RANKING_LABEL,
+      (v) => (Array.isArray(v) ? v.map((s, i) => `${i + 1}. ${s}`) : v),
+    ],
+    [
+      TABLE_TYPE_RANKING_KEY,
+      TABLE_TYPE_RANKING_LABEL,
+      (v) => (Array.isArray(v) ? v.map((t, i) => `${i + 1}. ${t}`) : v),
+    ],
+  ];
+  for (const [key, label, present] of essentialRows) {
+    if (key in data) {
+      seen.add(key);
+      push(key, label, present(data[key]));
+    }
+  }
+
+  for (const field of formFields.value) {
+    if (field.key in data && !seen.has(field.key)) {
+      seen.add(field.key);
+      push(field.key, field.label, data[field.key]);
+    }
+  }
+
+  for (const [key, value] of Object.entries(data)) {
+    if (!seen.has(key)) push(key, key, value);
+  }
+
+  return rows;
 });
 
 function logout() {
@@ -102,13 +180,16 @@ function logout() {
 
       <div class="dash-form-answers" data-testid="applicant-dashboard-answers">
         <h3>Your Answers</h3>
-        <div v-if="Object.keys(application.formData).length === 0" class="dash-no-answers">
-          No answers submitted yet.
-        </div>
+        <div v-if="answerRows.length === 0" class="dash-no-answers">No answers submitted yet.</div>
         <dl v-else class="answers-list">
-          <div v-for="(value, key) in application.formData" :key="key" class="answer-row">
-            <dt>{{ key }}</dt>
-            <dd>{{ Array.isArray(value) ? value.join(', ') : String(value ?? '') }}</dd>
+          <div
+            v-for="row in answerRows"
+            :key="row.key"
+            class="answer-row"
+            :data-testid="`applicant-dashboard-answer-${row.key}`"
+          >
+            <dt>{{ row.label }}</dt>
+            <dd>{{ row.value }}</dd>
           </div>
         </dl>
       </div>

--- a/front-end/src/views/ApplicationPage.vue
+++ b/front-end/src/views/ApplicationPage.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import type { FormField } from '@/assets/types/datatypes';
+import type { EssentialFormOptions, FormField } from '@/assets/types/datatypes';
 import ApplicationFormFields from '@/components/application/ApplicationFormFields.vue';
+import EssentialApplicationFields from '@/components/application/EssentialApplicationFields.vue';
 import { formValidationErrors, sortedFormFields } from '@/utils/applicationForm';
+import { EMPTY_ESSENTIAL_OPTIONS, essentialValidationErrors } from '@/utils/essentialFields';
 import { fetchPublicApplicationForm } from '@/utils/publicApplicationForm';
 import { useApplicationStore } from '@/stores/application';
 
@@ -14,6 +16,7 @@ const store = useApplicationStore();
 const marketSlug = computed(() => (route.params.marketSlug as string) || '');
 
 const fields = ref<FormField[]>([]);
+const essentialOptions = ref<EssentialFormOptions>(EMPTY_ESSENTIAL_OPTIONS);
 const marketName = ref('');
 const phaseLabel = ref('');
 const isOpen = ref(false);
@@ -37,6 +40,7 @@ onMounted(async () => {
 
   const form = await fetchPublicApplicationForm(marketSlug.value);
   fields.value = form.fields;
+  essentialOptions.value = form.essentialOptions;
   marketName.value = form.marketName;
   phaseLabel.value = form.phaseLabel;
   isOpen.value = form.isOpen;
@@ -44,13 +48,20 @@ onMounted(async () => {
 });
 
 function validateAll(): boolean {
-  validationErrors.value = formValidationErrors(sortedFields.value, formData.value);
+  validationErrors.value = {
+    ...essentialValidationErrors(essentialOptions.value, formData.value),
+    ...formValidationErrors(sortedFields.value, formData.value),
+  };
   return Object.keys(validationErrors.value).length === 0;
 }
 
 function clearFieldError(field: FormField) {
-  if (validationErrors.value[field.key]) {
-    validationErrors.value = { ...validationErrors.value, [field.key]: '' };
+  clearErrorFor(field.key);
+}
+
+function clearErrorFor(key: string) {
+  if (validationErrors.value[key]) {
+    validationErrors.value = { ...validationErrors.value, [key]: '' };
   }
 }
 
@@ -98,6 +109,17 @@ async function submitForm() {
         </div>
 
         <form v-else class="apply-form" @submit.prevent="submitForm" data-testid="apply-form">
+          <EssentialApplicationFields
+            v-model="formData"
+            :options="essentialOptions"
+            :errors="validationErrors"
+            :email="store.applicantEmail"
+            prefix="apply"
+            @field-change="clearErrorFor"
+          />
+
+          <div class="apply-custom-divider" v-if="sortedFields.length">More questions</div>
+
           <ApplicationFormFields
             v-model="formData"
             :fields="sortedFields"
@@ -194,6 +216,18 @@ async function submitForm() {
   display: flex;
   flex-direction: column;
   gap: 20px;
+}
+
+.apply-custom-divider {
+  font-family: 'Outfit Regular';
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--mm-grey, #999);
+  border-bottom: 1px solid #e5e5e5;
+  padding-bottom: 4px;
+  margin-top: 8px;
 }
 
 .apply-actions {

--- a/front-end/src/views/MarketSetupView.vue
+++ b/front-end/src/views/MarketSetupView.vue
@@ -11,11 +11,18 @@ import ElementTierSetup from '@/components/elements/ElementTierSetup.vue';
 import ElementLocationSetup from '@/components/elements/ElementLocationSetup.vue';
 import ElementSectionSetup from '@/components/elements/ElementSectionSetup.vue';
 import ChoosePathOverlay from '@/components/floorplan/ChoosePathOverlay.vue';
-import { type SetupObject, type Market, type ApplicationForm } from '@/assets/types/datatypes';
+import {
+  type SetupObject,
+  type Market,
+  type ApplicationForm,
+  type EssentialFormOptions,
+} from '@/assets/types/datatypes';
 import { api, getApiErrorMessage, getApiErrorStatus } from '@/utils/api';
 import { applicationFormError, applicationFormHint } from '@/utils/applicationForm';
+import { EMPTY_ESSENTIAL_OPTIONS, essentialOptionsFromSetup } from '@/utils/essentialFields';
 import FormBuilder from '@/components/application/FormBuilder.vue';
 import FormPreview from '@/components/application/FormPreview.vue';
+import EssentialFieldsPanel from '@/components/application/EssentialFieldsPanel.vue';
 import ApplicationMonitor from '@/components/application/ApplicationMonitor.vue';
 
 const router = useRouter();
@@ -74,6 +81,21 @@ const setupObject = reactive<SetupObject>({
 
 const pageIdx = ref(0);
 const maxPageIdx = 2;
+
+/**
+ * The essential questions' offering as the server reports it: the frozen snapshot once an
+ * applicant's answer exists, the stored plan otherwise.
+ */
+const serverEssentialOptions = ref<EssentialFormOptions | null>(null);
+/**
+ * What the essential questions offer right now. While the form is editable it follows the
+ * organizer's local market plan live - an unsaved date shows up immediately - and once the form
+ * is locked it is the server's frozen offering, which local plan edits can no longer move.
+ */
+const essentialOptions = computed<EssentialFormOptions>(() => {
+  if (formLocked.value) return serverEssentialOptions.value ?? EMPTY_ESSENTIAL_OPTIONS;
+  return essentialOptionsFromSetup(setupObject);
+});
 
 function parseFiniteInt(v: unknown): number | null {
   if (v === null || v === undefined || v === '') return null;
@@ -169,6 +191,7 @@ async function loadApplicationForm() {
     const response = await api.get(`/markets/${market.value.id}/application-form`);
     adoptStoredApplicationForm(response.data?.application_form ?? null);
     formLockReason.value = response.data?.lock_reason ?? null;
+    serverEssentialOptions.value = response.data?.essential_options ?? null;
     formLoadStatus.value = 'loaded';
   } catch (err: unknown) {
     formLoadStatus.value = 'error';
@@ -373,6 +396,11 @@ watch(pageIdx, (newIdx) => {
                   >
                     Loading the application form...
                   </div>
+                  <EssentialFieldsPanel
+                    v-if="!formStateUnknown"
+                    :options="essentialOptions"
+                    :locked="formLocked"
+                  />
                   <FormBuilder
                     v-if="!formStateUnknown"
                     :applicationForm="applicationForm"
@@ -427,7 +455,11 @@ watch(pageIdx, (newIdx) => {
                 <h2>Preview</h2>
               </template>
               <template #setting-content>
-                <FormPreview v-if="!formStateUnknown" :applicationForm="applicationForm" />
+                <FormPreview
+                  v-if="!formStateUnknown"
+                  :applicationForm="applicationForm"
+                  :essentialOptions="essentialOptions"
+                />
                 <p v-else class="preview-unavailable" data-testid="form-preview-unavailable">
                   Preview unavailable until the application form loads.
                 </p>


### PR DESCRIPTION
## Intent

Implement the essential form fields for market application forms: the five answers the assignment algorithm reads directly (email, available dates, max dates wanted, ranked section preference, ranked table type preference), present in every form and not removable by an admin. Deliberate design decisions: (1) essential questions are purpose-built components, NOT rows in applicationForm.fields - they cannot be removed because they are not part of the editable field list; the builder shows them in a read-only 'Essential questions' panel with zero edit controls. (2) The offering (which dates/sections/table types they present) is the market plan itself - dates from setupObject.marketDates, sections from setupObject.sections, table types from the LAST floorplan's tableTypes - no second source of truth; back-end/essential_fields.py is the single owner of that contract and front-end/src/utils/essentialFields.ts is its deliberate mirror. (3) Freeze semantics extend the D9 principle to the offering: it follows the plan live until the FIRST applicant answer is recorded, at which point the server snapshots it onto applicationForm.essentialOptions (server-owned like publishedAt, never client-writable, never refreshed - deliberately no escape hatch); the form save writes essentialOptions null so the freeze filter matches null-or-missing on purpose. (4) Applicant answers persist in Application.form_data under reserved essential_* keys (available dates as ISO strings in plan order, max_dates int, rankings best-first); custom field keys with the essential_ prefix are rejected on both ends. (5) Two product decisions were deliberately STUBBED per the product owner's instruction (stub and report, do not decide): rankings are TOTAL (a permutation of the offering, seeded in plan order, applicant reorders with up/down arrows - arrows chosen over drag deliberately for mobile usability and testability), and max_dates is validated only against the offered-date count, not the applicant's own selection (solver treats effective cap as min(max, available)); both are documented as stubs in code comments and tests. (6) Empty offering means the question is not asked and stores its empty value - deliberately no new transition guard, since guards.py and the phase machinery are owned by another task and were intentionally untouched. (7) The e2e login-challenge seed helper changed insertOne to an upsert replaceOne to match the production one-challenge-per-(market,email) semantics. (8) docs/schema.d.ts regenerated from the model as its test requires; AGENTS.md records the new contract and the DISABLE_EMAIL e2e env note. Validated by three new Playwright stories (admin customises offering through the real setup wizard, applicant completes all five through the real login-code flow with exact persisted-shape assertion, offering freeze after first answer) plus 27 new pytest tests; full suites green (pytest 525, vitest 44, e2e 41 incl. pre-existing D9 lock tests). UI polish from a layout audit: 20px checkboxes in padded highlighted rows, clamped rank aria-labels. PR base is dev, never main.

## What Changed

- Added the five essential application questions (email, available dates, max dates wanted, ranked section preference, ranked table type preference) as purpose-built, non-removable components: `back-end/essential_fields.py` owns the contract (offering derived live from the market plan - `setupObject.marketDates`, `setupObject.sections`, last floorplan's `tableTypes`), with `front-end/src/utils/essentialFields.ts` as its mirror; new Vue components (`EssentialApplicationFields`, `EssentialFieldsPanel`, `RankedChoiceInput`) render them in the applicant flow, form builder (read-only panel), preview, and applicant dashboard.
- Applicant answers persist in `Application.form_data` under reserved `essential_*` keys (rejected as custom field keys on both ends), validated server-side; the offering freezes onto server-owned `applicationForm.essentialOptions` before the first answer is persisted (freeze-first ordering per review feedback), after which market-plan edits no longer reach the form.
- Added 28 pytest tests and a Playwright spec with three stories (organizer customises offering, applicant answers all five questions with exact persisted-shape assertion, offering freeze after first answer), changed the e2e login-challenge seed helper from `insertOne` to upsert `replaceOne` to match production semantics, and regenerated `docs/schema.d.ts`; full suites green in the pipeline (pytest 526, vitest 44, Playwright 41).

## Risk Assessment

✅ Low: The two Round 1 issues have been properly resolved, the remaining changes are well-bounded UI components and backend validation, comprehensively tested (427 pytest + 420 e2e lines covering freeze semantics, race conditions, reserved-key enforcement, and offering derivation), and the code follows established project patterns.

## Testing

All test suites pass cleanly: 526 backend pytest (including 28 new essential_fields tests), 44 frontend vitest, and 41 Playwright E2E (including 3 new stories that exercise the essential form fields through the real UI - organizer customisation via setup wizard, applicant answering all five questions with exact persisted-shape assertion, and offering freeze after first answer). Seven screenshots captured from the E2E run provide visual evidence of the essential panel (before/after plan, after reload), applicant form (desktop + mobile), applicant dashboard with ranked answers, and frozen-offering lock banner.

- Evidence: Essential panel before market plan is configured (empty dates/sections warnings, table types from floorplan) (local file: <code>/tmp/no-mistakes-evidence/01KXNWCY9D806NG1MT09QFB3K9/01-essential-panel-before-plan.png</code>)
- Evidence: Essential panel with offering derived from the plan (dates, sections, and table types) (local file: <code>/tmp/no-mistakes-evidence/01KXNWCY9D806NG1MT09QFB3K9/02-essential-panel-offering-from-plan.png</code>)
- Evidence: Essential panel after page reload - offering survives round-trip (local file: <code>/tmp/no-mistakes-evidence/01KXNWCY9D806NG1MT09QFB3K9/03-essential-panel-after-reload.png</code>)
- Evidence: Applicant filling in all five essential questions (desktop viewport) (local file: <code>/tmp/no-mistakes-evidence/01KXNWCY9D806NG1MT09QFB3K9/04-applicant-essential-fields.png</code>)
- Evidence: Applicant essential fields at mobile viewport (390x844) (local file: <code>/tmp/no-mistakes-evidence/01KXNWCY9D806NG1MT09QFB3K9/05-applicant-essential-fields-mobile.png</code>)
- Evidence: Applicant dashboard showing submitted answers with ranked preferences (local file: <code>/tmp/no-mistakes-evidence/01KXNWCY9D806NG1MT09QFB3K9/06-applicant-dashboard-answers.png</code>)
- Evidence: Offering frozen after first applicant answer - lock banner visible, date chips show frozen offering (3 dates, not 4) (local file: <code>/tmp/no-mistakes-evidence/01KXNWCY9D806NG1MT09QFB3K9/07-essential-offering-frozen.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed ✅</summary>

- ⚠️ `back-end/api/applicants.py:333` - The offering freeze is written after the application answers are persisted (update_application_form_data at ~line 324, freeze at line 333) and only when no snapshot exists yet. Two windows follow: (1) a crash between the answer write and the freeze leaves a recorded answer with an unfrozen offering, so a subsequent plan edit can still move the questions under it until the next save re-freezes the then-current offering; (2) two concurrent first saves racing an organizer plan edit can each validate against different live offerings, and only one becomes the snapshot - the other applicant&#39;s stored answers may then name options the frozen offering never had. The window is narrow, but a more robust order is: attempt the freeze first with the offering used for validation, re-read the effective (possibly already-frozen) offering, validate against that, then persist the answers. This touches the deliberate freeze semantics in the intent, so confirming the intended tradeoff before changing it.
- ℹ️ `front-end/src/utils/essentialFields.ts:62` - formattedEssentialDate builds on getFormattedDate (front-end/src/utils/utils.ts:20), which parses the ISO date with a hardcoded &#39;-08:00&#39; offset and renders it in the viewer&#39;s local timezone. Applicants in timezones west of UTC-8 (e.g. Hawaii, winter Alaska) will see the previous calendar day for every offered market date. This is a pre-existing quirk of the shared formatter, but this change is its first applicant-facing use where the displayed day must match the stored ISO string the solver reads back.
- ℹ️ `back-end/api/markets.py:1233` - _effective_essential_options duplicates the snapshot-wins-else-live-plan decision that essential_fields.effective_essential_options already owns, just over a parsed Market instead of a raw document. Since essential_fields.py is documented as the single owner of the contract, moving this parsed-Market variant into that module (e.g. effective_essential_options_for_market(market)) would keep both representations of the rule in one file and prevent them drifting.
- ℹ️ `front-end/src/components/application/EssentialFieldsPanel.vue:34` - The panel hint says the offering &#39;is frozen with the rest of the form&#39; whenever the form is locked, but the form locks on first application existence (D9) while the offering only freezes on the first recorded answer. In the gap between an applicant signing in and their first save, the builder shows the server&#39;s live-plan offering under copy claiming it is frozen, and it snapshots whatever the server returned at page load (serverEssentialOptions is fetched once). Low impact; noting the tense mismatch as an accepted tradeoff of reusing formLocked.
- ℹ️ `front-end/src/views/ApplicationPage.vue:24` - The apply page never prefills a returning applicant&#39;s saved answers (formData starts empty), so their previously saved section/table-type rankings are silently re-seeded in plan order and a re-save overwrites all stored answers with the freshly entered ones. This matches the pre-existing behavior for custom fields, so the essential fields merely inherit it - flagging so the gap is a known, deliberate carry-over rather than an oversight.

🔧 Fix: freeze offering before persisting answers; dedupe effective-options rule
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./scripts/nm-test.sh`
- <code>`python -m pytest tests/ -v` -- 526 passed (includes 28 new test_essential_fields.py tests covering offering derivation, validation edges, freeze race conditions, reserved-key enforcement, and applicant-save integration)</code>
- <code>`npx vitest run` -- 44 passed (7 test files, existing unit coverage intact)</code>
- <code>`npx playwright test essential-fields.spec.ts` -- 3 new stories passed: organizer customises offering through market plan, applicant answers all five essential questions with exact persisted-shape assertion, offering freezes after first answer</code>
- <code>`npx playwright test` (full suite) -- 41 passed (38 pre-existing + 3 new, all green including D9 lock tests)</code>
- <code>Verified `replaceOne` upsert semantics for login-challenge seed helper (matches production one-challenge-per-(market,email) contract)</code>
- <code>Verified `docs/schema.d.ts` includes `essentialOptions` type and `AGENTS.md` records the contract</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
