### PR TITLE
fix(front-end): render market dates as timezone-independent calendar days

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,14 @@ This file is the project's committed home for project-intrinsic agent knowledge:
   `/register-user`.
 - **Run E2E**: `./scripts/seed_fixture.sh` then `cd front-end && npm run test:e2e`.
   Playwright config auto-detects worktree port via `stack().frontendPort`.
+  Bring the stack up with `DISABLE_EMAIL=true scripts/th-compose.sh up -d` (compose passes it
+  through from the host shell; CI and `nm-test.sh` set it) - without it the password-reset
+  E2E 500s on the missing `RESEND_API_KEY`.
+- **Market dates are calendar days, not instants**: a stored `YYYY-MM-DD` market date must
+  render as the same day for every viewer regardless of timezone. `getFormattedDate`
+  (`front-end/src/utils/utils.ts`) formats with pure UTC math; never parse a market date
+  through `new Date()` with an offset. `front-end/e2e/date-display-timezone.spec.ts` pins
+  this across Honolulu/LA/Tokyo via Playwright `timezoneId`.
 
 ### Floorplan Workflow E2E
 

--- a/front-end/e2e/date-display-timezone.spec.ts
+++ b/front-end/e2e/date-display-timezone.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect, BACKEND_URL, TEST_USER } from './fixtures';
+import { ensureTestOrg, loginViaApi } from './helpers/seeds';
+import type { APIRequestContext } from '@playwright/test';
+
+/**
+ * Regression test for the market-date formatter timezone bug.
+ *
+ * A market date is a calendar day ("2026-07-31"), not an instant. The old
+ * getFormattedDate pinned it to a hardcoded -08:00 offset and then rendered
+ * it in the viewer's local timezone, so any viewer west of UTC-8 (Honolulu,
+ * Alaska in winter) saw the PREVIOUS day. On an application form whose whole
+ * purpose is picking attendance days, that silently misassigns people.
+ *
+ * These tests render the same stored date in browser contexts fixed to three
+ * timezones spanning the bug boundary and assert every viewer sees the same
+ * calendar day:
+ *   - Pacific/Honolulu    (UTC-10: west of the pin — where the bug bit)
+ *   - America/Los_Angeles (UTC-8:  at the pin — where the bug hid)
+ *   - Asia/Tokyo          (UTC+9:  far east — always looked correct)
+ */
+
+const MARKET_DATE = '2026-07-31';
+const EXPECTED_LABEL = 'Friday, July 31';
+const TIMEZONES = ['Pacific/Honolulu', 'America/Los_Angeles', 'Asia/Tokyo'];
+
+/**
+ * Seed a market whose setupObject already holds MARKET_DATE, so the setup
+ * wizard's date row renders the formatted label on load with no interaction.
+ * Follows the market-pipeline.spec.ts API seeding pattern.
+ */
+async function seedMarketWithDate(request: APIRequestContext): Promise<Record<string, unknown>> {
+  await loginViaApi(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);
+  const orgId = await ensureTestOrg(request, BACKEND_URL, TEST_USER.email, TEST_USER.password);
+
+  const headers = {
+    'Content-Type': 'application/json',
+    'X-Owner-Email': TEST_USER.email,
+  };
+  const createRes = await request.post(`${BACKEND_URL}/markets`, {
+    headers,
+    data: {
+      name: `Date TZ E2E ${Date.now()}`,
+      creationDate: new Date().toISOString(),
+      organizationId: orgId,
+      roles: { [TEST_USER.email]: 'owner' },
+      modificationList: [],
+      assignmentObject: {},
+    },
+  });
+  if (!createRes.ok()) {
+    throw new Error(`Market creation failed: ${createRes.status()} ${await createRes.text()}`);
+  }
+  const { market_id: marketId } = (await createRes.json()) as { market_id: string };
+
+  const marketRes = await request.get(`${BACKEND_URL}/markets/${marketId}`, {
+    headers: { 'X-Owner-Email': TEST_USER.email },
+  });
+  const { market } = (await marketRes.json()) as { market: Record<string, unknown> };
+
+  const setupObject = {
+    colNames: ['email', 'day_1'],
+    colValues: [[], []],
+    colInclude: [false, false],
+    enumPriorityOrder: [[], []],
+    priority: [],
+    marketDates: [{ date: MARKET_DATE, colNameIdx: 1 }],
+    tiers: [],
+    locations: [],
+    sections: [],
+    assignmentOptions: {
+      maxAssignmentsPerVendor: null,
+      maxHalfTableProportionPerSection: null,
+      emailColNameIdx: null,
+      tableChoiceColNameIdx: null,
+      tableShareEmailColNameIdx: null,
+      maxDaysColNameIdx: null,
+    },
+  };
+  const putRes = await request.put(`${BACKEND_URL}/markets/${marketId}`, {
+    headers,
+    data: { ...market, setupObject },
+  });
+  if (!putRes.ok()) {
+    throw new Error(`Setup PUT failed: ${putRes.status()} ${await putRes.text()}`);
+  }
+  const updatedRes = await request.get(`${BACKEND_URL}/markets/${marketId}`, {
+    headers: { 'X-Owner-Email': TEST_USER.email },
+  });
+  return ((await updatedRes.json()) as { market: Record<string, unknown> }).market;
+}
+
+for (const timezoneId of TIMEZONES) {
+  test.describe(`market date rendering in ${timezoneId}`, () => {
+    test.use({ timezoneId });
+
+    test(`stored ${MARKET_DATE} renders as ${EXPECTED_LABEL}`, async ({ page }, testInfo) => {
+      // page.request shares the browser context's cookie jar, so the API
+      // login below also authenticates subsequent in-page fetches.
+      const market = await seedMarketWithDate(page.request);
+
+      // Establish the app origin, then inject market + user the same way
+      // market-pipeline.spec.ts does so /market-setup renders our market.
+      await page.goto('/login');
+      await page.evaluate(
+        ({ m, user }) => {
+          localStorage.setItem('market', JSON.stringify(m));
+          localStorage.setItem('user', JSON.stringify(user));
+        },
+        { m: market, user: TEST_USER.email },
+      );
+      await page.goto('/market-setup');
+
+      const dateLabel = page.getByTestId('setup-dates-date-display-0');
+      await expect(dateLabel).toBeVisible({ timeout: 10000 });
+      await expect(dateLabel).toHaveText(EXPECTED_LABEL);
+
+      await page.screenshot({
+        path: testInfo.outputPath(`market-dates-${timezoneId.replace('/', '_')}.png`),
+        fullPage: true,
+      });
+    });
+  });
+}

