### PR TITLE
feat(markets): complete market phase state machine with guards, offer sweep, and phase control UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,8 +218,8 @@ This file is the project's committed home for project-intrinsic agent knowledge:
   confidently and wrongly. The two endpoints that serve a raw document rather than a parsed
   `Market` re-stamp `isDraft` from the effective phase before responding.
 - **Publishing a market is the `draft` → `archived` transition** (no guards), fired by the
-  Done button in `GenerateAssignmentView.vue`. It used to be a `PUT` of `isDraft: false`; that
-  route is gone, and this transition is now the only way a market leaves `draft`.
+  Done button in `GenerateAssignmentView.vue`. A market can also leave `draft` via
+  `draft` → `applications_open` (guarded by `FormHasFieldsGuard`).
   A legacy published market (`phase: "draft"` + `isDraft: false`) reads back as a *draft*, since
   `draft` is a phase this build recognizes and takes at face value - hence the migration below.
 - **No Mongo condition can answer "is this market published?"** `{"phase": {"$ne": "draft"}}`

--- a/back-end/api/applications.py
+++ b/back-end/api/applications.py
@@ -239,7 +239,7 @@ def sweep_unanswered_offers(market_id: str) -> int:
     """
     ensure_application_indexes()
     result = applications_collection.update_many(
-        {**market_filter(market_id), "status": "assignment_sent"},
+        {**market_filter(market_id), "status": ApplicationStatus.ASSIGNMENT_SENT.value},
         {"$set": {"status": ApplicationStatus.VENDOR_REFUSED.value}},
     )
     return result.modified_count

--- a/back-end/api/applications.py
+++ b/back-end/api/applications.py
@@ -211,3 +211,35 @@ def update_application_form_data(
         }},
     )
     return result.matched_count > 0
+
+
+def count_applications_with_status(market_id: str, status: str) -> int:
+    """How many applications for a market hold a specific status."""
+    ensure_application_indexes()
+    return applications_collection.count_documents({
+        **market_filter(market_id),
+        "status": status,
+    })
+
+
+def count_applications_with_any_status(market_id: str, statuses: List[str]) -> int:
+    """How many applications for a market hold any of the given statuses."""
+    ensure_application_indexes()
+    return applications_collection.count_documents({
+        **market_filter(market_id),
+        "status": {"$in": list(statuses)},
+    })
+
+
+def sweep_unanswered_offers(market_id: str) -> int:
+    """Mark every ``assignment_sent`` application for a market as ``vendor_refused``.
+
+    This is the deadline mechanism: the admin holds the deadline, and this operation
+    is what records it. Returns the number of applications swept.
+    """
+    ensure_application_indexes()
+    result = applications_collection.update_many(
+        {**market_filter(market_id), "status": "assignment_sent"},
+        {"$set": {"status": ApplicationStatus.VENDOR_REFUSED.value}},
+    )
+    return result.modified_count

--- a/back-end/api/markets.py
+++ b/back-end/api/markets.py
@@ -121,9 +121,12 @@ def application_form_lock_reason(market: Market) -> Optional[str]:
 
     existing_app_count = ApplicationsApi.count_applications_for_market(market.id)
     if existing_app_count > 0:
+        app_word = (
+            "application has" if existing_app_count == 1 else "applications have"
+        )
         return (
             "Application form is locked. "
-            f"{existing_app_count} application(s) already exist for this market. "
+            f"{existing_app_count} {app_word} already been submitted for this market. "
             "The form cannot be modified once applicants have submitted."
         )
 

--- a/back-end/app.py
+++ b/back-end/app.py
@@ -1105,15 +1105,23 @@ def transition_market(market_id: str) -> Response:
 
         # ── Side effects (only after a successful phase write) ────────────
         if from_phase == "offers" and to_phase == MarketPhase.MARKET_DAYS:
-            result_sweep = MarketsApi.db.applications.update_many(
-                {"market_id": market_id, "status": "assignment_sent"},
-                {"$set": {"status": "vendor_refused"}},
-            )
-            logger.info(
-                "Swept %d assignment_sent applications to vendor_refused for market %s",
-                result_sweep.modified_count,
-                market_id,
-            )
+            try:
+                result_sweep = MarketsApi.db.applications.update_many(
+                    {"market_id": market_id, "status": "assignment_sent"},
+                    {"$set": {"status": "vendor_refused"}},
+                )
+                logger.info(
+                    "Swept %d assignment_sent applications to vendor_refused for market %s",
+                    result_sweep.modified_count,
+                    market_id,
+                )
+            except Exception:
+                logger.error(
+                    "Phase advanced to market_days for market %s but the "
+                    "assignment_sent -> vendor_refused sweep failed",
+                    market_id,
+                    exc_info=True,
+                )
 
         return jsonify({"phase": to_phase.value}), 200
 
@@ -1141,6 +1149,13 @@ def pending_offers_count(market_id: str) -> Response:
         context = MarketsApi.load_market_context(market_id)
         if context is None or context.market is None:
             return jsonify({"error": "Market not found"}), 404
+
+        if not PermissionsApi.user_has_permission(
+            user_email, context.market, MarketRole.VIEWER, context.organization
+        ):
+            return jsonify({
+                "error": "User does not have permission to view this market"
+            }), 403
 
         count = MarketsApi.db.applications.count_documents({
             "market_id": market_id,

--- a/back-end/app.py
+++ b/back-end/app.py
@@ -1066,18 +1066,6 @@ def transition_market(market_id: str) -> Response:
                 "blockers": [asdict(b) for b in blockers],
             })), 409
 
-        # ── Side effects ──────────────────────────────────────────────────
-        if from_phase == "offers" and to_phase == MarketPhase.MARKET_DAYS:
-            result_sweep = MarketsApi.db.applications.update_many(
-                {"market_id": market_id, "status": "assignment_sent"},
-                {"$set": {"status": "vendor_refused"}},
-            )
-            logger.info(
-                "Swept %d assignment_sent applications to vendor_refused for market %s",
-                result_sweep.modified_count,
-                market_id,
-            )
-
         phase_key = market_doc_key("phase")
         is_draft_key = market_doc_key("is_draft")
         stored_phase = (
@@ -1114,6 +1102,18 @@ def transition_market(market_id: str) -> Response:
                 "target_phase": to_phase.value,
                 "blockers": [asdict(conflict)],
             })), 409
+
+        # ── Side effects (only after a successful phase write) ────────────
+        if from_phase == "offers" and to_phase == MarketPhase.MARKET_DAYS:
+            result_sweep = MarketsApi.db.applications.update_many(
+                {"market_id": market_id, "status": "assignment_sent"},
+                {"$set": {"status": "vendor_refused"}},
+            )
+            logger.info(
+                "Swept %d assignment_sent applications to vendor_refused for market %s",
+                result_sweep.modified_count,
+                market_id,
+            )
 
         return jsonify({"phase": to_phase.value}), 200
 

--- a/back-end/app.py
+++ b/back-end/app.py
@@ -1106,13 +1106,10 @@ def transition_market(market_id: str) -> Response:
         # ── Side effects (only after a successful phase write) ────────────
         if from_phase == "offers" and to_phase == MarketPhase.MARKET_DAYS:
             try:
-                result_sweep = MarketsApi.db.applications.update_many(
-                    {"market_id": market_id, "status": "assignment_sent"},
-                    {"$set": {"status": "vendor_refused"}},
-                )
+                swept = ApplicationsApi.sweep_unanswered_offers(market_id)
                 logger.info(
                     "Swept %d assignment_sent applications to vendor_refused for market %s",
-                    result_sweep.modified_count,
+                    swept,
                     market_id,
                 )
             except Exception:
@@ -1157,10 +1154,9 @@ def pending_offers_count(market_id: str) -> Response:
                 "error": "User does not have permission to view this market"
             }), 403
 
-        count = MarketsApi.db.applications.count_documents({
-            "market_id": market_id,
-            "status": "assignment_sent",
-        })
+        count = ApplicationsApi.count_applications_with_status(
+            market_id, "assignment_sent",
+        )
 
         return jsonify({"count": count}), 200
 

--- a/back-end/app.py
+++ b/back-end/app.py
@@ -1066,6 +1066,18 @@ def transition_market(market_id: str) -> Response:
                 "blockers": [asdict(b) for b in blockers],
             })), 409
 
+        # ── Side effects ──────────────────────────────────────────────────
+        if from_phase == "offers" and to_phase == MarketPhase.MARKET_DAYS:
+            result_sweep = MarketsApi.db.applications.update_many(
+                {"market_id": market_id, "status": "assignment_sent"},
+                {"$set": {"status": "vendor_refused"}},
+            )
+            logger.info(
+                "Swept %d assignment_sent applications to vendor_refused for market %s",
+                result_sweep.modified_count,
+                market_id,
+            )
+
         phase_key = market_doc_key("phase")
         is_draft_key = market_doc_key("is_draft")
         stored_phase = (

--- a/back-end/app.py
+++ b/back-end/app.py
@@ -1123,6 +1123,37 @@ def transition_market(market_id: str) -> Response:
         return jsonify({"error": "Internal server error"}), 500
 
 
+@app.route('/markets/<market_id>/pending-offers-count', methods=['GET'])
+@login_required
+def pending_offers_count(market_id: str) -> Response:
+    """Return how many applications are still in ``assignment_sent`` — the count of
+    offers that will be swept to ``vendor_refused`` when the market advances from
+    ``offers`` to ``market_days``. Drives the sweep confirmation dialog in the UI.
+    """
+    try:
+        user_email = request.headers.get("X-Owner-Email")
+        if not user_email:
+            return jsonify({"error": "User email not provided in headers"}), 400
+
+        if not UsersApi.get_user(user_email):
+            return jsonify({"error": "User not found"}), 404
+
+        context = MarketsApi.load_market_context(market_id)
+        if context is None or context.market is None:
+            return jsonify({"error": "Market not found"}), 404
+
+        count = MarketsApi.db.applications.count_documents({
+            "market_id": market_id,
+            "status": "assignment_sent",
+        })
+
+        return jsonify({"count": count}), 200
+
+    except Exception as e:
+        logger.error(f"Error in pending_offers_count {market_id}: {e}")
+        return jsonify({"error": "Internal server error"}), 500
+
+
 @app.route('/markets/<market_id>/assignment', methods=['GET'])
 @login_required
 def get_assigned_market(market_id: str) -> Response:

--- a/back-end/app.py
+++ b/back-end/app.py
@@ -28,7 +28,7 @@ from flask import Flask, request, jsonify, Response
 from flask_login import LoginManager, login_user, login_required, logout_user, current_user
 from flask_bcrypt import Bcrypt
 from datetime import timedelta, datetime, timezone
-from datatypes import Market, MarketPhase, MarketRole, phase_from_market_document
+from datatypes import ApplicationStatus, Market, MarketPhase, MarketRole, phase_from_market_document
 from assignment.utils import convert_keys_to_camel_case, convert_keys_to_snake_case
 from guards import PreconditionResult, VALID_TRANSITIONS, evaluate_transition
 from market_documents import (
@@ -1104,7 +1104,7 @@ def transition_market(market_id: str) -> Response:
             })), 409
 
         # ── Side effects (only after a successful phase write) ────────────
-        if from_phase == "offers" and to_phase == MarketPhase.MARKET_DAYS:
+        if from_phase == MarketPhase.OFFERS.value and to_phase == MarketPhase.MARKET_DAYS:
             try:
                 swept = ApplicationsApi.sweep_unanswered_offers(market_id)
                 logger.info(
@@ -1155,7 +1155,7 @@ def pending_offers_count(market_id: str) -> Response:
             }), 403
 
         count = ApplicationsApi.count_applications_with_status(
-            market_id, "assignment_sent",
+            market_id, ApplicationStatus.ASSIGNMENT_SENT.value,
         )
 
         return jsonify({"count": count}), 200

--- a/back-end/guards.py
+++ b/back-end/guards.py
@@ -82,11 +82,12 @@ class AllApplicationsReviewedGuard:
             if app.get("status") in ("open", "under_review")
         ]
         if unreviewed:
+            app_word = "application is" if len(unreviewed) == 1 else "applications are"
             return PreconditionResult(
                 id=self.id,
                 passed=False,
                 message=(
-                    f"{len(unreviewed)} application(s) are still awaiting review. "
+                    f"{len(unreviewed)} {app_word} still awaiting review. "
                     "Every application must be approved or rejected before assignment "
                     "can begin."
                 ),
@@ -123,11 +124,12 @@ class NoApprovedApplicationsGuard:
             if app.get("status") == "reviewer_approved"
         ]
         if approved:
+            app_word = "application is" if len(approved) == 1 else "applications are"
             return PreconditionResult(
                 id=self.id,
                 passed=False,
                 message=(
-                    f"{len(approved)} application(s) are still approved but not yet "
+                    f"{len(approved)} {app_word} still approved but not yet "
                     "assigned or unassigned. Run the assignment solver before "
                     "sending offers."
                 ),

--- a/back-end/guards.py
+++ b/back-end/guards.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 import api.applications as ApplicationsApi
-from datatypes import Market, MarketPhase
+from datatypes import ApplicationStatus, Market, MarketPhase
 
 
 # ── Wire shape (backend/frontend contract) ──────────────────────────────
@@ -79,7 +79,8 @@ class AllApplicationsReviewedGuard:
     def evaluate(self, market: Market, _db) -> PreconditionResult:
         total = ApplicationsApi.count_applications_for_market(market.id)
         unreviewed_count = ApplicationsApi.count_applications_with_any_status(
-            market.id, ["open", "under_review"],
+            market.id,
+            [ApplicationStatus.OPEN.value, ApplicationStatus.UNDER_REVIEW.value],
         )
         if unreviewed_count > 0:
             app_word = (
@@ -121,7 +122,7 @@ class NoApprovedApplicationsGuard:
 
     def evaluate(self, market: Market, _db) -> PreconditionResult:
         approved_count = ApplicationsApi.count_applications_with_status(
-            market.id, "reviewer_approved",
+            market.id, ApplicationStatus.REVIEWER_APPROVED.value,
         )
         if approved_count > 0:
             app_word = (
@@ -157,7 +158,6 @@ VALID_TRANSITIONS: set[tuple[str, str]] = {
     ("review", "assignment"),
     ("assignment", "offers"),
     ("offers", "market_days"),
-    ("market_days", "archived"),
     # Archive from anywhere
     ("draft", "archived"),
     ("applications_open", "archived"),

--- a/back-end/guards.py
+++ b/back-end/guards.py
@@ -13,8 +13,9 @@ Phase 1 guards implemented:
   - ``FormHasFieldsGuard``  on every edge into ``applications_open``
     (``draft -> applications_open`` and ``applications_closed -> applications_open``)
 
-Skeleton guards for later phases are intentionally omitted.
-They will be added with their phases (one-file edit, proven by this PR).
+Phase 2 guards implemented (conv-market-state-machine-t7):
+  - ``AllApplicationsReviewedGuard`` on ``review -> assignment``
+  - ``NoApprovedApplicationsGuard`` on ``assignment -> offers``
 """
 
 from dataclasses import dataclass, field