--- a/front-end/src/__tests__/utils.test.ts
+++ b/front-end/src/__tests__/utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { getFormattedDate } from '@/utils/utils';
+
+describe('getFormattedDate', () => {
+  it('returns null for an empty string', () => {
+    expect(getFormattedDate('')).toBeNull();
+  });
+
+  it('formats an ISO calendar date as weekday, month and day', () => {
+    expect(getFormattedDate('2026-07-31')).toBe('Friday, July 31');
+    expect(getFormattedDate('2026-01-01')).toBe('Thursday, January 1');
+    expect(getFormattedDate('2024-02-29')).toBe('Thursday, February 29');
+    expect(getFormattedDate('2026-12-31')).toBe('Thursday, December 31');
+  });
+
+  // A market date is a calendar day, not an instant: the same stored date
+  // must render as the same day for every viewer on earth. The old
+  // implementation pinned the date to a hardcoded -08:00 offset and rendered
+  // it in the viewer's local timezone, showing the previous day to anyone
+  // west of UTC-8 (e.g. Hawaii). Node re-reads process.env.TZ, so exercising
+  // several zones in one process is reliable here.
+  it('renders the same calendar day regardless of the viewer timezone', () => {
+    const originalTz = process.env.TZ;
+    const zones = [
+      'Pacific/Honolulu',
+      'America/Anchorage',
+      'America/Los_Angeles',
+      'UTC',
+      'Asia/Tokyo',
+      'Pacific/Kiritimati',
+    ];
+    try {
+      for (const tz of zones) {
+        process.env.TZ = tz;
+        expect(getFormattedDate('2026-07-31'), `in ${tz}`).toBe('Friday, July 31');
+      }
+    } finally {
+      if (originalTz === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = originalTz;
+      }
+    }
+  });
+});

--- a/front-end/src/components/elements/ElementMarketDates.vue
+++ b/front-end/src/components/elements/ElementMarketDates.vue
@@ -80,7 +80,7 @@ const addRow = () => {
         @mouseleave="hoverIndex = null"
       >
         <div class="row-item text-item">
-          <h4 class="date-display">
+          <h4 class="date-display" :data-testid="'setup-dates-date-display-' + index">
             {{ getFormattedDate(marketDates[index].date) }}
           </h4>
           <input

--- a/front-end/src/utils/utils.ts
+++ b/front-end/src/utils/utils.ts
@@ -17,7 +17,14 @@ export const getFormattedDate = (dateString: string) => {
       'November',
       'December',
     ];
-    const now = new Date(dateString + 'T00:00:00.000-08:00');
-    return days[now.getDay()] + ', ' + months[now.getMonth()] + ' ' + now.getDate();
+    // A market date is a calendar day ("YYYY-MM-DD"), not an instant: the
+    // market happens on that day where the market is, so every viewer on
+    // earth must see the same day. Format it with pure UTC math and never
+    // convert it through a timezone. (The previous implementation pinned the
+    // string to a hardcoded -08:00 offset and rendered it in the viewer's
+    // local timezone, which showed the previous day to anyone west of UTC-8.)
+    const [year, month, day] = dateString.split('-').map(Number);
+    const date = new Date(Date.UTC(year, month - 1, day));
+    return days[date.getUTCDay()] + ', ' + months[date.getUTCMonth()] + ' ' + date.getUTCDate();
   }
 };


### PR DESCRIPTION
## Intent

Fix an applicant-facing date-display bug where getFormattedDate (front-end/src/utils/utils.ts) parsed stored YYYY-MM-DD market dates with a hardcoded -08:00 offset and rendered them in the viewer's local timezone, so any viewer west of UTC-8 (e.g. Pacific/Honolulu) saw the previous calendar day - on the market application date picker this silently misassigns applicants to the wrong day. The deliberate principle: a market date is a calendar day, not an instant, and must render as the same day for every viewer on earth; the formatter now parses the date components and formats with pure UTC math, never converting through any timezone. Scope was deliberately kept to this one bug (it was intentionally excluded from PR #45 so it could get its own reasoning and tests): the only caller on dev is ElementMarketDates.vue, which gained only an additive data-testid on the date label for test targeting; sibling views that parse dates via local-midnight T00:00:00 were audited and are already calendar-day-safe, so they were intentionally left untouched. Proof requirements from the task: unit tests pin the formatting plus a cross-timezone invariant loop, and a new Playwright spec (front-end/e2e/date-display-timezone.spec.ts) renders the same stored date in browser contexts pinned via timezoneId to Pacific/Honolulu (west of UTC-8, where the bug bit), America/Los_Angeles (where it hid), and Asia/Tokyo, asserting all three render 'Friday, July 31' for stored 2026-07-31; before the fix the Honolulu case failed with 'Thursday, July 30'. AGENTS.md gained two durable notes: the DISABLE_EMAIL=true requirement when bringing up the local stack (matches CI/nm-test; without it the password-reset E2E 500s), and the calendar-day rendering principle. PR base must be dev, never main. Two open PRs (#45, #46) will add more getFormattedDate callers; this change is intentionally small so it merges cleanly after them.

## What Changed

- Rewrote `getFormattedDate` in `front-end/src/utils/utils.ts` to parse stored `YYYY-MM-DD` market dates into components and format with pure UTC math, replacing the hardcoded `-08:00` offset + local-timezone rendering that showed viewers west of UTC-8 (e.g. Pacific/Honolulu) the previous calendar day.
- Added unit tests pinning the formatting and a cross-timezone invariant loop, plus a Playwright spec (`front-end/e2e/date-display-timezone.spec.ts`) that renders stored `2026-07-31` in browser contexts pinned to Pacific/Honolulu, America/Los_Angeles, and Asia/Tokyo and asserts all three show 'Friday, July 31'; `ElementMarketDates.vue` gained only an additive `data-testid` on the date label for test targeting.
- Documented two durable notes in `AGENTS.md`: the `DISABLE_EMAIL=true` requirement when bringing up the local stack, and the calendar-day (not instant) rendering principle for market dates.