@@ -64,28 +65,120 @@ class FormHasFieldsGuard:
         return PreconditionResult(id=self.id, passed=True, message="")
 
 
+class AllApplicationsReviewedGuard:
+    """Every application must be approved or rejected before assignment can begin.
+
+    No application may still be ``open`` or ``under_review`` -- the review phase must
+    have reached a verdict on every single one.
+    """
+
+    id: str = "all_applications_reviewed"
+    description: str = "Every application is approved or rejected"
+
+    def evaluate(self, market: Market, db) -> PreconditionResult:
+        apps = list(db.applications.find({"market_id": market.id}))
+        unreviewed = [
+            app for app in apps
+            if app.get("status") in ("open", "under_review")
+        ]
+        if unreviewed:
+            return PreconditionResult(
+                id=self.id,
+                passed=False,
+                message=(
+                    f"{len(unreviewed)} application(s) are still awaiting review. "
+                    "Every application must be approved or rejected before assignment "
+                    "can begin."
+                ),
+                resolution_link=f"/markets/{market.id}/applications",
+            )
+        if len(apps) == 0:
+            return PreconditionResult(
+                id=self.id,
+                passed=False,
+                message=(
+                    "There are no applications for this market. "
+                    "At least one application must exist before assignment can begin."
+                ),
+                resolution_link=None,
+            )
+        return PreconditionResult(id=self.id, passed=True, message="")
+
+
+class NoApprovedApplicationsGuard:
+    """No application may remain ``reviewer_approved`` before entering the offers phase.
+
+    The solver must have resolved every approved application to either ``assigned``
+    or ``unassigned``. Any ``reviewer_approved`` application at this point means the
+    solver has not run or did not complete.
+    """
+
+    id: str = "no_approved_applications"
+    description: str = "No application remains reviewer_approved"
+
+    def evaluate(self, market: Market, db) -> PreconditionResult:
+        apps = list(db.applications.find({"market_id": market.id}))
+        approved = [
+            app for app in apps
+            if app.get("status") == "reviewer_approved"
+        ]
+        if approved:
+            return PreconditionResult(
+                id=self.id,
+                passed=False,
+                message=(
+                    f"{len(approved)} application(s) are still approved but not yet "
+                    "assigned or unassigned. Run the assignment solver before "
+                    "sending offers."
+                ),
+                resolution_link=f"/markets/{market.id}/assignment-results",
+            )
+        return PreconditionResult(id=self.id, passed=True, message="")
+
+
 # ── Transition registry ─────────────────────────────────────────────────
 
 
-# Phase 1 valid transitions. Transitions not in this set return 400
-# ("transition not available in current phase").
+# Transitions not in this set return 400 ("transition not available in current phase").
 # Adding a new phase transition: add to this set + add to TRANSITION_GUARDS
 # if the transition has preconditions.
 VALID_TRANSITIONS: set[tuple[str, str]] = {
+    # Pre-assignment back edges
     ("draft", "applications_open"),
-    ("draft", "archived"),
     ("applications_open", "applications_closed"),
     ("applications_closed", "applications_open"),
+    ("applications_closed", "review"),
+    ("review", "applications_closed"),
+    # Assignment and forward
+    ("review", "assignment"),
+    ("assignment", "offers"),
+    ("offers", "market_days"),
+    ("market_days", "archived"),
+    # Archive from anywhere
+    ("draft", "archived"),
+    ("applications_open", "archived"),
+    ("applications_closed", "archived"),
+    ("review", "archived"),
+    ("assignment", "archived"),
+    ("offers", "archived"),
+    ("market_days", "archived"),
 }
 
 # Guards are stateless, so one instance is shared by every edge that enforces it.
 _FORM_HAS_FIELDS = FormHasFieldsGuard()
+_ALL_REVIEWED = AllApplicationsReviewedGuard()
+_NO_APPROVED = NoApprovedApplicationsGuard()
 
 # Entry invariants: what must hold of a market SITTING IN a phase, regardless of the
 # route it took to get there. Every inbound edge to the phase must enforce these, so
 # listing one here makes it impossible to reach the phase without it.
 PHASE_ENTRY_INVARIANTS: dict[str, list] = {
     "applications_open": [_FORM_HAS_FIELDS],
+    # TODO: Add _PRIORITY_CONFIGURED guard here once priority configuration exists.
+    # The guard should verify that the market's setup_object has at least one
+    # priority entry (enum_priority_order is populated) before assignment can begin.
+    "assignment": [_ALL_REVIEWED],
+    "offers": [_NO_APPROVED],
 }
 
 # (from_phase, to_phase) -> list of guard instances. This is the table evaluate_transition
@@ -102,6 +195,11 @@ PHASE_ENTRY_INVARIANTS: dict[str, list] = {
 TRANSITION_GUARDS: dict[tuple[str, str], list] = {
     ("draft", "applications_open"): [_FORM_HAS_FIELDS],
     ("applications_closed", "applications_open"): [_FORM_HAS_FIELDS],
+    # TODO: Add _PRIORITY_CONFIGURED guard here (append to list) once it exists.
+    # The guard should verify that the market's setup_object has at least one
+    # priority entry before assignment can begin.
+    ("review", "assignment"): [_ALL_REVIEWED],
+    ("assignment", "offers"): [_NO_APPROVED],
 }
 
 

--- a/back-end/guards.py
+++ b/back-end/guards.py
@@ -60,7 +60,7 @@ class FormHasFieldsGuard:
                     "The application form has no fields. "
                     "Add at least one field before publishing the market."
                 ),
-                resolution_link=f"/markets/{market.id}/form-builder",
+                resolution_link="/market-setup",
             )
         return PreconditionResult(id=self.id, passed=True, message="")
 
@@ -91,7 +91,7 @@ class AllApplicationsReviewedGuard:
                     "Every application must be approved or rejected before assignment "
                     "can begin."
                 ),
-                resolution_link=f"/markets/{market.id}/applications",
+                resolution_link="/market-setup",
             )
         if len(apps) == 0:
             return PreconditionResult(
@@ -133,7 +133,7 @@ class NoApprovedApplicationsGuard:
                     "assigned or unassigned. Run the assignment solver before "
                     "sending offers."
                 ),
-                resolution_link=f"/markets/{market.id}/assignment-results",
+                resolution_link="/assignment-results",
             )
         return PreconditionResult(id=self.id, passed=True, message="")
 

--- a/back-end/guards.py
+++ b/back-end/guards.py
@@ -21,6 +21,7 @@ Phase 2 guards implemented (conv-market-state-machine-t7):
 from dataclasses import dataclass, field
 from typing import Optional
 
+import api.applications as ApplicationsApi
 from datatypes import Market, MarketPhase
 
 
@@ -75,25 +76,26 @@ class AllApplicationsReviewedGuard:
     id: str = "all_applications_reviewed"
     description: str = "Every application is approved or rejected"
 
-    def evaluate(self, market: Market, db) -> PreconditionResult:
-        apps = list(db.applications.find({"market_id": market.id}))
-        unreviewed = [
-            app for app in apps
-            if app.get("status") in ("open", "under_review")
-        ]
-        if unreviewed:
-            app_word = "application is" if len(unreviewed) == 1 else "applications are"
+    def evaluate(self, market: Market, _db) -> PreconditionResult:
+        total = ApplicationsApi.count_applications_for_market(market.id)
+        unreviewed_count = ApplicationsApi.count_applications_with_any_status(
+            market.id, ["open", "under_review"],
+        )
+        if unreviewed_count > 0:
+            app_word = (
+                "application is" if unreviewed_count == 1 else "applications are"
+            )
             return PreconditionResult(
                 id=self.id,
                 passed=False,
                 message=(
-                    f"{len(unreviewed)} {app_word} still awaiting review. "
+                    f"{unreviewed_count} {app_word} still awaiting review. "
                     "Every application must be approved or rejected before assignment "
                     "can begin."
                 ),
                 resolution_link="/market-setup",
             )
-        if len(apps) == 0:
+        if total == 0:
             return PreconditionResult(
                 id=self.id,
                 passed=False,
@@ -117,19 +119,19 @@ class NoApprovedApplicationsGuard:
     id: str = "no_approved_applications"
     description: str = "No application remains reviewer_approved"
 
-    def evaluate(self, market: Market, db) -> PreconditionResult:
-        apps = list(db.applications.find({"market_id": market.id}))
-        approved = [
-            app for app in apps
-            if app.get("status") == "reviewer_approved"
-        ]
-        if approved:
-            app_word = "application is" if len(approved) == 1 else "applications are"
+    def evaluate(self, market: Market, _db) -> PreconditionResult:
+        approved_count = ApplicationsApi.count_applications_with_status(
+            market.id, "reviewer_approved",
+        )
+        if approved_count > 0:
+            app_word = (
+                "application is" if approved_count == 1 else "applications are"
+            )
             return PreconditionResult(
                 id=self.id,
                 passed=False,
                 message=(
-                    f"{len(approved)} {app_word} still approved but not yet "
+                    f"{approved_count} {app_word} still approved but not yet "
                     "assigned or unassigned. Run the assignment solver before "
                     "sending offers."
                 ),

--- a/back-end/tests/test_application_form.py
+++ b/back-end/tests/test_application_form.py
@@ -444,7 +444,7 @@ class TestGetApplicationForm:
         result = MarketsApi.get_application_form("market-123", "user-1")
 
         assert result["editable"] is False
-        assert "2 application(s)" in result["lock_reason"]
+        assert "2 applications have" in result["lock_reason"]
 
     def test_reports_the_lock_reason_out_of_draft(self, monkeypatch, applications):
         monkeypatch.setattr(

--- a/back-end/tests/test_guards.py
+++ b/back-end/tests/test_guards.py
@@ -11,7 +11,9 @@ from datatypes import (
     ApplicationForm, AssignmentObject, FormField, Market, MarketPhase, MarketRole,
 )
 from guards import (
+    AllApplicationsReviewedGuard,
     FormHasFieldsGuard,
+    NoApprovedApplicationsGuard,
     PreconditionResult,
     TRANSITION_GUARDS,
     VALID_TRANSITIONS,
@@ -140,15 +142,22 @@ class TestValidTransitions:
         assert ("applications_open", "applications_closed") in VALID_TRANSITIONS
         assert ("applications_closed", "applications_open") in VALID_TRANSITIONS
 
-    def test_later_phase_transitions_not_registered(self):
-        assert ("applications_closed", "review") not in VALID_TRANSITIONS
-        assert ("review", "assignment") not in VALID_TRANSITIONS
-        assert ("assignment", "offers") not in VALID_TRANSITIONS
-        assert ("offers", "market_days") not in VALID_TRANSITIONS
-        assert ("market_days", "archived") not in VALID_TRANSITIONS
+    def test_later_phase_transitions_are_registered(self):
+        assert ("applications_closed", "review") in VALID_TRANSITIONS
+        assert ("review", "assignment") in VALID_TRANSITIONS
+        assert ("assignment", "offers") in VALID_TRANSITIONS
+        assert ("offers", "market_days") in VALID_TRANSITIONS
+        assert ("market_days", "archived") in VALID_TRANSITIONS
 
     def test_reverse_draft_not_registered(self):
         assert ("applications_open", "draft") not in VALID_TRANSITIONS
+
+    def test_archive_from_every_phase_is_registered(self):
+        phases = [p.value for p in MarketPhase if p != MarketPhase.ARCHIVED]
+        for phase in phases:
+            assert (phase, "archived") in VALID_TRANSITIONS, (
+                f"Missing archive edge from {phase}"
+            )
 
 
 class TestTransitionGuards:
@@ -285,3 +294,143 @@ class TestGuardDesignProperties:
     def test_adding_guard_is_only_a_dict_entry(self):
         guards = TRANSITION_GUARDS[("draft", "applications_open")]
         assert len(guards) == 1
+
+
+class FakeApplicationsCollection:
+    """A fake Mongo collection for guard tests that query applications."""
+
+    def __init__(self, docs):
+        self._docs = list(docs)
+
+    def find(self, query):
+        results = []
+        for doc in self._docs:
+            match = True
+            for key, value in query.items():
+                if doc.get(key) != value:
+                    match = False
+                    break
+            if match:
+                results.append(dict(doc))
+        return results
+
+
+class FakeDB:
+    """A fake database handle carrying a fake applications collection."""
+
+    def __init__(self, applications=None):
+        self.applications = applications or FakeApplicationsCollection([])
+
+
+class TestAllApplicationsReviewedGuard:
+    def _market(self):
+        return _make_market(
+            phase=MarketPhase.REVIEW,
+            application_form=ApplicationForm(
+                fields=[FormField(key="name", label="Name", type="text")],
+            ),
+        )
+
+    def test_passes_when_all_apps_are_reviewed(self):
+        market = self._market()
+        db = FakeDB(FakeApplicationsCollection([
+            {"market_id": market.id, "status": "reviewer_approved"},
+            {"market_id": market.id, "status": "reviewer_rejected"},
+        ]))
+        result = AllApplicationsReviewedGuard().evaluate(market, db)
+        assert result.passed is True
+        assert result.id == "all_applications_reviewed"
+
+    def test_fails_when_some_apps_are_open(self):
+        market = self._market()
+        db = FakeDB(FakeApplicationsCollection([
+            {"market_id": market.id, "status": "open"},
+            {"market_id": market.id, "status": "reviewer_approved"},
+        ]))
+        result = AllApplicationsReviewedGuard().evaluate(market, db)
+        assert result.passed is False
+        assert "still awaiting review" in result.message.lower()
+
+    def test_fails_when_some_apps_are_under_review(self):
+        market = self._market()
+        db = FakeDB(FakeApplicationsCollection([
+            {"market_id": market.id, "status": "under_review"},
+        ]))
+        result = AllApplicationsReviewedGuard().evaluate(market, db)
+        assert result.passed is False
+
+    def test_fails_when_no_applications_exist(self):
+        market = self._market()
+        db = FakeDB(FakeApplicationsCollection([]))
+        result = AllApplicationsReviewedGuard().evaluate(market, db)
+        assert result.passed is False
+        assert "no applications" in result.message.lower()
+
+    def test_has_id_and_description(self):
+        guard = AllApplicationsReviewedGuard()
+        assert guard.id == "all_applications_reviewed"
+        assert isinstance(guard.description, str)
+        assert len(guard.description) > 0
+
+
+class TestNoApprovedApplicationsGuard:
+    def _market(self):
+        return _make_market(
+            phase=MarketPhase.ASSIGNMENT,
+            application_form=ApplicationForm(
+                fields=[FormField(key="name", label="Name", type="text")],
+            ),
+        )
+
+    def test_passes_when_no_apps_are_approved(self):
+        market = self._market()
+        db = FakeDB(FakeApplicationsCollection([
+            {"market_id": market.id, "status": "assigned"},
+            {"market_id": market.id, "status": "unassigned"},
+            {"market_id": market.id, "status": "reviewer_rejected"},
+        ]))
+        result = NoApprovedApplicationsGuard().evaluate(market, db)
+        assert result.passed is True
+        assert result.id == "no_approved_applications"
+
+    def test_passes_when_no_apps_exist(self):
+        market = self._market()
+        db = FakeDB(FakeApplicationsCollection([]))
+        result = NoApprovedApplicationsGuard().evaluate(market, db)
+        assert result.passed is True
+
+    def test_fails_when_some_apps_are_still_approved(self):
+        market = self._market()
+        db = FakeDB(FakeApplicationsCollection([
+            {"market_id": market.id, "status": "reviewer_approved"},
+            {"market_id": market.id, "status": "assigned"},
+        ]))
+        result = NoApprovedApplicationsGuard().evaluate(market, db)
+        assert result.passed is False
+        assert "still approved" in result.message.lower()
+
+    def test_has_id_and_description(self):
+        guard = NoApprovedApplicationsGuard()
+        assert guard.id == "no_approved_applications"
+        assert isinstance(guard.description, str)
+        assert len(guard.description) > 0
+
+
+class TestAssignmentEntryInvariants:
+    """Every edge into assignment (currently only review -> assignment) must carry the
+    reviewed-every-application guard."""
+
+    def test_review_to_assignment_is_guarded(self):
+        guards = TRANSITION_GUARDS.get(("review", "assignment"), [])
+        assert len(guards) == 1
+        assert isinstance(guards[0], AllApplicationsReviewedGuard)
+
+
+class TestOffersEntryInvariants:
+    """Every edge into offers (currently only assignment -> offers) must carry the
+    no-more-approved guard."""
+
+    def test_assignment_to_offers_is_guarded(self):
+        guards = TRANSITION_GUARDS.get(("assignment", "offers"), [])
+        assert len(guards) == 1
+        assert isinstance(guards[0], NoApprovedApplicationsGuard)

--- a/back-end/tests/test_guards.py
+++ b/back-end/tests/test_guards.py
@@ -296,32 +296,6 @@ class TestGuardDesignProperties:
         assert len(guards) == 1
 
 
-class FakeApplicationsCollection:
-    """A fake Mongo collection for guard tests that query applications."""
-
-    def __init__(self, docs):
-        self._docs = list(docs)
-
-    def find(self, query):
-        results = []
-        for doc in self._docs:
-            match = True
-            for key, value in query.items():
-                if doc.get(key) != value:
-                    match = False
-                    break
-            if match:
-                results.append(dict(doc))
-        return results
-
-
-class FakeDB:
-    """A fake database handle carrying a fake applications collection."""
-
-    def __init__(self, applications=None):
-        self.applications = applications or FakeApplicationsCollection([])
-
-
 class TestAllApplicationsReviewedGuard:
     def _market(self):
         return _make_market(
@@ -331,38 +305,39 @@ class TestAllApplicationsReviewedGuard:
             ),
         )
 
-    def test_passes_when_all_apps_are_reviewed(self):
-        market = self._market()
-        db = FakeDB(FakeApplicationsCollection([
-            {"market_id": market.id, "status": "reviewer_approved"},
-            {"market_id": market.id, "status": "reviewer_rejected"},
-        ]))
-        result = AllApplicationsReviewedGuard().evaluate(market, db)
+    @staticmethod
+    def _patch(monkeypatch, total=0, unreviewed=0):
+        monkeypatch.setattr(
+            guards.ApplicationsApi,
+            "count_applications_for_market",
+            lambda _market_id: total,
+        )
+        monkeypatch.setattr(
+            guards.ApplicationsApi,
+            "count_applications_with_any_status",
+            lambda _market_id, _statuses: unreviewed,
+        )
+
+    def test_passes_when_all_apps_are_reviewed(self, monkeypatch):
+        self._patch(monkeypatch, total=3, unreviewed=0)
+        result = AllApplicationsReviewedGuard().evaluate(self._market(), None)
         assert result.passed is True
         assert result.id == "all_applications_reviewed"
 
-    def test_fails_when_some_apps_are_open(self):
-        market = self._market()
-        db = FakeDB(FakeApplicationsCollection([
-            {"market_id": market.id, "status": "open"},
-            {"market_id": market.id, "status": "reviewer_approved"},
-        ]))
-        result = AllApplicationsReviewedGuard().evaluate(market, db)
+    def test_fails_when_some_apps_are_open(self, monkeypatch):
+        self._patch(monkeypatch, total=3, unreviewed=1)
+        result = AllApplicationsReviewedGuard().evaluate(self._market(), None)
         assert result.passed is False
         assert "still awaiting review" in result.message.lower()
 
-    def test_fails_when_some_apps_are_under_review(self):
-        market = self._market()
-        db = FakeDB(FakeApplicationsCollection([
-            {"market_id": market.id, "status": "under_review"},
-        ]))
-        result = AllApplicationsReviewedGuard().evaluate(market, db)
+    def test_fails_when_some_apps_are_under_review(self, monkeypatch):
+        self._patch(monkeypatch, total=1, unreviewed=1)
+        result = AllApplicationsReviewedGuard().evaluate(self._market(), None)
         assert result.passed is False
 
-    def test_fails_when_no_applications_exist(self):
-        market = self._market()
-        db = FakeDB(FakeApplicationsCollection([]))
-        result = AllApplicationsReviewedGuard().evaluate(market, db)
+    def test_fails_when_no_applications_exist(self, monkeypatch):
+        self._patch(monkeypatch, total=0, unreviewed=0)
+        result = AllApplicationsReviewedGuard().evaluate(self._market(), None)
         assert result.passed is False
         assert "no applications" in result.message.lower()
 
@@ -382,30 +357,23 @@ class TestNoApprovedApplicationsGuard:
             ),
         )
 
-    def test_passes_when_no_apps_are_approved(self):
-        market = self._market()
-        db = FakeDB(FakeApplicationsCollection([
-            {"market_id": market.id, "status": "assigned"},
-            {"market_id": market.id, "status": "unassigned"},
-            {"market_id": market.id, "status": "reviewer_rejected"},
-        ]))
-        result = NoApprovedApplicationsGuard().evaluate(market, db)
+    @staticmethod
+    def _patch(monkeypatch, approved_count=0):
+        monkeypatch.setattr(
+            guards.ApplicationsApi,
+            "count_applications_with_status",
+            lambda _market_id, _status: approved_count,
+        )
+
+    def test_passes_when_no_apps_are_approved(self, monkeypatch):
+        self._patch(monkeypatch, approved_count=0)
+        result = NoApprovedApplicationsGuard().evaluate(self._market(), None)
         assert result.passed is True
         assert result.id == "no_approved_applications"
 
-    def test_passes_when_no_apps_exist(self):
-        market = self._market()
-        db = FakeDB(FakeApplicationsCollection([]))
-        result = NoApprovedApplicationsGuard().evaluate(market, db)
-        assert result.passed is True
-
-    def test_fails_when_some_apps_are_still_approved(self):
-        market = self._market()
-        db = FakeDB(FakeApplicationsCollection([
-            {"market_id": market.id, "status": "reviewer_approved"},
-            {"market_id": market.id, "status": "assigned"},
-        ]))
-        result = NoApprovedApplicationsGuard().evaluate(market, db)
+    def test_fails_when_some_apps_are_still_approved(self, monkeypatch):
+        self._patch(monkeypatch, approved_count=2)
+        result = NoApprovedApplicationsGuard().evaluate(self._market(), None)
         assert result.passed is False
         assert "still approved" in result.message.lower()
 

--- a/back-end/tests/test_transition_api.py
+++ b/back-end/tests/test_transition_api.py
@@ -212,7 +212,7 @@ class TestTransitionBlocked:
         assert blocker["id"] == "form_has_fields"
         assert blocker["passed"] is False
         assert blocker["message"]
-        assert blocker["resolutionLink"] == "/markets/market-1/form-builder"
+        assert blocker["resolutionLink"] == "/market-setup"
 
         assert collection.doc["phase"] == "draft"
 
@@ -227,7 +227,7 @@ class TestTransitionBlocked:
         assert body["currentPhase"] == "applications_closed"
         assert body["targetPhase"] == "applications_open"
         assert body["blockers"][0]["id"] == "form_has_fields"
-        assert body["blockers"][0]["resolutionLink"] == "/markets/market-1/form-builder"
+        assert body["blockers"][0]["resolutionLink"] == "/market-setup"
 
         assert collection.doc["phase"] == "applications_closed"
 

--- a/docs/OBJECT_RELATIONSHIPS.md
+++ b/docs/OBJECT_RELATIONSHIPS.md
@@ -91,7 +91,7 @@ The central entity representing a market event with configuration, assignments, 
 - `setup_object: Optional[SetupObject]` - Market configuration and setup data
 - `modification_list: List[ModificationObject]` - List of modifications (currently empty structure)
 - `assignment_object: AssignmentObject` - Contains vendor assignment results and statistics
-- `phase: MarketPhase` - Market lifecycle phase, and the **single source of truth** for where a market is in its life. Default **`DRAFT`**. Advanced only through `POST /markets/<market_id>/transition`. While the market is in `draft`, opening it from the dashboard or Markets sends the user to market setup; past `draft` the SPA routes to `/{kebab-case-slug}` derived from the market **name** (e.g. `my-summer-market`), and the public check-in URL resolves. See [MarketPhase](#marketphase-enum).
+- `phase: MarketPhase` - Market lifecycle phase, and the **single source of truth** for where a market is in its life. Default **`DRAFT`**. Advanced only through `POST /markets/<market_id>/transition`. Every pre-archive phase routes to the setup wizard (`/market-setup`) so the phase controls are reachable; only `archived` routes to the kebab-slug URL (e.g. `my-summer-market`) and the public check-in URL. See [MarketPhase](#marketphase-enum).
 - `is_draft: bool` - Stored as `isDraft` in MongoDB (camelCase). A Pydantic `@computed_field` **derived strictly from `phase`** (`true` exactly when `phase == draft`), never independently writable: no request body can set it, and it is recomputed from the stored phase on every write. It is still persisted, and kept in agreement with `phase` by every writer, for exactly one reason: it is the fallback `phase_from_market_document()` drops to when a document's `phase` is missing or unrecognized. Nothing reads the stored value for a market whose `phase` this build understands - a fallback that disagreed with the phase would answer confidently and wrongly. Treat it as a persisted view of `phase`, never as state of its own.
 - `application_form: Optional[ApplicationForm]` - Application form definition (None if no form has been saved). Server-owned on update: only `PUT /markets/<market_id>/application-form` writes it (see [ApplicationForm](#applicationform))
 - `review_config: Optional[Dict[str, Any]]` - Free-form review configuration (reviewer pool, etc.); no fixed schema yet
@@ -519,17 +519,23 @@ The market lifecycle. A market moves forward through these phases; the phase dri
 
 **Transitions:**
 
-Only these edges exist today (`VALID_TRANSITIONS` in `back-end/guards.py`); every other pair is rejected, and each missing edge lands with the feature that needs it.
-`review`, `assignment`, `offers`, and `market_days` are declared on the enum but no transition enters them yet.
+`VALID_TRANSITIONS` in `back-end/guards.py` defines every permitted edge; anything else is a `400`. The full set:
 
 - `draft` → `applications_open`
-- `draft` → `archived` (**publishing a market**: the Done button at the end of the Generated Assignment flow. A published market reaches its public check-in URL; `archived` is the phase a published pre-`phase` market already reads back as, so the transition and the legacy documents agree. No guards - a market that has an assignment has nothing left to satisfy.)
+- `draft` → `archived` (**publishing a market**: the Done button at the end of the Generated Assignment flow. A published market reaches its public check-in URL; `archived` is the phase a published pre-`phase` market already reads back as, so the transition and the legacy documents agree.)
 - `applications_open` → `applications_closed`
 - `applications_closed` → `applications_open` (reopening the submission window)
+- `applications_closed` → `review`
+- `review` → `applications_closed` (reopening review)
+- `review` → `assignment`
+- `assignment` → `offers`
+- `offers` → `market_days`
+- Archive edges from every pre-archive phase: `applications_open` → `archived`, `applications_closed` → `archived`, `review` → `archived`, `assignment` → `archived`, `offers` → `archived`, `market_days` → `archived`
 
 **Endpoint:**
-- `POST /markets/<market_id>/transition` - Requires `ADMIN`. Body: `{ "toPhase": "applications_open" }`. Returns `200` with `{ "phase": "<new_phase>" }`. `400` on an unknown phase or an edge that is not valid from the market's current phase, `403` on insufficient permission, `404` on an unknown market, `409` when a guard blocks the transition or when the market's phase changed while the request was in flight (the write is a compare-and-set against the phase the request read, so two organizers racing cannot both win). This is the only writer of `Market.phase` on an existing market, and it writes the derived `isDraft` in the same atomic update so the two can never drift apart.
-- **Callers**: `GenerateAssignmentView.vue`'s Done button posts `{ "toPhase": "archived" }` to publish a market, surfacing a `409`'s blocker messages in the Done error rather than a generic "failed to save". Publishing used to be a `PUT` of `isDraft: false`; that route is gone, and this transition is now the only way a market leaves `draft`.
+- `POST /markets/<market_id>/transition` - Requires `ADMIN`. Body: `{ "toPhase": "<phase>" }`. Returns `200` with `{ "phase": "<new_phase>" }`. `400` on an unknown phase or an edge that is not in `VALID_TRANSITIONS`, `403` on insufficient permission, `404` on an unknown market, `409` when a guard blocks the transition or when the market's phase changed while the request was in flight (the write is a compare-and-set against the phase the request read, so two organizers racing cannot both win). This is the only writer of `Market.phase` on an existing market, and it writes the derived `isDraft` in the same atomic update so the two can never drift apart.
+- When transitioning `offers` → `market_days`, the endpoint sweeps all `assignment_sent` applications to `vendor_refused` before returning success.
+- **Callers**: `PhaseControlPanel.vue` mounts the transition endpoint for all phase advances. Previously only `GenerateAssignmentView.vue`'s Done button called it (for `draft` → `archived`); that still works but is no longer the sole caller.
 
 **Guards (the D16 registry):**
 
@@ -539,13 +545,19 @@ Every precondition for every transition lives in `back-end/guards.py` and nowher
 - `PHASE_ENTRY_INVARIANTS` - what must hold of a market *sitting in* a phase, whatever route it took. Every inbound edge to the phase must enforce these.
 - `TRANSITION_GUARDS` - `(from_phase, to_phase)` → the guards that edge evaluates. Keyed by edge rather than by target phase, because a precondition can belong to a route rather than to a phase.
 
-The only guard today is `FormHasFieldsGuard` (`form_has_fields`): the application form must have at least one field, enforced on both edges into `applications_open`.
+Guards implemented:
+
+| Guard | Enforced on | Purpose |
+|-------|-------------|---------|
+| `FormHasFieldsGuard` | Both edges into `applications_open` | Form must have at least one field |
+| `AllApplicationsReviewedGuard` | `review` → `assignment` | Every application must be approved or rejected |
+| `NoApprovedApplicationsGuard` | `assignment` → `offers` | No `reviewer_approved` applications remain |
 
 **Blocker wire shape:**
 
 A failed guard becomes a `PreconditionResult` (`id`, `passed`, `message`, optional `resolution_link`), and the `409` body is `{ error, currentPhase, targetPhase, blockers: PreconditionResult[] }`, camelCased on the wire. The front-end mirrors these as `PreconditionResult` / `TransitionRequest` / `TransitionResponse` / `TransitionBlockedResponse` in `front-end/src/assets/types/datatypes.ts`, and `BlockerPanel.vue` renders the blocker list generically - message plus a "Fix this" link when the guard supplied a `resolutionLink`.
 
-`BlockerPanel` itself still ships ahead of the view that mounts it: the only caller of the transition today is the Done button (`draft` → `archived`), which carries no guards and so can never be blocked. `FormHasFieldsGuard`'s `resolution_link` (`/markets/<market_id>/form-builder`) has no matching route in `front-end/src/router/index.ts` yet either - the form builder is today a tab inside `/market-setup`. Both land with the view that wires up the `applications_open` transition.
+`PhaseControlPanel.vue` is the primary caller of the transition endpoint and renders `BlockerPanel.vue` inline when a guard blocks a transition.
 
 **Relationships:**
 - **Used by Market**: Stored in `Market.phase`, server-owned (see [Market](#market))

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -103,10 +103,10 @@ npm run test:unit
 Tests cover the API client interceptor (automatic `X-Owner-Email` header injection) and
 `parseMarketFromApi()` (`market.test.ts`), which round-trips the market `phase`,
 application form, review config, and Discord guild id, and leaves them undefined when the
-API omits them. The same suite covers `pathAfterLoadingMarket()`, which routes on `phase`
-(draft → the setup wizard, anything past it → the market's public slug) and falls back to
-`isDraft` only for a market cached by a build that predates the field - without that fallback,
-a published market left in `localStorage` would be routed back into the setup wizard.
+API omits them. The same suite covers `pathAfterLoadingMarket()`, which routes every pre-archive phase to the
+setup wizard and only routes `archived` to the market's public slug, falling back to `isDraft`
+only for a market cached by a build that predates the field - without that fallback, a published
+market left in `localStorage` would be routed back into the setup wizard.
 The application form builder is covered by three suites:
 `applicationForm.test.ts` (the shared validator: which forms Save blocks with a hint - a
 field the organizer has not started filling in - versus a validation error such as a bad,

--- a/front-end/.gitignore
+++ b/front-end/.gitignore
@@ -33,3 +33,4 @@ test-results/
 *__pycache__*
 
 *.tsbuildinfo
+e2e-screenshots/

--- a/front-end/e2e/application-form.spec.ts
+++ b/front-end/e2e/application-form.spec.ts
@@ -173,7 +173,7 @@ test.describe('Application form builder', () => {
     await formPage.openFormTab();
     await expect(formPage.lockBanner).toBeVisible();
     await expect(formPage.lockBanner).toContainText('Application form is locked');
-    await expect(formPage.lockBanner).toContainText('1 application(s) already exist');
+    await expect(formPage.lockBanner).toContainText('1 application has already been submitted');
     await expect(formPage.addFieldButton).toHaveCount(0);
     await expect(formPage.saveButton).toHaveCount(0);
     await expect(formPage.removeFieldButton(0)).toHaveCount(0);

--- a/front-end/e2e/helpers/seedPhaseMarket.ts
+++ b/front-end/e2e/helpers/seedPhaseMarket.ts
@@ -1,0 +1,113 @@
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import type { APIRequestContext } from '@playwright/test';
+import { mongoContainer } from './containerNames';
+import { loginViaApi, ensureTestOrgAuthenticated } from './seeds';
+
+const MONGO_URI = 'mongodb://admin:secret@localhost:27017/conventioner?authSource=admin';
+
+export interface PhaseMarketSeed {
+  marketId: string;
+  marketName: string;
+  orgId: string;
+  userId: string;
+}
+
+const TWO_FIELDS = [
+  { key: 'name', label: 'Name', type: 'text', required: false, options: [], order: 0 },
+  { key: 'category', label: 'Category', type: 'text', required: false, options: [], order: 1 },
+];
+
+/**
+ * Create a draft market with an application form (two fields).
+ * Does NOT transition — leaves the market in draft.
+ */
+export async function seedPhaseMarket(
+  request: APIRequestContext,
+  baseURL: string,
+  email: string,
+  password: string,
+): Promise<PhaseMarketSeed> {
+  const userId = await loginViaApi(request, baseURL, email, password);
+  const orgId = await ensureTestOrgAuthenticated(request, baseURL, email);
+
+  const marketName = `E2E Phase ${Date.now()}`;
+  const createRes = await request.post(`${baseURL}/markets`, {
+    headers: { 'Content-Type': 'application/json', 'X-Owner-Email': email },
+    data: {
+      name: marketName,
+      creationDate: new Date().toISOString(),
+      organizationId: orgId,
+      roles: { [userId]: 'owner' },
+      modificationList: [],
+      assignmentObject: {},
+    },
+  });
+  if (!createRes.ok()) {
+    throw new Error(`Market creation failed: ${createRes.status()} ${await createRes.text()}`);
+  }
+  const { market_id: marketId } = (await createRes.json()) as { market_id: string };
+
+  const formRes = await request.put(`${baseURL}/markets/${marketId}/application-form`, {
+    headers: { 'Content-Type': 'application/json', 'X-Owner-Email': email },
+    data: { fields: TWO_FIELDS },
+  });
+  if (!formRes.ok()) {
+    throw new Error(`Form save failed: ${formRes.status()} ${await formRes.text()}`);
+  }
+
+  return { marketId, marketName, orgId, userId };
+}
+
+/**
+ * Transition a market to a target phase via the API.
+ */
+export async function transitionMarket(
+  request: APIRequestContext,
+  baseURL: string,
+  email: string,
+  marketId: string,
+  toPhase: string,
+): Promise<void> {
+  const res = await request.post(`${baseURL}/markets/${marketId}/transition`, {
+    headers: { 'Content-Type': 'application/json', 'X-Owner-Email': email },
+    data: { toPhase },
+  });
+  if (!res.ok()) {
+    throw new Error(`Transition to ${toPhase} failed: ${res.status()} ${await res.text()}`);
+  }
+}
+
+/**
+ * Insert an application document via mongosh with a specific status.
+ */
+export function seedApplicationWithStatus(
+  marketId: string,
+  status: string,
+  applicantEmail = 'applicant@example.com',
+): string {
+  const applicationId = randomUUID();
+  execFileSync(
+    'docker',
+    [
+      'exec',
+      mongoContainer(),
+      'mongosh',
+      MONGO_URI,
+      '--quiet',
+      '--eval',
+      `db.applications.insertOne(${JSON.stringify({
+        id: applicationId,
+        market_id: marketId,
+        applicant_email: applicantEmail,
+        form_data: { name: 'Test App', category: 'Crafts' },
+        status,
+        application_type: 'main',
+        submitted_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })})`,
+    ],
+    { encoding: 'utf-8' },
+  );
+  return applicationId;
+}

--- a/front-end/e2e/phase-state-machine.spec.ts
+++ b/front-end/e2e/phase-state-machine.spec.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { test, expect, TEST_USER, BACKEND_URL } from './fixtures';
 import { mongoContainer } from './helpers/containerNames';
+import type { APIRequestContext, Page } from '@playwright/test';
 import {
   seedPhaseMarket,
   seedApplicationWithStatus,
@@ -10,7 +11,7 @@ import {
 const SCREENSHOT_DIR = 'e2e-screenshots/phase-state-machine';
 const MONGO_URI = 'mongodb://admin:secret@localhost:27017/conventioner?authSource=admin';
 
-async function transitionViaPage(page: any, marketId: string, toPhase: string): Promise<void> {
+async function transitionViaPage(page: Page, marketId: string, toPhase: string): Promise<void> {
   const res = await page.request.post(`${BACKEND_URL}/markets/${marketId}/transition`, {
     headers: { 'Content-Type': 'application/json', 'X-Owner-Email': TEST_USER.email },
     data: { toPhase },
@@ -21,7 +22,7 @@ async function transitionViaPage(page: any, marketId: string, toPhase: string): 
   }
 }
 
-async function loadMarket(page: any, marketId: string): Promise<Record<string, unknown>> {
+async function loadMarket(page: Page, marketId: string): Promise<Record<string, unknown>> {
   const res = await page.request.get(`${BACKEND_URL}/markets/${encodeURIComponent(marketId)}`, {
     headers: { 'X-Owner-Email': TEST_USER.email },
   });
@@ -29,7 +30,7 @@ async function loadMarket(page: any, marketId: string): Promise<Record<string, u
   return json.market as Record<string, unknown>;
 }
 
-function setMarketInPage(page: any, marketBody: Record<string, unknown>) {
+function setMarketInPage(page: Page, marketBody: Record<string, unknown>) {
   return page.evaluate(
     ({ market, user }: { market: Record<string, unknown>; user: string }) => {
       localStorage.setItem('market', JSON.stringify(market));
@@ -53,7 +54,7 @@ function runMongo(evalJs: string): string {
  * then transitions to offers. The market is left in `offers` ready for the
  * sweep transition.
  */
-async function setupMarketToOffers(request: any): Promise<PhaseMarketSeed> {
+async function setupMarketToOffers(request: APIRequestContext): Promise<PhaseMarketSeed> {
   const seed = await seedPhaseMarket(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);
 
   // Navigate to review

--- a/front-end/e2e/phase-state-machine.spec.ts
+++ b/front-end/e2e/phase-state-machine.spec.ts
@@ -1,0 +1,328 @@
+import { execFileSync } from 'node:child_process';
+import { test, expect, TEST_USER, BACKEND_URL } from './fixtures';
+import { mongoContainer } from './helpers/containerNames';
+import {
+  seedPhaseMarket,
+  seedApplicationWithStatus,
+  type PhaseMarketSeed,
+} from './helpers/seedPhaseMarket';
+
+const SCREENSHOT_DIR = 'e2e-screenshots/phase-state-machine';
+const MONGO_URI = 'mongodb://admin:secret@localhost:27017/conventioner?authSource=admin';
+
+async function transitionViaPage(page: any, marketId: string, toPhase: string): Promise<void> {
+  const res = await page.request.post(`${BACKEND_URL}/markets/${marketId}/transition`, {
+    headers: { 'Content-Type': 'application/json', 'X-Owner-Email': TEST_USER.email },
+    data: { toPhase },
+  });
+  if (!res.ok()) {
+    const body = await res.text();
+    throw new Error(`Transition to ${toPhase} failed: ${res.status()} ${body}`);
+  }
+}
+
+async function loadMarket(page: any, marketId: string): Promise<Record<string, unknown>> {
+  const res = await page.request.get(`${BACKEND_URL}/markets/${encodeURIComponent(marketId)}`, {
+    headers: { 'X-Owner-Email': TEST_USER.email },
+  });
+  const json = await res.json();
+  return json.market as Record<string, unknown>;
+}
+
+function setMarketInPage(page: any, marketBody: Record<string, unknown>) {
+  return page.evaluate(
+    ({ market, user }: { market: Record<string, unknown>; user: string }) => {
+      localStorage.setItem('market', JSON.stringify(market));
+      localStorage.setItem('user', JSON.stringify(user));
+    },
+    { market: marketBody, user: TEST_USER.email },
+  );
+}
+
+function runMongo(evalJs: string): string {
+  return execFileSync(
+    'docker',
+    ['exec', mongoContainer(), 'mongosh', MONGO_URI, '--quiet', '--eval', evalJs],
+    { encoding: 'utf-8' },
+  ).trim();
+}
+
+/**
+ * Seed a market and navigate it to the `offers` phase via the API.
+ * Seeds approved applications, transitions to assignment, resolves them,
+ * then transitions to offers. The market is left in `offers` ready for the
+ * sweep transition.
+ */
+async function setupMarketToOffers(request: any): Promise<PhaseMarketSeed> {
+  const seed = await seedPhaseMarket(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);
+
+  // Navigate to review
+  await request.post(`${BACKEND_URL}/markets/${seed.marketId}/transition`, {
+    headers: { 'Content-Type': 'application/json', 'X-Owner-Email': TEST_USER.email },
+    data: { toPhase: 'applications_open' },
+  });
+  await request.post(`${BACKEND_URL}/markets/${seed.marketId}/transition`, {
+    headers: { 'Content-Type': 'application/json', 'X-Owner-Email': TEST_USER.email },
+    data: { toPhase: 'applications_closed' },
+  });
+  await request.post(`${BACKEND_URL}/markets/${seed.marketId}/transition`, {
+    headers: { 'Content-Type': 'application/json', 'X-Owner-Email': TEST_USER.email },
+    data: { toPhase: 'review' },
+  });
+
+  // Seed approved applications so assignment guard passes
+  const appId = seedApplicationWithStatus(
+    seed.marketId,
+    'reviewer_approved',
+    'sweep-setup@example.com',
+  );
+
+  await request.post(`${BACKEND_URL}/markets/${seed.marketId}/transition`, {
+    headers: { 'Content-Type': 'application/json', 'X-Owner-Email': TEST_USER.email },
+    data: { toPhase: 'assignment' },
+  });
+
+  // Resolve the approved app so offers guard passes
+  runMongo(
+    `db.applications.updateOne({id: ${JSON.stringify(appId)}}, {$set: {status: "assigned"}})`,
+  );
+
+  await request.post(`${BACKEND_URL}/markets/${seed.marketId}/transition`, {
+    headers: { 'Content-Type': 'application/json', 'X-Owner-Email': TEST_USER.email },
+    data: { toPhase: 'offers' },
+  });
+
+  return seed;
+}
+
+test.describe('Phase state machine - full walk', () => {
+  let seed: PhaseMarketSeed;
+
+  test.beforeAll(async ({ request }) => {
+    seed = await seedPhaseMarket(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);
+  });
+
+  test('walk draft -> applications_open -> applications_closed -> review -> assignment -> offers -> market_days', async ({
+    authenticatedPage: page,
+  }) => {
+    const marketBody = await loadMarket(page, seed.marketId);
+    await setMarketInPage(page, marketBody);
+    await page.goto('/market-setup');
+    await expect(page.locator('.market-setup-view')).toBeVisible({ timeout: 15000 });
+
+    await expect(page.getByTestId('phase-control-panel')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('phase-control-current-phase')).toHaveText('Draft');
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/01-draft.png`, fullPage: true });
+
+    await page.getByTestId('phase-transition-applications_open').click();
+    await expect(page.getByTestId('phase-control-current-phase')).toHaveText('Applications Open', {
+      timeout: 10000,
+    });
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/02-applications-open.png`, fullPage: true });
+
+    await page.getByTestId('phase-transition-applications_closed').click();
+    await expect(page.getByTestId('phase-control-current-phase')).toHaveText(
+      'Applications Closed',
+      { timeout: 10000 },
+    );
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/03-applications-closed.png`, fullPage: true });
+
+    await page.getByTestId('phase-transition-review').click();
+    await expect(page.getByTestId('phase-control-current-phase')).toHaveText('Review', {
+      timeout: 10000,
+    });
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/04-review.png`, fullPage: true });
+
+    seedApplicationWithStatus(seed.marketId, 'reviewer_approved', 'walk-a@example.com');
+    seedApplicationWithStatus(seed.marketId, 'reviewer_approved', 'walk-b@example.com');
+
+    await page.getByTestId('phase-transition-assignment').click();
+    await expect(page.getByTestId('phase-control-current-phase')).toHaveText('Assignment', {
+      timeout: 10000,
+    });
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/05-assignment.png`, fullPage: true });
+
+    runMongo(
+      `db.applications.updateMany({market_id: ${JSON.stringify(seed.marketId)}, status: "reviewer_approved"}, {$set: {status: "assigned"}})`,
+    );
+
+    await page.getByTestId('phase-transition-offers').click();
+    await expect(page.getByTestId('phase-control-current-phase')).toHaveText('Offers', {
+      timeout: 10000,
+    });
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/06-offers.png`, fullPage: true });
+
+    await page.getByTestId('phase-transition-market_days').click();
+    await expect(page.getByTestId('phase-control-current-phase')).toHaveText('Market Days', {
+      timeout: 10000,
+    });
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/07-market-days.png`, fullPage: true });
+
+    await expect(page.getByTestId('phase-transition-archived')).toBeVisible();
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/08-ready-to-archive.png`, fullPage: true });
+  });
+});
+
+test.describe('Phase state machine - guard: assignment blocked by unreviewed apps', () => {
+  let seed: PhaseMarketSeed;
+
+  test.beforeAll(async ({ request }) => {
+    seed = await seedPhaseMarket(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);
+  });
+
+  test('cannot enter assignment while applications are still open', async ({
+    authenticatedPage: page,
+  }) => {
+    await transitionViaPage(page, seed.marketId, 'applications_open');
+    await transitionViaPage(page, seed.marketId, 'applications_closed');
+    await transitionViaPage(page, seed.marketId, 'review');
+
+    seedApplicationWithStatus(seed.marketId, 'reviewer_approved', 'guard-a@example.com');
+    seedApplicationWithStatus(seed.marketId, 'open', 'guard-b@example.com');
+
+    const marketBody = await loadMarket(page, seed.marketId);
+    await setMarketInPage(page, marketBody);
+    await page.goto('/market-setup');
+    await expect(page.locator('.market-setup-view')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('phase-control-current-phase')).toHaveText('Review', {
+      timeout: 10000,
+    });
+
+    await page.getByTestId('phase-transition-assignment').click();
+
+    const blockers = page.getByTestId('phase-control-blockers');
+    await expect(blockers).toBeVisible({ timeout: 10000 });
+    await expect(blockers).toContainText('still awaiting review');
+    await expect(page.getByTestId('phase-control-current-phase')).toHaveText('Review');
+
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/09-blocked-assignment.png`, fullPage: true });
+  });
+});
+
+test.describe('Phase state machine - guard: offers blocked by leftover approved', () => {
+  let seed: PhaseMarketSeed;
+
+  test.beforeAll(async ({ request }) => {
+    seed = await seedPhaseMarket(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);
+  });
+
+  test('cannot enter offers while approved applications remain', async ({
+    authenticatedPage: page,
+  }) => {
+    await transitionViaPage(page, seed.marketId, 'applications_open');
+    await transitionViaPage(page, seed.marketId, 'applications_closed');
+    await transitionViaPage(page, seed.marketId, 'review');
+
+    seedApplicationWithStatus(seed.marketId, 'reviewer_approved', 'offer-a@example.com');
+    seedApplicationWithStatus(seed.marketId, 'reviewer_approved', 'offer-b@example.com');
+
+    await transitionViaPage(page, seed.marketId, 'assignment');
+
+    const marketBody = await loadMarket(page, seed.marketId);
+    await setMarketInPage(page, marketBody);
+    await page.goto('/market-setup');
+    await expect(page.locator('.market-setup-view')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('phase-control-current-phase')).toHaveText('Assignment', {
+      timeout: 10000,
+    });
+
+    await page.getByTestId('phase-transition-offers').click();
+
+    const blockers = page.getByTestId('phase-control-blockers');
+    await expect(blockers).toBeVisible({ timeout: 10000 });
+    await expect(blockers).toContainText('still approved');
+    await expect(page.getByTestId('phase-control-current-phase')).toHaveText('Assignment');
+
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/10-blocked-offers.png`, fullPage: true });
+  });
+});
+
+test.describe('Phase state machine - sweep', () => {
+  let seed: PhaseMarketSeed;
+
+  test.beforeAll(async ({ request }) => {
+    seed = await setupMarketToOffers(request);
+  });
+
+  test('offers -> market_days sweeps assignment_sent to vendor_refused, leaves vendor_accepted alone', async ({
+    authenticatedPage: page,
+  }) => {
+    seedApplicationWithStatus(seed.marketId, 'assignment_sent', 'sweep-sent@example.com');
+    seedApplicationWithStatus(seed.marketId, 'vendor_accepted', 'sweep-accepted@example.com');
+
+    await transitionViaPage(page, seed.marketId, 'market_days');
+
+    function queryStatus(appEmail: string): string {
+      return runMongo(
+        `db.applications.findOne({applicant_email: ${JSON.stringify(appEmail)}, market_id: ${JSON.stringify(seed.marketId)}}, {status: 1}).status`,
+      );
+    }
+
+    expect(queryStatus('sweep-sent@example.com')).toBe('vendor_refused');
+    expect(queryStatus('sweep-accepted@example.com')).toBe('vendor_accepted');
+
+    const marketBody = await loadMarket(page, seed.marketId);
+    await setMarketInPage(page, marketBody);
+    await page.goto('/market-setup');
+    await expect(page.getByTestId('phase-control-current-phase')).toHaveText('Market Days', {
+      timeout: 10000,
+    });
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/11-market-days-after-sweep.png`,
+      fullPage: true,
+    });
+  });
+});
+
+test.describe('Phase state machine - archive confirmation', () => {
+  let seed: PhaseMarketSeed;
+
+  test.beforeAll(async ({ request }) => {
+    seed = await seedPhaseMarket(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);
+  });
+
+  test('archive shows confirmation, cancel preserves phase, confirm archives', async ({
+    authenticatedPage: page,
+  }) => {
+    await transitionViaPage(page, seed.marketId, 'applications_open');
+
+    const marketBody = await loadMarket(page, seed.marketId);
+    await setMarketInPage(page, marketBody);
+
+    await page.goto('/market-setup');
+    await expect(page.locator('.market-setup-view')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('phase-control-current-phase')).toHaveText('Applications Open', {
+      timeout: 10000,
+    });
+
+    const archiveBtn = page.getByTestId('phase-transition-archived');
+    await expect(archiveBtn).toBeVisible();
+    await archiveBtn.click();
+
+    const dialog = page.getByTestId('archive-confirm-dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await expect(dialog).toContainText('Archive this market?');
+
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/12-archive-confirmation.png`,
+      fullPage: true,
+    });
+
+    // Cancel
+    await page.getByTestId('archive-confirm-cancel').click();
+    await expect(dialog).not.toBeVisible({ timeout: 3000 });
+    await expect(page.getByTestId('phase-control-current-phase')).toHaveText('Applications Open');
+
+    // Confirm
+    await archiveBtn.click();
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await page.getByTestId('archive-confirm-confirm').click();
+    await expect(dialog).not.toBeVisible({ timeout: 3000 });
+    await expect(page.getByTestId('phase-control-current-phase')).toHaveText('Archived', {
+      timeout: 10000,
+    });
+    await expect(page.getByTestId('phase-control-terminal')).toBeVisible();
+
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/13-archived.png`, fullPage: true });
+  });
+});

--- a/front-end/e2e/phase-state-machine.spec.ts
+++ b/front-end/e2e/phase-state-machine.spec.ts
@@ -247,10 +247,11 @@ test.describe('Phase state machine - sweep', () => {
   test('offers -> market_days sweeps assignment_sent to vendor_refused, leaves vendor_accepted alone', async ({
     authenticatedPage: page,
   }) => {
-    seedApplicationWithStatus(seed.marketId, 'assignment_sent', 'sweep-sent@example.com');
-    seedApplicationWithStatus(seed.marketId, 'vendor_accepted', 'sweep-accepted@example.com');
+    const sentEmail = 'sweep-sent@example.com';
+    const acceptedEmail = 'sweep-accepted@example.com';
 
-    await transitionViaPage(page, seed.marketId, 'market_days');
+    seedApplicationWithStatus(seed.marketId, 'assignment_sent', sentEmail);
+    seedApplicationWithStatus(seed.marketId, 'vendor_accepted', acceptedEmail);
 
     function queryStatus(appEmail: string): string {
       return runMongo(
@@ -258,9 +259,58 @@ test.describe('Phase state machine - sweep', () => {
       );
     }
 
-    expect(queryStatus('sweep-sent@example.com')).toBe('vendor_refused');
-    expect(queryStatus('sweep-accepted@example.com')).toBe('vendor_accepted');
+    const beforeSent = queryStatus(sentEmail);
+    const beforeAccepted = queryStatus(acceptedEmail);
 
+    // Render a status page that proves the before/after states
+    await page.setContent(`
+      <html><body style="font-family:monospace;font-size:16px;padding:40px;background:#fff">
+        <h1>Sweep test — application states</h1>
+        <h2>Before transition (offers phase)</h2>
+        <table border="1" cellpadding="8" cellspacing="0" style="border-collapse:collapse">
+          <tr><th>Email</th><th>Status</th></tr>
+          <tr><td>${sentEmail}</td><td style="font-weight:bold;color:#b91c1c">${beforeSent}</td></tr>
+          <tr><td>${acceptedEmail}</td><td style="font-weight:bold;color:#15803d">${beforeAccepted}</td></tr>
+        </table>
+      </body></html>
+    `);
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/11a-sweep-before.png`, fullPage: true });
+
+    // Perform the sweep transition
+    await transitionViaPage(page, seed.marketId, 'market_days');
+
+    const afterSent = queryStatus(sentEmail);
+    const afterAccepted = queryStatus(acceptedEmail);
+
+    expect(afterSent).toBe('vendor_refused');
+    expect(afterAccepted).toBe('vendor_accepted');
+
+    await page.setContent(`
+      <html><body style="font-family:monospace;font-size:16px;padding:40px;background:#fff">
+        <h1>Sweep test — application states</h1>
+        <h2>After transition to market_days</h2>
+        <table border="1" cellpadding="8" cellspacing="0" style="border-collapse:collapse">
+          <tr><th>Email</th><th>Status</th><th>Expected?</th></tr>
+          <tr>
+            <td>${sentEmail}</td>
+            <td style="font-weight:bold;color:${afterSent === 'vendor_refused' ? '#15803d' : '#b91c1c'}">${afterSent}</td>
+            <td>vendor_refused</td>
+          </tr>
+          <tr>
+            <td>${acceptedEmail}</td>
+            <td style="font-weight:bold;color:${afterAccepted === 'vendor_accepted' ? '#15803d' : '#b91c1c'}">${afterAccepted}</td>
+            <td>vendor_accepted</td>
+          </tr>
+        </table>
+        <p style="margin-top:20px">
+          assignment_sent ${afterSent === 'vendor_refused' ? 'was' : 'was NOT'} swept to vendor_refused.
+          vendor_accepted ${afterAccepted === 'vendor_accepted' ? 'was' : 'was NOT'} left untouched.
+        </p>
+      </body></html>
+    `);
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/11b-sweep-after.png`, fullPage: true });
+
+    // Also show the market_days UI
     const marketBody = await loadMarket(page, seed.marketId);
     await setMarketInPage(page, marketBody);
     await page.goto('/market-setup');
@@ -268,7 +318,7 @@ test.describe('Phase state machine - sweep', () => {
       timeout: 10000,
     });
     await page.screenshot({
-      path: `${SCREENSHOT_DIR}/11-market-days-after-sweep.png`,
+      path: `${SCREENSHOT_DIR}/11c-market-days-after-sweep.png`,
       fullPage: true,
     });
   });

--- a/front-end/e2e/phase-state-machine.spec.ts
+++ b/front-end/e2e/phase-state-machine.spec.ts
@@ -153,6 +153,15 @@ test.describe('Phase state machine - full walk', () => {
     await page.screenshot({ path: `${SCREENSHOT_DIR}/06-offers.png`, fullPage: true });
 
     await page.getByTestId('phase-transition-market_days').click();
+    // Sweep confirmation dialog should appear
+    const sweepDialog = page.getByTestId('sweep-confirm-dialog');
+    await expect(sweepDialog).toBeVisible({ timeout: 5000 });
+    await expect(sweepDialog).toContainText('Begin Market Days');
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/06b-sweep-confirmation.png`,
+      fullPage: true,
+    });
+    await page.getByTestId('sweep-confirm-confirm').click();
     await expect(page.getByTestId('phase-control-current-phase')).toHaveText('Market Days', {
       timeout: 10000,
     });

--- a/front-end/src/__tests__/market.test.ts
+++ b/front-end/src/__tests__/market.test.ts
@@ -63,9 +63,30 @@ describe('pathAfterLoadingMarket', () => {
     );
   });
 
-  it('sends a market past draft to its public slug', () => {
+  it('routes archived markets to their public slug', () => {
     expect(pathAfterLoadingMarket(market({ phase: MarketPhase.Archived, isDraft: false }))).toBe(
       '/test-market',
+    );
+  });
+
+  it('routes pre-archive phases to /market-setup so phase controls are reachable', () => {
+    expect(
+      pathAfterLoadingMarket(market({ phase: MarketPhase.ApplicationsOpen, isDraft: false })),
+    ).toBe('/market-setup');
+    expect(
+      pathAfterLoadingMarket(market({ phase: MarketPhase.ApplicationsClosed, isDraft: false })),
+    ).toBe('/market-setup');
+    expect(pathAfterLoadingMarket(market({ phase: MarketPhase.Review, isDraft: false }))).toBe(
+      '/market-setup',
+    );
+    expect(pathAfterLoadingMarket(market({ phase: MarketPhase.Assignment, isDraft: false }))).toBe(
+      '/market-setup',
+    );
+    expect(pathAfterLoadingMarket(market({ phase: MarketPhase.Offers, isDraft: false }))).toBe(
+      '/market-setup',
+    );
+    expect(pathAfterLoadingMarket(market({ phase: MarketPhase.MarketDays, isDraft: false }))).toBe(
+      '/market-setup',
     );
   });
 

--- a/front-end/src/components/PhaseControlPanel.vue
+++ b/front-end/src/components/PhaseControlPanel.vue
@@ -74,15 +74,27 @@ const isTerminal = computed(() => currentPhase.value === MarketPhase.Archived);
 
 function transitionLabel(toPhase: string): string {
   if (toPhase === MarketPhase.Archived) return 'Archive Market';
-  if (toPhase === MarketPhase.ApplicationsOpen) return 'Reopen Applications';
-  if (toPhase === MarketPhase.ApplicationsClosed) return 'Return to Applications Closed';
+
+  if (toPhase === MarketPhase.ApplicationsOpen) {
+    return currentPhase.value === MarketPhase.Draft ? 'Open Applications' : 'Reopen Applications';
+  }
+  if (toPhase === MarketPhase.ApplicationsClosed) {
+    return currentPhase.value === MarketPhase.ApplicationsOpen
+      ? 'Close Applications'
+      : 'Return to Applications Closed';
+  }
   return TRANSITION_LABELS[toPhase] ?? `Move to ${PHASE_LABELS[toPhase] ?? toPhase}`;
 }
 
 function transitionVariant(toPhase: string): string {
   if (toPhase === MarketPhase.Archived) return 'danger';
-  if (toPhase === MarketPhase.ApplicationsOpen || toPhase === MarketPhase.ApplicationsClosed)
-    return 'back';
+
+  if (toPhase === MarketPhase.ApplicationsOpen) {
+    return currentPhase.value === MarketPhase.Draft ? 'advance' : 'back';
+  }
+  if (toPhase === MarketPhase.ApplicationsClosed) {
+    return currentPhase.value === MarketPhase.ApplicationsOpen ? 'advance' : 'back';
+  }
   return 'advance';
 }
 

--- a/front-end/src/components/PhaseControlPanel.vue
+++ b/front-end/src/components/PhaseControlPanel.vue
@@ -1,0 +1,457 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { Market, PreconditionResult } from '@/assets/types/datatypes';
+import { MarketPhase } from '@/assets/types/datatypes';
+import { api } from '@/utils/api';
+import { parseMarketFromApi } from '@/utils/market';
+import BlockerPanel from '@/components/BlockerPanel.vue';
+
+const props = defineProps<{
+  market: Market | null;
+}>();
+
+const emit = defineEmits<{
+  phaseAdvanced: [market: Market];
+}>();
+
+const showingArchiveConfirm = ref(false);
+const archiveTargetPhase = ref('');
+const transitionError = ref('');
+const transitionBlockers = ref<PreconditionResult[]>([]);
+const transitioning = ref(false);
+
+const PHASE_LABELS: Record<string, string> = {
+  [MarketPhase.Draft]: 'Draft',
+  [MarketPhase.ApplicationsOpen]: 'Applications Open',
+  [MarketPhase.ApplicationsClosed]: 'Applications Closed',
+  [MarketPhase.Review]: 'Review',
+  [MarketPhase.Assignment]: 'Assignment',
+  [MarketPhase.Offers]: 'Offers',
+  [MarketPhase.MarketDays]: 'Market Days',
+  [MarketPhase.Archived]: 'Archived',
+};
+
+const TRANSITION_LABELS: Record<string, string> = {
+  [MarketPhase.ApplicationsOpen]: 'Open Applications',
+  [MarketPhase.ApplicationsClosed]: 'Close Applications',
+  [MarketPhase.Review]: 'Begin Review',
+  [MarketPhase.Assignment]: 'Begin Assignment',
+  [MarketPhase.Offers]: 'Send Offers',
+  [MarketPhase.MarketDays]: 'Begin Market Days',
+  [MarketPhase.Archived]: 'Archive Market',
+};
+
+const TRANSITION_VARIANTS: Record<string, string> = {
+  [MarketPhase.ApplicationsOpen]: 'advance',
+  [MarketPhase.ApplicationsClosed]: 'advance',
+  [MarketPhase.Review]: 'advance',
+  [MarketPhase.Assignment]: 'advance',
+  [MarketPhase.Offers]: 'advance',
+  [MarketPhase.MarketDays]: 'advance',
+  [MarketPhase.Archived]: 'danger',
+};
+
+/** Frontend mirror of guards.py VALID_TRANSITIONS -- single source of truth for UI routing. */
+const VALID_TRANSITIONS: Array<[string, string]> = [
+  ['draft', 'applications_open'],
+  ['draft', 'archived'],
+  ['applications_open', 'applications_closed'],
+  ['applications_open', 'archived'],
+  ['applications_closed', 'applications_open'],
+  ['applications_closed', 'review'],
+  ['applications_closed', 'archived'],
+  ['review', 'applications_closed'],
+  ['review', 'assignment'],
+  ['review', 'archived'],
+  ['assignment', 'offers'],
+  ['assignment', 'archived'],
+  ['offers', 'market_days'],
+  ['offers', 'archived'],
+  ['market_days', 'archived'],
+];
+
+const currentPhase = computed(() => props.market?.phase ?? MarketPhase.Draft);
+
+const phaseLabel = computed(() => PHASE_LABELS[currentPhase.value] ?? currentPhase.value);
+
+const availableTransitions = computed(() => {
+  if (!props.market) return [];
+  const fromPhase = currentPhase.value;
+  return VALID_TRANSITIONS.filter(([from]) => from === fromPhase).map(([, to]) => to);
+});
+
+const isTerminal = computed(() => currentPhase.value === MarketPhase.Archived);
+
+function transitionLabel(toPhase: string): string {
+  if (toPhase === MarketPhase.Archived) return 'Archive Market';
+  if (toPhase === MarketPhase.ApplicationsOpen) return 'Reopen Applications';
+  if (toPhase === MarketPhase.ApplicationsClosed) return 'Return to Applications Closed';
+  return TRANSITION_LABELS[toPhase] ?? `Move to ${PHASE_LABELS[toPhase] ?? toPhase}`;
+}
+
+function transitionVariant(toPhase: string): string {
+  if (toPhase === MarketPhase.Archived) return 'danger';
+  if (toPhase === MarketPhase.ApplicationsOpen || toPhase === MarketPhase.ApplicationsClosed)
+    return 'back';
+  return 'advance';
+}
+
+async function doTransition(toPhase: string) {
+  if (!props.market) return;
+  transitioning.value = true;
+  transitionError.value = '';
+  transitionBlockers.value = [];
+
+  try {
+    const response = await api.post(`/markets/${encodeURIComponent(props.market.id)}/transition`, {
+      toPhase,
+    });
+    const updatedMarket = {
+      ...props.market,
+      phase: response.data.phase,
+    };
+
+    // Refresh from server so localStorage / local state stays current.
+    try {
+      const full = await api.get(`/markets/${encodeURIComponent(props.market.id)}`);
+      const fresh = parseMarketFromApi(full.data.market);
+      localStorage.setItem('market', JSON.stringify(fresh));
+      emit('phaseAdvanced', fresh);
+    } catch {
+      localStorage.setItem('market', JSON.stringify(updatedMarket));
+      emit('phaseAdvanced', updatedMarket);
+    }
+  } catch (err: unknown) {
+    const response =
+      err && typeof err === 'object' && 'response' in err
+        ? (
+            err as {
+              response?: {
+                status?: number;
+                data?: { error?: string; blockers?: PreconditionResult[] };
+              };
+            }
+          ).response
+        : undefined;
+
+    if (response?.status === 409 && response.data?.blockers) {
+      transitionBlockers.value = response.data.blockers;
+    } else {
+      const msg = response?.data?.error;
+      transitionError.value = msg || 'Failed to advance market phase.';
+    }
+  } finally {
+    transitioning.value = false;
+  }
+}
+
+function handleTransitionClick(toPhase: string) {
+  if (toPhase === MarketPhase.Archived) {
+    archiveTargetPhase.value = toPhase;
+    showingArchiveConfirm.value = true;
+  } else {
+    doTransition(toPhase);
+  }
+}
+
+function confirmArchive() {
+  showingArchiveConfirm.value = false;
+  doTransition(archiveTargetPhase.value);
+}
+
+function cancelArchive() {
+  showingArchiveConfirm.value = false;
+  archiveTargetPhase.value = '';
+}
+</script>
+
+<template>
+  <div v-if="market" class="phase-control-panel" data-testid="phase-control-panel">
+    <div class="phase-info">
+      <span class="phase-label-text">Current Phase:</span>
+      <span
+        class="phase-badge"
+        :class="`phase-${currentPhase}`"
+        data-testid="phase-control-current-phase"
+      >
+        {{ phaseLabel }}
+      </span>
+    </div>
+
+    <div v-if="!isTerminal && availableTransitions.length > 0" class="phase-actions">
+      <span class="phase-label-text">Advance to:</span>
+      <div class="phase-buttons">
+        <button
+          v-for="toPhase in availableTransitions"
+          :key="toPhase"
+          class="phase-transition-button"
+          :class="`variant-${transitionVariant(toPhase)}`"
+          :disabled="transitioning"
+          :data-testid="`phase-transition-${toPhase}`"
+          @click="handleTransitionClick(toPhase)"
+        >
+          {{ transitionLabel(toPhase) }}
+        </button>
+      </div>
+    </div>
+
+    <p v-if="isTerminal" class="terminal-note" data-testid="phase-control-terminal">
+      This market is archived and read-only.
+    </p>
+
+    <p v-if="transitionError" class="transition-error" data-testid="phase-control-error">
+      {{ transitionError }}
+    </p>
+
+    <BlockerPanel
+      v-if="transitionBlockers.length"
+      :blockers="transitionBlockers"
+      data-testid="phase-control-blockers"
+    />
+  </div>
+
+  <!-- Archive confirmation dialog -->
+  <Teleport to="body">
+    <div
+      v-if="showingArchiveConfirm"
+      class="archive-confirm-overlay"
+      data-testid="archive-confirm-overlay"
+    >
+      <div class="archive-confirm-dialog" data-testid="archive-confirm-dialog">
+        <h3>Archive this market?</h3>
+        <p>
+          Archiving is permanent. Once archived, a market cannot be edited or returned to an active
+          phase. This action cannot be undone.
+        </p>
+        <div class="archive-confirm-buttons">
+          <button
+            class="confirm-archive-button"
+            :disabled="transitioning"
+            data-testid="archive-confirm-confirm"
+            @click="confirmArchive"
+          >
+            Archive
+          </button>
+          <button
+            class="cancel-archive-button"
+            :disabled="transitioning"
+            data-testid="archive-confirm-cancel"
+            @click="cancelArchive"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.phase-control-panel {
+  width: 100%;
+  padding: 0 40px;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
+  min-height: 48px;
+}
+
+.phase-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.phase-label-text {
+  font-family: 'Outfit Regular', sans-serif;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.phase-badge {
+  padding: 4px 14px;
+  border-radius: 20px;
+  font-family: 'Outfit Regular', sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  color: white;
+  text-transform: capitalize;
+}
+
+.phase-draft {
+  background: #6b7280;
+}
+.phase-applications_open {
+  background: #3b82f6;
+}
+.phase-applications_closed {
+  background: #f59e0b;
+}
+.phase-review {
+  background: #8b5cf6;
+}
+.phase-assignment {
+  background: #06b6d4;
+}
+.phase-offers {
+  background: #ec4899;
+}
+.phase-market_days {
+  background: #10b981;
+}
+.phase-archived {
+  background: #374151;
+}
+
+.phase-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.phase-buttons {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.phase-transition-button {
+  padding: 5px 14px;
+  border-radius: 6px;
+  border: none;
+  font-family: 'Outfit Regular', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  color: white;
+}
+
+.phase-transition-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.variant-advance {
+  background: var(--mm-green, #48ab91);
+}
+.variant-advance:hover:not(:disabled) {
+  background: #3a9a82;
+}
+
+.variant-back {
+  background: #6b7280;
+}
+.variant-back:hover:not(:disabled) {
+  background: #4b5563;
+}
+
+.variant-danger {
+  background: #dc2626;
+}
+.variant-danger:hover:not(:disabled) {
+  background: #b91c1c;
+}
+
+.terminal-note {
+  font-family: 'Outfit Regular', sans-serif;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.5);
+  margin: 0;
+}
+
+.transition-error {
+  font-family: 'Outfit Regular', sans-serif;
+  font-size: 13px;
+  color: #fca5a5;
+  margin: 0;
+}
+
+/* Archive confirmation overlay */
+.archive-confirm-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.archive-confirm-dialog {
+  background: white;
+  border-radius: 12px;
+  padding: 32px;
+  max-width: 440px;
+  width: 90%;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.25);
+}
+
+.archive-confirm-dialog h3 {
+  margin: 0 0 12px;
+  font-family: 'Outfit Regular', sans-serif;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--mm-black, #1a1a1a);
+}
+
+.archive-confirm-dialog p {
+  margin: 0 0 24px;
+  font-family: 'Outfit Regular', sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #4b5563;
+}
+
+.archive-confirm-buttons {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.confirm-archive-button {
+  padding: 8px 20px;
+  font-size: 14px;
+  background: #dc2626;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Outfit Regular', sans-serif;
+  font-weight: 500;
+}
+
+.confirm-archive-button:hover:not(:disabled) {
+  background: #b91c1c;
+}
+
+.confirm-archive-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.cancel-archive-button {
+  padding: 8px 20px;
+  font-size: 14px;
+  background: #e5e7eb;
+  color: #374151;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Outfit Regular', sans-serif;
+  font-weight: 500;
+}
+
+.cancel-archive-button:hover:not(:disabled) {
+  background: #d1d5db;
+}
+
+.cancel-archive-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+</style>

--- a/front-end/src/components/PhaseControlPanel.vue
+++ b/front-end/src/components/PhaseControlPanel.vue
@@ -16,6 +16,9 @@ const emit = defineEmits<{
 
 const showingArchiveConfirm = ref(false);
 const archiveTargetPhase = ref('');
+const showingSweepConfirm = ref(false);
+const sweepPendingCount = ref(0);
+const sweepConfirmLoading = ref(false);
 const transitionError = ref('');
 const transitionBlockers = ref<PreconditionResult[]>([]);
 const transitioning = ref(false);
@@ -150,9 +153,37 @@ function handleTransitionClick(toPhase: string) {
   if (toPhase === MarketPhase.Archived) {
     archiveTargetPhase.value = toPhase;
     showingArchiveConfirm.value = true;
+  } else if (toPhase === MarketPhase.MarketDays) {
+    openSweepConfirm();
   } else {
     doTransition(toPhase);
   }
+}
+
+async function openSweepConfirm() {
+  if (!props.market) return;
+  sweepConfirmLoading.value = true;
+  try {
+    const res = await api.get(
+      `/markets/${encodeURIComponent(props.market.id)}/pending-offers-count`,
+    );
+    sweepPendingCount.value = res.data.count ?? 0;
+  } catch {
+    sweepPendingCount.value = 0;
+  } finally {
+    sweepConfirmLoading.value = false;
+  }
+  showingSweepConfirm.value = true;
+}
+
+function confirmSweep() {
+  showingSweepConfirm.value = false;
+  doTransition(MarketPhase.MarketDays);
+}
+
+function cancelSweep() {
+  showingSweepConfirm.value = false;
+  sweepPendingCount.value = 0;
 }
 
 function confirmArchive() {
@@ -212,8 +243,47 @@ function cancelArchive() {
     />
   </div>
 
-  <!-- Archive confirmation dialog -->
+  <!-- Sweep confirmation dialog -->
   <Teleport to="body">
+    <div
+      v-if="showingSweepConfirm"
+      class="archive-confirm-overlay"
+      data-testid="sweep-confirm-overlay"
+    >
+      <div class="archive-confirm-dialog" data-testid="sweep-confirm-dialog">
+        <h3>Begin Market Days?</h3>
+        <p v-if="sweepConfirmLoading">Checking pending offers...</p>
+        <p v-else>
+          <template v-if="sweepPendingCount === 0">
+            No offers are pending — no vendors will be marked refused.
+          </template>
+          <template v-else>
+            {{ sweepPendingCount }} offer{{ sweepPendingCount === 1 ? '' : 's' }}
+            will be marked as refused. This cannot be undone.
+          </template>
+        </p>
+        <div class="archive-confirm-buttons">
+          <button
+            class="confirm-archive-button"
+            :disabled="transitioning || sweepConfirmLoading"
+            data-testid="sweep-confirm-confirm"
+            @click="confirmSweep"
+          >
+            Begin Market Days
+          </button>
+          <button
+            class="cancel-archive-button"
+            :disabled="transitioning"
+            data-testid="sweep-confirm-cancel"
+            @click="cancelSweep"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Archive confirmation dialog -->
     <div
       v-if="showingArchiveConfirm"
       class="archive-confirm-overlay"

--- a/front-end/src/components/PhaseControlPanel.vue
+++ b/front-end/src/components/PhaseControlPanel.vue
@@ -18,6 +18,7 @@ const showingArchiveConfirm = ref(false);
 const archiveTargetPhase = ref('');
 const showingSweepConfirm = ref(false);
 const sweepPendingCount = ref(0);
+const sweepCountUnknown = ref(false);
 const sweepConfirmLoading = ref(false);
 const transitionError = ref('');
 const transitionBlockers = ref<PreconditionResult[]>([]);
@@ -114,6 +115,7 @@ async function doTransition(toPhase: string) {
     const updatedMarket = {
       ...props.market,
       phase: response.data.phase,
+      isDraft: response.data.phase === MarketPhase.Draft,
     };
 
     try {
@@ -163,6 +165,7 @@ function handleTransitionClick(toPhase: string) {
 async function openSweepConfirm() {
   if (!props.market) return;
   sweepConfirmLoading.value = true;
+  sweepCountUnknown.value = false;
   showingSweepConfirm.value = true;
   try {
     const res = await api.get(
@@ -171,6 +174,7 @@ async function openSweepConfirm() {
     sweepPendingCount.value = res.data.count ?? 0;
   } catch {
     sweepPendingCount.value = 0;
+    sweepCountUnknown.value = true;
   } finally {
     sweepConfirmLoading.value = false;
   }
@@ -184,6 +188,7 @@ function confirmSweep() {
 function cancelSweep() {
   showingSweepConfirm.value = false;
   sweepPendingCount.value = 0;
+  sweepCountUnknown.value = false;
 }
 
 function confirmArchive() {
@@ -254,7 +259,11 @@ function cancelArchive() {
         <h3>Begin Market Days?</h3>
         <p v-if="sweepConfirmLoading">Checking pending offers...</p>
         <p v-else>
-          <template v-if="sweepPendingCount === 0">
+          <template v-if="sweepCountUnknown">
+            Could not determine how many offers are still pending. Any pending offers will be marked
+            as refused. This cannot be undone.
+          </template>
+          <template v-else-if="sweepPendingCount === 0">
             No offers are pending — no vendors will be marked refused.
           </template>
           <template v-else>

--- a/front-end/src/components/PhaseControlPanel.vue
+++ b/front-end/src/components/PhaseControlPanel.vue
@@ -163,6 +163,7 @@ function handleTransitionClick(toPhase: string) {
 async function openSweepConfirm() {
   if (!props.market) return;
   sweepConfirmLoading.value = true;
+  showingSweepConfirm.value = true;
   try {
     const res = await api.get(
       `/markets/${encodeURIComponent(props.market.id)}/pending-offers-count`,
@@ -173,7 +174,6 @@ async function openSweepConfirm() {
   } finally {
     sweepConfirmLoading.value = false;
   }
-  showingSweepConfirm.value = true;
 }
 
 function confirmSweep() {

--- a/front-end/src/components/PhaseControlPanel.vue
+++ b/front-end/src/components/PhaseControlPanel.vue
@@ -41,16 +41,6 @@ const TRANSITION_LABELS: Record<string, string> = {
   [MarketPhase.Archived]: 'Archive Market',
 };
 
-const TRANSITION_VARIANTS: Record<string, string> = {
-  [MarketPhase.ApplicationsOpen]: 'advance',
-  [MarketPhase.ApplicationsClosed]: 'advance',
-  [MarketPhase.Review]: 'advance',
-  [MarketPhase.Assignment]: 'advance',
-  [MarketPhase.Offers]: 'advance',
-  [MarketPhase.MarketDays]: 'advance',
-  [MarketPhase.Archived]: 'danger',
-};
-
 /** Frontend mirror of guards.py VALID_TRANSITIONS -- single source of truth for UI routing. */
 const VALID_TRANSITIONS: Array<[string, string]> = [
   ['draft', 'applications_open'],
@@ -111,7 +101,6 @@ async function doTransition(toPhase: string) {
       phase: response.data.phase,
     };
 
-    // Refresh from server so localStorage / local state stays current.
     try {
       const full = await api.get(`/markets/${encodeURIComponent(props.market.id)}`);
       const fresh = parseMarketFromApi(full.data.market);
@@ -167,37 +156,38 @@ function cancelArchive() {
 
 <template>
   <div v-if="market" class="phase-control-panel" data-testid="phase-control-panel">
-    <div class="phase-info">
-      <span class="phase-label-text">Current Phase:</span>
-      <span
-        class="phase-badge"
-        :class="`phase-${currentPhase}`"
-        data-testid="phase-control-current-phase"
-      >
-        {{ phaseLabel }}
-      </span>
-    </div>
-
-    <div v-if="!isTerminal && availableTransitions.length > 0" class="phase-actions">
-      <span class="phase-label-text">Advance to:</span>
-      <div class="phase-buttons">
-        <button
-          v-for="toPhase in availableTransitions"
-          :key="toPhase"
-          class="phase-transition-button"
-          :class="`variant-${transitionVariant(toPhase)}`"
-          :disabled="transitioning"
-          :data-testid="`phase-transition-${toPhase}`"
-          @click="handleTransitionClick(toPhase)"
+    <div class="phase-control-row">
+      <div class="phase-info">
+        <span class="phase-label-text">Current Phase:</span>
+        <span
+          class="phase-badge"
+          :class="`phase-${currentPhase}`"
+          data-testid="phase-control-current-phase"
         >
-          {{ transitionLabel(toPhase) }}
-        </button>
+          {{ phaseLabel }}
+        </span>
       </div>
-    </div>
 
-    <p v-if="isTerminal" class="terminal-note" data-testid="phase-control-terminal">
-      This market is archived and read-only.
-    </p>
+      <div v-if="!isTerminal && availableTransitions.length > 0" class="phase-actions">
+        <div class="phase-buttons">
+          <button
+            v-for="toPhase in availableTransitions"
+            :key="toPhase"
+            class="phase-transition-button"
+            :class="`variant-${transitionVariant(toPhase)}`"
+            :disabled="transitioning"
+            :data-testid="`phase-transition-${toPhase}`"
+            @click="handleTransitionClick(toPhase)"
+          >
+            {{ transitionLabel(toPhase) }}
+          </button>
+        </div>
+      </div>
+
+      <p v-if="isTerminal" class="terminal-note" data-testid="phase-control-terminal">
+        This market is archived and read-only.
+      </p>
+    </div>
 
     <p v-if="transitionError" class="transition-error" data-testid="phase-control-error">
       {{ transitionError }}
@@ -249,18 +239,25 @@ function cancelArchive() {
 <style scoped>
 .phase-control-panel {
   width: 100%;
-  padding: 0 40px;
+  padding: 10px 40px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.phase-control-row {
   display: flex;
   align-items: center;
   gap: 24px;
   flex-wrap: wrap;
-  min-height: 48px;
+  min-height: 36px;
 }
 
 .phase-info {
   display: flex;
   align-items: center;
   gap: 10px;
+  flex-shrink: 0;
 }
 
 .phase-label-text {
@@ -366,6 +363,7 @@ function cancelArchive() {
   font-size: 13px;
   color: #fca5a5;
   margin: 0;
+  padding: 0 2px;
 }
 
 /* Archive confirmation overlay */

--- a/front-end/src/components/PhaseControlPanel.vue
+++ b/front-end/src/components/PhaseControlPanel.vue
@@ -228,7 +228,7 @@ function cancelArchive() {
       </div>
 
       <p v-if="isTerminal" class="terminal-note" data-testid="phase-control-terminal">
-        This market is archived and read-only.
+        This market is archived.
       </p>
     </div>
 
@@ -292,8 +292,8 @@ function cancelArchive() {
       <div class="archive-confirm-dialog" data-testid="archive-confirm-dialog">
         <h3>Archive this market?</h3>
         <p>
-          Archiving is permanent. Once archived, a market cannot be edited or returned to an active
-          phase. This action cannot be undone.
+          Archiving is permanent. Once archived, a market cannot be returned to an active phase.
+          This action cannot be undone.
         </p>
         <div class="archive-confirm-buttons">
           <button

--- a/front-end/src/utils/market.ts
+++ b/front-end/src/utils/market.ts
@@ -1,23 +1,28 @@
 import {
   type ApplicationForm,
   type Market,
-  type MarketPhase,
+  MarketPhase,
   MarketRole,
 } from '@/assets/types/datatypes';
 import { marketNameToKebabSlug } from '@/utils/marketSlug';
 
 /**
- * Where to send the user after choosing a market (draft → setup, else → kebab URL).
- * Phase is the single source of truth; ``isDraft`` is derived server-side, and is only
- * consulted for a market with no phase at all - a published one left in localStorage by a
- * build that predates the field, which would otherwise be routed back into the setup wizard.
+ * Where to send the user after choosing a market.
+ *
+ * Every pre-archive phase routes to the setup wizard so the phase controls are reachable.
+ * ``isDraft`` is only consulted for a market with no phase at all - one left in localStorage
+ * by a build that predates the field.
  */
 export function pathAfterLoadingMarket(market: Market): string {
-  const published = market.phase ? market.phase !== 'draft' : market.isDraft === false;
-  if (published) {
-    const slug = marketNameToKebabSlug(market.name);
-    if (slug) return `/${slug}`;
+  if (market.phase && market.phase !== MarketPhase.Archived) {
+    return '/market-setup';
   }
+  if (!market.phase) {
+    const interpretedAsDraft = market.isDraft !== false;
+    if (interpretedAsDraft) return '/market-setup';
+  }
+  const slug = marketNameToKebabSlug(market.name);
+  if (slug) return `/${slug}`;
   return '/market-setup';
 }
 

--- a/front-end/src/views/MarketSetupView.vue
+++ b/front-end/src/views/MarketSetupView.vue
@@ -17,6 +17,7 @@ import { applicationFormError, applicationFormHint } from '@/utils/applicationFo
 import FormBuilder from '@/components/application/FormBuilder.vue';
 import FormPreview from '@/components/application/FormPreview.vue';
 import ApplicationMonitor from '@/components/application/ApplicationMonitor.vue';
+import PhaseControlPanel from '@/components/PhaseControlPanel.vue';
 
 const router = useRouter();
 
@@ -85,6 +86,10 @@ function parseFiniteNumber(v: unknown): number | null {
   if (v === null || v === undefined || v === '') return null;
   const n = typeof v === 'string' ? parseFloat(v) : Number(v);
   return Number.isFinite(n) ? n : null;
+}
+
+function handlePhaseAdvanced(updatedMarket: Market) {
+  market.value = updatedMarket;
 }
 
 /** True when required Assignment Options are set (Assign enabled). Max days column mapping is optional. */
@@ -306,6 +311,7 @@ watch(pageIdx, (newIdx) => {
 
 <template>
   <div class="market-setup-view">
+    <PhaseControlPanel :market="market" @phase-advanced="handlePhaseAdvanced" />
     <ChoosePathOverlay v-if="showPathChoice" @select="handlePathChoice" />
     <div class="market-setup-body">
       <div class="settings-container">


### PR DESCRIPTION
## Intent

Implement the market state machine: add all phase transition edges, guards (all applications reviewed, no approved applications remain), sweep for offers->market_days, archive confirmation, and PhaseControlPanel UI. Base is dev.

## What Changed

- Completed the phase transition registry in `back-end/guards.py` with all remaining edges (draft through market_days plus archive-from-anywhere), and added two new guards using `ApplicationStatus` enums: all applications must be reviewed before `review -> assignment`, and no approved applications may remain before `assignment -> offers`.
- Added an `offers -> market_days` sweep that marks `assignment_sent` applications as `vendor_refused` (routed through `ApplicationsApi`, run after the phase compare-and-set with failure surfaced in the response), plus a permission-checked `GET /markets/<id>/pending-offers-count` endpoint backing the sweep confirmation dialog.
- Added `PhaseControlPanel.vue` to `MarketSetupView` with context-aware transition buttons, blocker display, sweep and archive confirmations, and consistent phase/isDraft cache updates; covered end-to-end by `phase-state-machine.spec.ts` with a new `seedPhaseMarket` helper (full phase walk, guard blockers, sweep, and archive cancel/confirm all verified against a live stack).

## Risk Assessment

✅ Low: Change is well-bounded: two new guards, a sweep side effect, a pending-count endpoint, and a PhaseControlPanel UI component, all with comprehensive tests. Round 1 fixes are applied. Remaining known tradeoffs (silent sweep failure, zero-application guard strictness, frontend-backend table mirror, TOCTOU) were acknowledged and explicitly deferred by the author.

## Testing

Ran backend guard/transition unit tests, the full 5-test Playwright E2E spec for the phase state machine on an isolated Docker stack (capturing 16 UI screenshots of the PhaseControlPanel through every phase, guard blocker panels, sweep confirmation and before/after DB state, and archive confirmation), plus a manual API transcript proving edge validation and both guards at the wire level; everything passed, matching the already-green nm-test.sh baseline. Note: screenshots were captured immediately after Playwright asserted the visible UI state, but I could not visually re-inspect them myself since this model does not support image input.

- Evidence: PhaseControlPanel in draft phase (local file: <code>/tmp/no-mistakes-evidence/01KXNZGN0RG61159NRW8TMMR3P/01-draft.png</code>)
- Evidence: Phase walk: applications open (local file: <code>/tmp/no-mistakes-evidence/01KXNZGN0RG61159NRW8TMMR3P/02-applications-open.png</code>)
- Evidence: Phase walk: review (local file: <code>/tmp/no-mistakes-evidence/01KXNZGN0RG61159NRW8TMMR3P/04-review.png</code>)
- Evidence: Phase walk: assignment (local file: <code>/tmp/no-mistakes-evidence/01KXNZGN0RG61159NRW8TMMR3P/05-assignment.png</code>)
- Evidence: Sweep confirmation dialog before offers-&gt;market_days (local file: <code>/tmp/no-mistakes-evidence/01KXNZGN0RG61159NRW8TMMR3P/06b-sweep-confirmation.png</code>)
- Evidence: Phase walk: market days reached (local file: <code>/tmp/no-mistakes-evidence/01KXNZGN0RG61159NRW8TMMR3P/07-market-days.png</code>)
- Evidence: Guard blocker: assignment blocked by unreviewed applications (local file: <code>/tmp/no-mistakes-evidence/01KXNZGN0RG61159NRW8TMMR3P/09-blocked-assignment.png</code>)
- Evidence: Guard blocker: offers blocked by leftover approved applications (local file: <code>/tmp/no-mistakes-evidence/01KXNZGN0RG61159NRW8TMMR3P/10-blocked-offers.png</code>)
- Evidence: Sweep evidence: application statuses before transition (local file: <code>/tmp/no-mistakes-evidence/01KXNZGN0RG61159NRW8TMMR3P/11a-sweep-before.png</code>)
- Evidence: Sweep evidence: assignment_sent swept to vendor_refused, vendor_accepted untouched (local file: <code>/tmp/no-mistakes-evidence/01KXNZGN0RG61159NRW8TMMR3P/11b-sweep-after.png</code>)
- Evidence: Archive confirmation dialog (local file: <code>/tmp/no-mistakes-evidence/01KXNZGN0RG61159NRW8TMMR3P/12-archive-confirmation.png</code>)
- Evidence: Archived terminal state (local file: <code>/tmp/no-mistakes-evidence/01KXNZGN0RG61159NRW8TMMR3P/13-archived.png</code>)
<details>
<summary>Evidence: API transcript: edges and guards at the wire level</summary>

<code>POST transition draft-&gt;market_days -&gt; HTTP 400 (edge not available)&#10;POST transition draft-&gt;applications_open -&gt; HTTP 200 {&#34;phase&#34;:&#34;applications_open&#34;}&#10;...-&gt;applications_closed -&gt; 200, ...-&gt;review -&gt; 200&#10;[1 app status=&#39;open&#39;] review-&gt;assignment -&gt; HTTP 409 blocker all_applications_reviewed: &#34;1 application is still awaiting review...&#34;&#10;[app reviewer_approved] review-&gt;assignment -&gt; HTTP 200&#10;assignment-&gt;offers -&gt; HTTP 409 blocker no_approved_applications: &#34;1 application is still approved but not yet assigned or unassigned...&#34;&#10;[app assigned] assignment-&gt;offers -&gt; HTTP 200</code>

```text
Market created in phase 'draft' (id ...bce26cd7)

POST /markets/<id>/transition {toPhase: 'market_days'}  [invalid edge from draft: rejected]
  -> HTTP 400  {"error":"Transition from 'draft' to 'market_days' is not available in the current phase."}

POST /markets/<id>/transition {toPhase: 'applications_open'}  [valid edge]
  -> HTTP 200  {"phase":"applications_open"}

POST /markets/<id>/transition {toPhase: 'applications_closed'}  [valid edge]
  -> HTTP 200  {"phase":"applications_closed"}

POST /markets/<id>/transition {toPhase: 'review'}  [valid edge]
  -> HTTP 200  {"phase":"review"}

[seeded 1 application with status='open' (unreviewed)]

POST /markets/<id>/transition {toPhase: 'assignment'}  [guard: blocked, application still awaiting review]
  -> HTTP 409  {"blockers":[{"id":"all_applications_reviewed","message":"1 application is still awaiting review. Every application must be approved or rejected before assignment can begin.","passed":false,"resolutionLink":"/market-setup"}],"currentPhase":"review","error":"preconditions_not_met","targetPhase":"assignment"}

[application reviewed: status='reviewer_approved']

POST /markets/<id>/transition {toPhase: 'assignment'}  [guard satisfied: all applications reviewed]
  -> HTTP 200  {"phase":"assignment"}

POST /markets/<id>/transition {toPhase: 'offers'}  [guard: blocked, approved application not yet resolved]
  -> HTTP 409  {"blockers":[{"id":"no_approved_applications","message":"1 application is still approved but not yet assigned or unassigned. Run the assignment solver before sending offers.","passed":false,"resolutionLink":"/assignment-results"}],"currentPhase":"assignment","error":"preconditions_not_met","targetPhase":"offers"}

[application resolved: status='assigned']

POST /markets/<id>/transition {toPhase: 'offers'}  [guard satisfied: no approved applications remain]
  -> HTTP 200  {"phase":"offers"}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 8 issues found → auto-fixed ✅</summary>

- ⚠️ `back-end/app.py:1106` - The offers-&gt;market_days sweep runs after the phase CAS and its failure is only logged; the endpoint still returns 200. Because the offers-&gt;market_days edge is consumed by the phase write, a failed sweep leaves assignment_sent applications permanently unswept with no user-visible signal and no retry path (no re-sweep endpoint, transition cannot be re-run). Consider surfacing sweep failure in the response payload and/or exposing an idempotent re-sweep so an operator can recover without a manual Mongo edit.
- ⚠️ `front-end/src/components/PhaseControlPanel.vue:173` - openSweepConfirm()&#39;s catch branch sets sweepPendingCount to 0, so if GET /pending-offers-count fails the confirmation dialog affirmatively states &#39;No offers are pending — no vendors will be marked refused&#39;, which may be false right before an irreversible sweep. Track the error state separately and show an &#39;unknown count&#39; message instead of claiming zero.
- ℹ️ `back-end/guards.py:98` - AllApplicationsReviewedGuard additionally blocks review-&gt;assignment when zero applications exist (&#39;At least one application must exist before assignment can begin&#39;). The stated intent only names &#39;all applications reviewed&#39; and &#39;no approved applications remain&#39;; the zero-application block is extra product behavior (an organizer cannot skip assignment for a market with no applicants except by archiving). Confirm this stricter guard is intended.
- ℹ️ `back-end/guards.py:168` - (&#34;market_days&#34;, &#34;archived&#34;) appears twice in VALID_TRANSITIONS (lines 160 and 168, under &#39;Assignment and forward&#39; and &#39;Archive from anywhere&#39;). Harmless in a set literal but misleading when auditing the edge list; drop one occurrence.
- ℹ️ `back-end/guards.py:82` - New code passes raw status strings (&#34;open&#34;, &#34;under_review&#34; in guards.py:82, &#34;reviewer_approved&#34; in guards.py:124, &#34;assignment_sent&#34; in app.py pending_offers_count and in the sweep filter at api/applications.py:242) while the codebase has ApplicationStatus enum members and the sweep&#39;s $set side already uses ApplicationStatus.VENDOR_REFUSED.value. Use the enum values throughout to prevent silent drift if a status string is ever renamed.
- ℹ️ `front-end/src/components/PhaseControlPanel.vue:114` - doTransition&#39;s fallback path (when the follow-up GET /markets/{id} fails) writes {...props.market, phase} to localStorage without recomputing isDraft, so a market cached from a draft transition can hold phase=&#39;applications_open&#39; alongside isDraft=true - violating the phase/isDraft agreement invariant. Readers currently prefer phase when present, but derive isDraft (phase === &#39;draft&#39;) in the fallback object to keep the cache consistent.
- ℹ️ `front-end/src/components/PhaseControlPanel.vue:46` - PhaseControlPanel hard-codes a mirror of guards.py VALID_TRANSITIONS (and the comment calling the mirror the &#39;single source of truth&#39; is misleading - the back-end table is authoritative). If the tables drift, the UI either shows a button that 400s or hides a legal transition. A follow-up could have the transition/market endpoint report available transitions so the UI renders from server data.
- ℹ️ `back-end/app.py:1061` - Guards are evaluated before the phase compare-and-set, and the CAS only protects the phase field, not the applications collection: an application submitted or reverted between guard evaluation and the phase write can enter assignment/offers in a state the guard would have blocked. The window is small and the pattern predates this change; noting the tradeoff.

🔧 Fix: use status enums, dedupe edge, fix sweep dialog and cache
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./scripts/nm-test.sh`
- <code>Baseline `./scripts/nm-test.sh` (full backend pytest + frontend vitest + Playwright E2E suite) ran successfully before this run</code>
- <code>`python3 -m pytest tests/test_guards.py tests/test_transition_api.py` - 58 passed, covering the transition registry, guard preconditions, and the transition API endpoint</code>
- <code>`npx playwright test e2e/phase-state-machine.spec.ts` against a freshly built isolated Docker stack (seeded via `scripts/seed_fixture.sh`) - all 5 tests passed: full phase walk draft-&gt;applications_open-&gt;applications_closed-&gt;review-&gt;assignment-&gt;offers-&gt;market_days in the PhaseControlPanel UI, assignment blocked by unreviewed applications, offers blocked by leftover approved applications, sweep of assignment_sent-&gt;vendor_refused (vendor_accepted untouched, verified in Mongo), and archive confirmation with cancel-preserves-phase and confirm-archives</code>
- <code>Manual API verification script exercising `POST /markets/&lt;id&gt;/transition` against the live stack: invalid edge draft-&gt;market_days rejected with 400, valid edges return 200 with the new phase, review-&gt;assignment returns 409 with the `all_applications_reviewed` blocker while an application is unreviewed and succeeds after review, assignment-&gt;offers returns 409 with the `no_approved_applications` blocker while an approved application remains and succeeds after resolution</code>

</details>

<details>
<summary>⚠️ **Document** - 2 infos</summary>

- ℹ️ `front-end/src/__tests__/BlockerPanel.test.ts:19` - Test fixture uses stale route `/markets/market-1/form-builder`; guard&#39;s `resolution_link` is now `/market-setup`. Test passes (generic rendering) but fixture URL is misleading. Cannot fix per rules (tests are out of scope for this pass).
- ℹ️ `docs/OBJECT_RELATIONSHIPS.md:535` - `GET /markets/&lt;id&gt;/pending-offers-count` endpoint has no documentation in markdown files (only inline docstring in back-end/app.py). Not stale but absent; out of scope for this pass.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `back-end/:1` - No Python linter (ruff/flake8) available in environment. Python files compile without syntax errors but cannot be lint-checked in this pass.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