## Risk Assessment

✅ Low: The change is well-bounded: one function fix plus one additive data-testid attribute on its sole caller. The UTC-math approach is correct and portable. Tests are comprehensive (unit formatting + cross-timezone invariance + three-browser E2E). No behavioral changes beyond the intended timezone fix.

## Testing

Validated the timezone-independent date formatter end-to-end: unit tests pin the formatting and cross-timezone invariant, the new Playwright spec rendered stored 2026-07-31 as 'Friday, July 31' in real browser contexts pinned to Honolulu, Los Angeles, and Tokyo against a seeded market on an isolated stack (full-page screenshots captured per timezone), and an old-vs-new repro transcript demonstrates the pre-fix Honolulu regression ('Thursday, July 30'); all tests passed and the baseline full suite had already passed.

- Evidence: Market setup page rendering &#39;Friday, July 31&#39; in Pacific/Honolulu (where the bug bit) (local file: <code>/tmp/no-mistakes-evidence/01KXP364H4MEM66ZS8B4F51XG4/market-dates-Pacific_Honolulu.png</code>)
- Evidence: Market setup page rendering &#39;Friday, July 31&#39; in America/Los_Angeles (where the bug hid) (local file: <code>/tmp/no-mistakes-evidence/01KXP364H4MEM66ZS8B4F51XG4/market-dates-America_Los_Angeles.png</code>)
- Evidence: Market setup page rendering &#39;Friday, July 31&#39; in Asia/Tokyo (local file: <code>/tmp/no-mistakes-evidence/01KXP364H4MEM66ZS8B4F51XG4/market-dates-Asia_Tokyo.png</code>)
<details>
<summary>Evidence: Old vs new formatter repro for stored 2026-07-31 across timezones</summary>

<code>Pacific/Honolulu old: Thursday, July 30 new: Friday, July 31&#10;America/Los_Angeles old: Friday, July 31 new: Friday, July 31&#10;Asia/Tokyo old: Friday, July 31 new: Friday, July 31</code>

```text
Pacific/Honolulu     old: Thursday, July 30    new: Friday, July 31
America/Los_Angeles  old: Friday, July 31      new: Friday, July 31
Asia/Tokyo           old: Friday, July 31      new: Friday, July 31
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `front-end/src/utils/utils.ts:26` - The new implementation calls `.split()` on `dateString` without guarding against `null` or `undefined`. The TypeScript signature says `string`, and the sole caller (`ElementMarketDates.vue:84`) passes a typed `MarketDateObject.date` (required string), so this is very unlikely to surface at runtime. However, the old code degraded on null/undefined by silently producing garbage output (&#34;undefined, undefined NaN&#34;), while the new code throws TypeError. This is a marginal robustness regression with negligible practical risk given the strongly-typed data path.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./scripts/nm-test.sh`
- <code>Baseline full suite `./scripts/nm-test.sh` (backend pytest, frontend vitest, full Playwright E2E) ran successfully before this validation</code>
- <code>`npm run test:unit -- --run src/__tests__/utils.test.ts` - 3 tests passed, including the cross-timezone invariant loop over 6 zones</code>
- <code>Brought up an isolated Docker stack (unique COMPOSE_PROJECT_NAME + free ports, DISABLE_EMAIL=true) and ran `scripts/seed_fixture.sh`</code>
- <code>`npx playwright test date-display-timezone.spec.ts` - all 3 timezone-pinned browser contexts (Pacific/Honolulu, America/Los_Angeles, Asia/Tokyo) rendered stored 2026-07-31 as &#39;Friday, July 31&#39; on the real market-setup page via the new setup-dates-date-display-0 testid</code>
- <code>Manual bug repro `node /tmp/opencode/tz-repro.mjs` comparing the old -08:00-pinned formatter (from base commit eac2a5e4) against the new UTC-math formatter across the three timezones, confirming the pre-fix Honolulu failure (&#39;Thursday, July 30&#39;)</code>
- `Tore down the isolated stack and removed transient test-results artifacts from the working tree`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
